### PR TITLE
Add fix-ups so that missing properties are generated

### DIFF
--- a/gtk/Gtk.metadata
+++ b/gtk/Gtk.metadata
@@ -710,9 +710,15 @@
   <attr path="/api/namespace/object[@cname='GtkToggleAction']/method[@name='Toggled']" name="name">Toggle</attr>
   <attr path="/api/namespace/object[@cname='GtkToggleButton']/constructor[@cname='gtk_toggle_button_new_with_mnemonic']" name="preferred">1</attr>
   <attr path="/api/namespace/object[@cname='GtkToggleButton']/method[@name='Toggled']" name="name">Toggle</attr>
+  <attr path="/api/namespace/object[@cname='GtkToolbar']/method[@name='GetStyle']" name="new_flag">1</attr>
+  <attr path="/api/namespace/object[@cname='GtkToolbar']/method[@name='SetStyle']" name="new_flag">1</attr>
   <attr path="/api/namespace/object[@cname='GtkToolItem']/method[@name='ToolbarReconfigured']" name="name">EmitToolbarReconfigured</attr>
+  <attr path="/api/namespace/object[@cname='GtkToolItem']/method[@name='GetExpand']" name="new_flag">1</attr>
+  <attr path="/api/namespace/object[@cname='GtkToolItem']/method[@name='SetExpand']" name="new_flag">1</attr>
   <attr path="/api/namespace/object[@cname='GtkToolPalette']/method[@name='GetHadjustment']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GtkToolPalette']/method[@name='GetVadjustment']" name="hidden">1</attr>
+  <attr path="/api/namespace/object[@cname='GtkToolPalette']/method[@name='GetStyle']" name="new_flag">1</attr>
+  <attr path="/api/namespace/object[@cname='GtkToolPalette']/method[@name='SetStyle']" name="new_flag">1</attr>
   <attr path="/api/namespace/object[@cname='GtkTreeModelFilter']/constructor[@cname='gtk_tree_model_filter_new']/*/*[@name='root']" name="property_name">virtual-root</attr>
   <attr path="/api/namespace/object[@cname='GtkTreeModelFilter']/method[@name='ConvertIterToChildIter']/*/*[@name='child_iter']" name="pass_as">out</attr>
   <attr path="/api/namespace/object[@cname='GtkTreeModelFilter']/method[@name='ConvertChildIterToIter']" name="hidden">1</attr>


### PR DESCRIPTION
A few properties would not be generated, as a property with the same
name already exists in the Widget class. To resolve this, we mark the
corresponding accessors as new.
