### PR TITLE
glib: fix glue build

### DIFF
--- a/glib/glue/thread.c
+++ b/glib/glue/thread.c
@@ -19,8 +19,11 @@
  * Boston, MA 02111-1307, USA.
  */
 
-
+#ifdef DISABLE_GTHREAD_CHECK
+#include <glib.h>
+#else
 #include <glib/gthread.h>
+#endif
 
 gboolean glibsharp_g_thread_supported (void);
 
@@ -28,7 +31,7 @@ gboolean
 glibsharp_g_thread_supported ()
 {
 #ifdef DISABLE_GTHREAD_CHECK
-	return true;
+	return TRUE;
 #else
 	return g_thread_supported ();
 #endif


### PR DESCRIPTION
Oops, this fixes:
/opt/gnome/include/glib-2.0/glib/gtypes.h:28
error: #error "Only <glib.h> can be included directly.
