### PR TITLE
parser: Handle the G_DEFINE_TYPE_EXTENDED macro

### DIFF
--- a/gtk/gtk-api.raw
+++ b/gtk/gtk-api.raw
@@ -8393,6 +8393,9 @@
       <virtual_method name="GtkReserved4" cname="_gtk_reserved4" shared="true" padding="true">
         <return-type type="void" />
       </virtual_method>
+      <implements>
+        <interface cname="GtkStyleProvider" />
+      </implements>
       <method name="ErrorQuark" cname="gtk_css_provider_error_quark" shared="true">
         <return-type type="GQuark" />
       </method>
@@ -13182,6 +13185,9 @@
       <virtual_method name="GtkReserved4" cname="_gtk_reserved4" shared="true" padding="true">
         <return-type type="void" />
       </virtual_method>
+      <implements>
+        <interface cname="GtkStyleProvider" />
+      </implements>
     </object>
     <object name="MountOperation" cname="GtkMountOperation" parent="GMountOperation">
       <class_struct cname="GtkMountOperationClass">
@@ -16740,6 +16746,9 @@
       <virtual_method name="GtkReserved4" cname="_gtk_reserved4" shared="true" padding="true">
         <return-type type="void" />
       </virtual_method>
+      <implements>
+        <interface cname="GtkStyleProvider" />
+      </implements>
       <method name="GetDefault" cname="gtk_settings_get_default" shared="true">
         <return-type type="GtkSettings*" />
       </method>
@@ -18309,6 +18318,9 @@
       <virtual_method name="GtkReserved4" cname="_gtk_reserved4" shared="true" padding="true">
         <return-type type="void" />
       </virtual_method>
+      <implements>
+        <interface cname="GtkStyleProvider" />
+      </implements>
       <method name="Clear" cname="gtk_style_properties_clear">
         <return-type type="void" />
       </method>

--- a/parser/gapi2xml.pl
+++ b/parser/gapi2xml.pl
@@ -161,8 +161,8 @@ while ($line = <STDIN>) {
 			last if ($line =~ /^(deprecated)?}/);
 		}
 		$typefuncs{lc($class)} = $pedef;
-	} elsif ($line =~ /^G_DEFINE_TYPE_WITH_CODE\s*\(\s*(\w+)/) {
-		$typefuncs{lc($1)} = $line;
+	} elsif ($line =~ /^G_DEFINE_TYPE_(EXTENDED|WITH_CODE)\s*\(\s*(\w+)/) {
+		$typefuncs{lc($2)} = $line;
 	} elsif ($line =~ /^G_DEFINE_BOXED_TYPE\s*\(\s*(\w+)/) {
 		$boxdefs{$1} = $line;
 	} elsif ($line =~ /^G_DEFINE_INTERFACE\s*\(\s*(\w+)\s*,\s*(\w+)/) {
@@ -410,7 +410,7 @@ foreach $type (sort(keys(%objects))) {
 
 	# Get the interfaces from the class_init func.
 	if ($typefunc) {
-		if ($typefunc =~ /G_DEFINE_TYPE_WITH_CODE/) {
+		if ($typefunc =~ /G_DEFINE_TYPE_(EXTENDED|WITH_CODE)/) {
 			parseTypeFuncMacro($obj_el, $typefunc);
 		} else {
 			parseTypeFunc($obj_el, $typefunc);

--- a/parser/gapi_pp.pl
+++ b/parser/gapi_pp.pl
@@ -207,9 +207,9 @@ foreach $fname (@srcs, @privhdrs) {
 	}
 
 	while ($line = <INFILE>) {
-		next if ($line !~ /^(struct|typedef struct.*;|\w+_class_init|\w+_base_init|\w+_default_init|\w+_get_type\b|G_DEFINE_TYPE_WITH_CODE|G_DEFINE_BOXED_TYPE|G_DEFINE_INTERFACE)/);
+		next if ($line !~ /^(struct|typedef struct.*;|\w+_class_init|\w+_base_init|\w+_default_init|\w+_get_type\b|G_DEFINE_TYPE_EXTENDED|G_DEFINE_TYPE_WITH_CODE|G_DEFINE_BOXED_TYPE|G_DEFINE_INTERFACE)/);
 
-		if ($line =~ /^G_DEFINE_(TYPE_WITH_CODE|BOXED_TYPE|INTERFACE)/) {
+		if ($line =~ /^G_DEFINE_(TYPE_EXTENDED|TYPE_WITH_CODE|BOXED_TYPE|INTERFACE)/) {
 			my $macro;
 			my $parens = 0;
 			do {


### PR DESCRIPTION
G_DEFINE_TYPE_EXTENDED is the general macro for type implementations, on
which G_DEFINE_TYPE_WITH_CODE is based. Handle it just like
G_DEFINE_TYPE_WITH_CODE.

Reparse the API with that change, which marks a few classes as
implementing GtkStyleProvider.
