### PR TITLE
Pull request, already signed-off by mkestner in #gtk#

### DIFF
--- a/glib/ToggleRef.cs
+++ b/glib/ToggleRef.cs
@@ -59,6 +59,10 @@ namespace GLib {
 
   		public void Free ()
   		{
+			lock (PendingDestroys) {
+				PendingDestroys.Remove (this);
+			}
+
 			if (hardened)
 				g_object_unref (handle);
 			else


### PR DESCRIPTION
Apparently the recent changes in gtk-sharp master that changed
the destroy/dispose strategy caused a bug about calling
g_object_remove_toggle_ref() twice because now Dispose(true)
could call ToggleRef.Free() directly bypassing
ToggleRef.QueueUnref(). This change makes sure that
the ref is removed from the PendingDestroys list.
