### PR TITLE
Fix NRE for SetBackgroundPattern

### DIFF
--- a/gdk/Gdk.metadata
+++ b/gdk/Gdk.metadata
@@ -111,9 +111,11 @@
   <attr path="/api/namespace/object[@cname='GdkWindow']/method[@name='GetOrigin']/*/*[@type='gint*']" name="pass_as">out</attr>
   <attr path="/api/namespace/object[@cname='GdkWindow']/method[@name='GetPointer']/*/*[@type='gint*']" name="pass_as">out</attr>
   <attr path="/api/namespace/object[@cname='GdkWindow']/method[@name='GetPointer']/*/*[@type='GdkModifierType*']" name="pass_as">out</attr>
+  <attr path="/api/namespace/object[@cname='GdkWindow']/method[@name='GetBackgroundPattern']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GdkWindow']/method[@name='InvalidateMaybeRecurse']/*/*[@name='child_func']" name="scope">call</attr>
   <attr path="/api/namespace/object[@cname='GdkWindow']/method[@name='PeekChildren']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GdkWindow']/method[@name='RemoveFilter']" name="hidden">1</attr>
+  <attr path="/api/namespace/object[@cname='GdkWindow']/method[@name='SetBackgroundPattern']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GdkWindow']/method[@name='SetIconList']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GdkWindow']/method[@name='ThawToplevelUpdatesLibgtkOnly']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GdkWindow']/method[@name='GetUserData']" name="hidden">1</attr>

--- a/gdk/Window.custom
+++ b/gdk/Window.custom
@@ -24,6 +24,23 @@
 
 	public Window (Gdk.Window parent, Gdk.WindowAttr attributes, Gdk.WindowAttributesType attributes_mask) : this (parent, attributes, (int)attributes_mask) {}
 
+	[DllImport("libgdk-win32-3.0-0.dll", CallingConvention = CallingConvention.Cdecl)]
+	static extern IntPtr gdk_window_get_background_pattern(IntPtr raw);
+
+	[DllImport("libgdk-win32-3.0-0.dll", CallingConvention = CallingConvention.Cdecl)]
+	static extern void gdk_window_set_background_pattern(IntPtr raw, IntPtr pattern);
+
+	public Cairo.Pattern BackgroundPattern { 
+		get {
+			IntPtr raw_ret = gdk_window_get_background_pattern(Handle);
+			Cairo.Pattern ret = Cairo.Pattern.Lookup (raw_ret);
+			return ret;
+		}
+		set {
+			gdk_window_set_background_pattern(Handle, (value == null) ? IntPtr.Zero : value.Handle);
+		}
+	}
+
 	[DllImport ("libgdk-win32-3.0-0.dll", CallingConvention = CallingConvention.Cdecl)]
 	static extern IntPtr gdk_window_get_children(IntPtr raw);
 


### PR DESCRIPTION
If we set it to null background is set to parent brackground.
So we must handle null case and sent it to native without NRE.
