### PR TITLE
Handle floating refs in InitiallyUnowned

### DIFF
--- a/glib/InitiallyUnowned.cs
+++ b/glib/InitiallyUnowned.cs
@@ -35,6 +35,43 @@ namespace GLib {
 			}
 		}
 
+		[DllImport ("libgobject-2.0-0.dll", CallingConvention = CallingConvention.Cdecl)]
+		private static extern void g_object_ref_sink (IntPtr raw);
+
+		protected override IntPtr Raw {
+			get {
+				return base.Raw;
+			}
+			set {
+				if (value != IntPtr.Zero)
+					g_object_ref_sink (value);
+				base.Raw = value;
+			}
+		}
+
+		[DllImport ("libgobject-2.0-0.dll", CallingConvention = CallingConvention.Cdecl)]
+		static extern bool g_object_is_floating (IntPtr raw);
+
+		[DllImport ("libgobject-2.0-0.dll", CallingConvention = CallingConvention.Cdecl)]
+		static extern void g_object_force_floating (IntPtr raw);
+
+		[DllImport ("libgobject-2.0-0.dll", CallingConvention = CallingConvention.Cdecl)]
+		static extern void g_object_unref (IntPtr raw);
+
+		public bool IsFloating {
+			get {
+				return g_object_is_floating (Handle);
+			}
+			set {
+			  	if (value == true) {
+					if (!IsFloating)
+						g_object_force_floating (Handle);
+				} else {
+					g_object_ref_sink (Handle);
+					g_object_unref (Handle);
+				}
+			}
+		}
 	}
 }
 

--- a/gtk/Widget.custom
+++ b/gtk/Widget.custom
@@ -378,16 +378,11 @@ public void Path (out string path, out string path_reversed)
 			base.Dispose (disposing);
 		}
 
-		[DllImport ("libgobject-2.0-0.dll", CallingConvention = CallingConvention.Cdecl)]
-		private static extern void g_object_ref_sink (IntPtr raw);
-
 		protected override IntPtr Raw {
 			get {
 				return base.Raw;
 			}
 			set {
-				if (value != IntPtr.Zero)
-					g_object_ref_sink (value);
 				base.Raw = value;
 				if (value != IntPtr.Zero)
 					InternalDestroyed += NativeDestroyHandler;
@@ -403,28 +398,4 @@ public void Path (out string path, out string path_reversed)
 				return;
 			gtk_widget_destroy (Handle);
 			InternalDestroyed -= NativeDestroyHandler;
-		}
-
-		[DllImport ("libgobject-2.0-0.dll", CallingConvention = CallingConvention.Cdecl)]
-		static extern bool g_object_is_floating (IntPtr raw);
-
-		[DllImport ("libgobject-2.0-0.dll", CallingConvention = CallingConvention.Cdecl)]
-		static extern void g_object_force_floating (IntPtr raw);
-
-		[DllImport ("libgobject-2.0-0.dll", CallingConvention = CallingConvention.Cdecl)]
-		static extern void g_object_unref (IntPtr raw);
-
-		public bool IsFloating {
-			get {
-				return g_object_is_floating (Handle);
-			}
-			set {
-			  	if (value == true) {
-					if (!IsFloating)
-						g_object_force_floating (Handle);
-				} else {
-					g_object_ref_sink (Handle);
-					g_object_unref (Handle);
-				}
-			}
 		}


### PR DESCRIPTION
When Gtk.Object was removed, most of the code was moved to Gtk.Widget.
But the part that deals with floating references actually belongs in
Glib.InitiallyUnowned.

This prevents classes that are only subclasses of Glib.InitiallyUnowned, but that are referenced by Gtk.Widget subclasses, from being disposed too early.

This fixes various issues, in particular crashes in the TreeModelDemo
sample.

I'm not really super familiar with GLib memory management, so any improvements are welcome!
