### PR TITLE
gdk: Add a dllmap for libgio-2.0-0.dll

### DIFF
--- a/gdk/gdk-sharp.dll.config.in
+++ b/gdk/gdk-sharp.dll.config.in
@@ -1,4 +1,5 @@
 <configuration>
+  <dllmap dll="libgio-2.0-0.dll" target="libgio-2.0@LIB_PREFIX@.0@LIB_SUFFIX@"/>
   <dllmap dll="libglib-2.0-0.dll" target="libglib-2.0@LIB_PREFIX@.0@LIB_SUFFIX@"/>
   <dllmap dll="libgobject-2.0-0.dll" target="libgobject-2.0@LIB_PREFIX@.0@LIB_SUFFIX@"/>
   <dllmap dll="libgdk-win32-3.0-0.dll" target="libgdk-3@LIB_PREFIX@.0@LIB_SUFFIX@"/>


### PR DESCRIPTION
As Gdk.Pixbuf uses two functions from libgio, we need a dllmap for that
in gdk-sharp.dll.config.
