### PR TITLE
gdk: Fix up WindowWindowClass enum value names

### DIFF
--- a/gdk/Gdk.metadata
+++ b/gdk/Gdk.metadata
@@ -38,6 +38,8 @@
   <attr path="/api/namespace/class[@cname='GdkThreads_']/method[@cname='gdk_threads_set_lock_functions']" name="hidden">1</attr>
   <add-node path="/api/namespace/enum[@cname='GdkModifierType']"><member name="None" value="0" /></add-node>
   <attr path="/api/namespace/enum[@cname='GdkModifierType']/member[@name='ModifierMask']" name="value">ReleaseMask | 0x1fff</attr>
+  <attr path="/api/namespace/enum[@cname='GdkWindowWindowClass']/member[@name='Output']" name="name">InputOutput</attr>
+  <attr path="/api/namespace/enum[@cname='GdkWindowWindowClass']/member[@name='Only']" name="name">InputOnly</attr>
   <attr path="/api/namespace/object[@cname='GdkDevice']/method[@name='GetAxis']/*/*[@name='axes']" name="array">1</attr>
   <attr path="/api/namespace/object[@cname='GdkDevice']/method[@name='FreeHistory']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GdkDevice']/method[@name='GetHistory']" name="hidden">1</attr>


### PR DESCRIPTION
WindowClass was renamed to WindowWindowClass so the fix ups were
incorrectly dropped.
