### PR TITLE
gio: Add fix-up to GSettings.GetStrv's return-type to be null_term_array

### DIFF
--- a/gio/Gio.metadata
+++ b/gio/Gio.metadata
@@ -149,6 +149,7 @@
   <attr path="/api/namespace/object[@cname='GResolver']/*[@name='LookupServiceFinish']/return-type" name="element_type">GSrvTarget*</attr>
   <attr path="/api/namespace/object[@cname='GResolver']/*[@name='LookupServiceFinish']/return-type" name="owned">true</attr>
   <attr path="/api/namespace/object[@cname='GResolver']/*[@name='LookupServiceFinish']/return-type" name="elements_owned">true</attr>
+  <attr path="/api/namespace/object[@cname='GSettings']/method[@name='GetStrv']/return-type" name="null_term_array">1</attr>
   <attr path="/api/namespace/object[@cname='GSimpleAction']/signal[@cname='activate']" name="name">Activated</attr>
   <attr path="/api/namespace/object[@cname='GSimpleAsyncResult']/constructor[@cname='g_simple_async_result_new_error']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GSimpleAsyncResult']/method[@name='SetError']" name="hidden">1</attr>


### PR DESCRIPTION
Otherwise the method would have a return type of string instead of
string[], and then it would return invalid data.

(Marking its element_type as "gchar**" would achieve the same method
signature but it would crash when marshalling.)
