### PR TITLE
Fixed P/Invokes and Dllmap to use GDK 3.0 instead of 2.0

### DIFF
--- a/gtkdotnet/Graphics.cs
+++ b/gtkdotnet/Graphics.cs
@@ -33,19 +33,19 @@ namespace Gtk.DotNet {
 		
 		private Graphics () {}
 
- 		[DllImport ("libgdk-win32-2.0-0.dll", CallingConvention = CallingConvention.Cdecl)]
+ 		[DllImport ("libgdk-win32-3.0-0.dll", CallingConvention = CallingConvention.Cdecl)]
 		internal static extern IntPtr gdk_win32_drawable_get_handle(IntPtr raw);
 
-		[DllImport ("libgdk-win32-2.0-0.dll", CallingConvention = CallingConvention.Cdecl)]
+		[DllImport ("libgdk-win32-3.0-0.dll", CallingConvention = CallingConvention.Cdecl)]
 		internal static extern IntPtr gdk_win32_hdc_get(IntPtr drawable, IntPtr gc, int usage);
 		
-		[DllImport ("libgdk-win32-2.0-0.dll", CallingConvention = CallingConvention.Cdecl)]
+		[DllImport ("libgdk-win32-3.0-0.dll", CallingConvention = CallingConvention.Cdecl)]
 		internal static extern void gdk_win32_hdc_release(IntPtr drawable,IntPtr gc,int usage);
 
-		[DllImport ("libgdk-win32-2.0-0.dll", CallingConvention = CallingConvention.Cdecl)]
+		[DllImport ("libgdk-win32-3.0-0.dll", CallingConvention = CallingConvention.Cdecl)]
 		internal static extern IntPtr gdk_x11_drawable_get_xdisplay (IntPtr raw);
 		
-		[DllImport ("libgdk-win32-2.0-0.dll", CallingConvention = CallingConvention.Cdecl)]
+		[DllImport ("libgdk-win32-3.0-0.dll", CallingConvention = CallingConvention.Cdecl)]
 		internal static extern IntPtr gdk_x11_drawable_get_xid (IntPtr raw);
 		
 		public static System.Drawing.Graphics FromDrawable (Gdk.Window drawable)

--- a/gtkdotnet/gtk-dotnet.dll.config.in
+++ b/gtkdotnet/gtk-dotnet.dll.config.in
@@ -1,3 +1,3 @@
 <configuration>
-  <dllmap dll="libgdk-win32-2.0-0.dll" target="libgdk-@GDK_BACKEND@-2.0@LIB_PREFIX@.0@LIB_SUFFIX@"/>
+  <dllmap dll="libgdk-win32-3.0-0.dll" target="libgdk-3@LIB_PREFIX@.0@LIB_SUFFIX@"/>
 </configuration>


### PR DESCRIPTION
While packaging GTK#3 for Debian the package dependency resolver tool bailed out because of an unresolvable dllmap in gtk-dotnet:
dh_clideps: Error: Missing shlibs entry: libgdk--2.0.so.0 or libgdk-win32-2.0-0.dll for: gtk-dotnet.dll!

This pull request fixes the P/Invokes and dllmap of gtk-dotnet
