### PR TITLE
Object: Fix ToggleRef disposing when we're being finalized

### DIFF
--- a/glib/Object.cs
+++ b/glib/Object.cs
@@ -47,20 +47,19 @@ namespace GLib {
 
 		public void Dispose ()
 		{
-			if (disposed)
-				return;
-
 			Dispose (true);
-			disposed = true;
 			GC.SuppressFinalize (this);
 		}
 
 		protected virtual void Dispose (bool disposing)
 		{
-			ToggleRef tref;
+			if (disposed)
+				return;
+
+			ToggleRef toggle_ref;
 			lock (Objects) {
-				if (Objects.TryGetValue (Handle, out tref)) {
-					tref.QueueUnref ();
+				if (Objects.TryGetValue (Handle, out toggle_ref)) {
+					toggle_ref.QueueUnref ();
 					Objects.Remove (Handle);
 				}
 			}
@@ -71,8 +70,8 @@ namespace GLib {
 			
 			if (disposing)
 				tref.Dispose ();
-			else
-				tref.QueueUnref ();
+
+			disposed = true;
 		}
 
 		public static bool WarnOnFinalize { get; set; }


### PR DESCRIPTION
We should not try to dispose our ToggleRef when Dispose(bool) has been
called by the finalizer, because we should not reference any managed
objects.

Set and check the disposed flag inside of Dispose(bool) so that it's
also done when the object is finalized.

Also clear up a confusion between a local ToggleRef variable in Dispose
and the ToggleRef member field.

A close inspection is needed on this one, to double-check that I'm not introducing any leak...
