### PR TITLE
glib-sharp: avoid issuing a CRITICAL from g_object lib

### DIFF
--- a/glib/ToggleRef.cs
+++ b/glib/ToggleRef.cs
@@ -124,7 +124,7 @@ namespace GLib {
 			}
 		}
 
-		static List<ToggleRef> PendingDestroys = new List<ToggleRef> ();
+		static HashSet<ToggleRef> PendingDestroys = new HashSet<ToggleRef> ();
 		static bool idle_queued;
 
 		public void QueueUnref ()


### PR DESCRIPTION
If a finalizer is called twice on a GObject, QueueUnref was being called twice, which added the object to PendingDestroys twice.
By making PendingDestroys a HashSet instead of a List, we avoid it having duplicated objects.

I observe this finalizer-called-twice behaviour happening with Mono 2.10.6 x86 on Linux.
This fixes BXC#4909.
