### PR TITLE
Fix for library name in glib assembly

### DIFF
--- a/glib/Thread.cs
+++ b/glib/Thread.cs
@@ -36,7 +36,7 @@ namespace GLib
 			g_thread_init (IntPtr.Zero);
 		}
 
-		[DllImport ("libgthread-2.0-0.dll", CallingConvention = CallingConvention.Cdecl)]
+		[DllImport ("libglib-2.0-0.dll", CallingConvention = CallingConvention.Cdecl)]
 		static extern bool g_thread_get_initialized ();
 
 		public static bool Supported


### PR DESCRIPTION
Hi everyone,

Seems there is a misprint in Glib\Thread.cs file. There is Supported property which use g_thread_get_initialized external method. It marked with DllImport to libgthread-2.0-0 library, but in that library there is no such method. This method exists in libglib-2.0-0 library since glib 2.20. Without it Gtk.Application.Init() fails with EntryNotFoundException.

I also created a bug - http://bugzilla.xamarin.com/show_bug.cgi?id=2329

Please, review it :)
