### PR TITLE
Optimization for previous fix, please review! Thanks

### DIFF
--- a/glib/ToggleRef.cs
+++ b/glib/ToggleRef.cs
@@ -63,6 +63,11 @@ namespace GLib {
 				PendingDestroys.Remove (this);
 			}
 
+			InternalFree ();
+		}
+
+		public void InternalFree ()
+		{
 			if (hardened)
 				g_object_unref (handle);
 			else
@@ -146,7 +151,7 @@ namespace GLib {
 			}
 
 			foreach (ToggleRef r in references)
-				r.Free ();
+				r.InternalFree ();
 
 			return false;
 		}


### PR DESCRIPTION
Previous change introduced a slowdown because PerformQueuedUnrefs()
doesn't need to lock again when calling Free(), so we separate
the extra lock{} into an private (InternalFree) and a public Free.
