### PR TITLE
glib: Remove redundant call to ToggleRef.QueueUnref()

### DIFF
--- a/glib/Object.cs
+++ b/glib/Object.cs
@@ -60,7 +60,6 @@ namespace GLib {
 			ToggleRef tref;
 			lock (Objects) {
 				if (Objects.TryGetValue (Handle, out tref)) {
-					tref.QueueUnref ();
 					Objects.Remove (Handle);
 				}
 			}


### PR DESCRIPTION
Proper fix for https://bugzilla.xamarin.com/show_bug.cgi?id=4909.

Signed-off-by: Mike Kestner mkestner@gmail.com
