### PR TITLE
build: Specify assembly version when uninstalling from the GAC

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -3,6 +3,7 @@ API = $(pkg)-api.xml
 RAW_API = $(pkg)-api.raw
 
 ASSEMBLY_NAME = $(pkg)-sharp
+ASSEMBLY_NAME_VERSION = $(ASSEMBLY_NAME),Version=$(API_VERSION)
 ASSEMBLY = $(ASSEMBLY_NAME).dll
 
 TARGET = $(pkg:=-sharp.dll) $(pkg:=-sharp.dll.config) $(POLICY_ASSEMBLIES)
@@ -67,8 +68,8 @@ install-data-local:
 
 uninstall-local:
 	@if test -n '$(pkg)'; then							\
-	  echo "$(GACUTIL) -u $(ASSEMBLY_NAME) $(GACUTIL_FLAGS)";			\
-	  $(GACUTIL) -u $(ASSEMBLY_NAME) $(GACUTIL_FLAGS) || exit 1;			\
+	  echo "$(GACUTIL) -u $(ASSEMBLY_NAME_VERSION) $(GACUTIL_FLAGS)";		\
+	  $(GACUTIL) -u $(ASSEMBLY_NAME_VERSION) $(GACUTIL_FLAGS) || exit 1;		\
 	  if test -n '$(POLICY_VERSIONS)'; then						\
 	    for i in $(POLICY_VERSIONS); do						\
 	      echo "$(GACUTIL) -u policy.$$i.$(ASSEMBLY_NAME) $(GACUTIL_FLAGS)";	\

--- a/cairo/Makefile.am
+++ b/cairo/Makefile.am
@@ -1,4 +1,5 @@
 ASSEMBLY_NAME = cairo-sharp
+ASSEMBLY_NAME_VERSION = $(ASSEMBLY_NAME),Version=$(API_VERSION)
 ASSEMBLY = $(ASSEMBLY_NAME).dll
 SNK = $(srcdir)/mono.snk
 
@@ -75,8 +76,8 @@ install-data-local:
 
 uninstall-local:
 	@if test -n '$(TARGET)'; then							\
-	  echo "$(GACUTIL) -u $(ASSEMBLY_NAME) $(GACUTIL_FLAGS)";			\
-	  $(GACUTIL) -u $(ASSEMBLY_NAME) $(GACUTIL_FLAGS) || exit 1;			\
+	  echo "$(GACUTIL) -u $(ASSEMBLY_NAME_VERSION) $(GACUTIL_FLAGS)";			\
+	  $(GACUTIL) -u $(ASSEMBLY_NAME_VERSION) $(GACUTIL_FLAGS) || exit 1;			\
 	fi
 
 EXTRA_DIST = $(sources) cairo-api.xml mono.snk

--- a/glib/Makefile.am
+++ b/glib/Makefile.am
@@ -4,6 +4,7 @@ SNK = $(top_srcdir)/gtk-sharp.snk
 TARGET = $(ASSEMBLY)
 ASSEMBLY = $(ASSEMBLY_NAME).dll
 ASSEMBLY_NAME = glib-sharp
+ASSEMBLY_NAME_VERSION = $(ASSEMBLY_NAME),Version=$(API_VERSION)
 noinst_DATA = $(ASSEMBLY) $(ASSEMBLY).config $(POLICY_ASSEMBLIES)
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = glib-sharp-3.0.pc
@@ -104,8 +105,8 @@ install-data-local:
 
 uninstall-local:
 	@if test -n '$(TARGET)'; then							\
-	  echo "$(GACUTIL) -u $(ASSEMBLY_NAME) $(GACUTIL_FLAGS)";			\
-	  $(GACUTIL) -u $(ASSEMBLY_NAME) $(GACUTIL_FLAGS) || exit 1;			\
+	  echo "$(GACUTIL) -u $(ASSEMBLY_NAME_VERSION) $(GACUTIL_FLAGS)";		\
+	  $(GACUTIL) -u $(ASSEMBLY_NAME_VERSION) $(GACUTIL_FLAGS) || exit 1;		\
 	  if test -n '$(POLICY_VERSIONS)'; then						\
 	    for i in $(POLICY_VERSIONS); do						\
 	      echo "$(GACUTIL) -u policy.$$i.$(ASSEMBLY_NAME) $(GACUTIL_FLAGS)";	\

--- a/gtkdotnet/Makefile.am
+++ b/gtkdotnet/Makefile.am
@@ -9,6 +9,7 @@ endif
 SNK = $(top_srcdir)/gtk-sharp.snk
 ASSEMBLY = $(ASSEMBLY_NAME).dll
 ASSEMBLY_NAME = gtk-dotnet
+ASSEMBLY_NAME_VERSION = $(ASSEMBLY_NAME),Version=$(API_VERSION)
 noinst_DATA = $(ASSEMBLY) $(POLICY_ASSEMBLIES)
 CLEANFILES = $(ASSEMBLY) $(ASSEMBLY).mdb $(POLICY_ASSEMBLIES) $(POLICY_CONFIGS)
 DISTCLEANFILES = $(ASSEMBLY).config
@@ -54,8 +55,8 @@ install-data-local:
 
 uninstall-local:
 	@if test -n '$(TARGET)'; then							\
-	  echo "$(GACUTIL) -u $(ASSEMBLY_NAME) $(GACUTIL_FLAGS)";			\
-	  $(GACUTIL) -u $(ASSEMBLY_NAME) $(GACUTIL_FLAGS) || exit 1;			\
+	  echo "$(GACUTIL) -u $(ASSEMBLY_NAME_VERSION) $(GACUTIL_FLAGS)";			\
+	  $(GACUTIL) -u $(ASSEMBLY_NAME_VERSION) $(GACUTIL_FLAGS) || exit 1;			\
 	  if test -n '$(POLICY_VERSIONS)'; then						\
 	    for i in $(POLICY_VERSIONS); do						\
 	      echo "$(GACUTIL) -u policy.$$i.$(ASSEMBLY_NAME) $(GACUTIL_FLAGS)";	\


### PR DESCRIPTION
We need to qualify the assembly name with the version, otherwise gacutil
uninstall all versions of the assembly.
Fixes http://bugzilla.xamarin.com/show_bug.cgi?id=207
