### PR TITLE
gtk: Fix creation of ComboBox and ComboBoxText subclasses with entry

### DIFF
--- a/gtk/ComboBox.custom
+++ b/gtk/ComboBox.custom
@@ -33,7 +33,7 @@
 		protected ComboBox (bool with_entry) : base (IntPtr.Zero)
 		{
 			if (GetType () != typeof (ComboBox)) {
-				CreateNativeObject (new string [0], new GLib.Value[0]);
+				CreateNativeObject (new string[] { "has-entry" }, new GLib.Value[] { new GLib.Value (with_entry) });
 				return;
 			}
 				

--- a/gtk/ComboBoxText.cs
+++ b/gtk/ComboBoxText.cs
@@ -27,7 +27,8 @@ namespace Gtk {
 		protected ComboBoxText (bool has_entry) : base (IntPtr.Zero)
 		{
 			if (GetType () != typeof (ComboBoxText)) {
-				CreateNativeObject (new string[] { "has-entry" }, new GLib.Value[] { new GLib.Value (has_entry) });
+				CreateNativeObject (new string[] { "has-entry", "entry-text-column", "id-column" },
+									new GLib.Value[] { new GLib.Value (has_entry), new GLib.Value (0), new GLib.Value (1) });
 				return;
 			}
 				


### PR DESCRIPTION
When creating a subclass of ComboBox with an entry, the has-entry
property was not initialized, leading to a crash when trying to access
the entry.

For subclasses of ComboBoxText, two other properties were not
initialized, leading to Gtk-CRITICAL error messages.
