### PR TITLE
glib: install interfaces earlier, and avoid GetClassPtr() at init time

### DIFF
--- a/glib/Object.cs
+++ b/glib/Object.cs
@@ -429,7 +429,7 @@ namespace GLib {
 
 				if (!iface.IsAssignableFrom (t.BaseType)) {
 					GInterfaceInfo info = adapter.Info;
-					info.Data = gtype.GetClassPtr ();
+					info.Data = gtype.Val;
 					//FIXME:  overiding prop is done inside the init of interface adapter
 					// not sure that it is the good solution but 
 					// it is the only one I found without exception or loop
@@ -460,6 +460,9 @@ namespace GLib {
 			GType gtype = GType.RegisterGObjectType (t);
 			bool is_first_subclass = gtype.GetBaseType () == gtype.GetThresholdType ();
 
+			bool handlers_overridden = is_first_subclass;
+			AddInterfaces (gtype, t, ref handlers_overridden);
+
 			if (is_first_subclass) {
 				IntPtr class_ptr = gtype.GetClassPtr ();
 				GObjectClass gobject_class = (GObjectClass) Marshal.PtrToStructure (class_ptr, typeof (GObjectClass));
@@ -469,11 +472,9 @@ namespace GLib {
 				Marshal.StructureToPtr (gobject_class, class_ptr, false);
 			}
 			idx = 1;
-			bool handlers_overridden = is_first_subclass;
 			AddProperties (gtype, t, is_first_subclass, ref handlers_overridden);
 			ConnectDefaultHandlers (gtype, t);
 			InvokeTypeInitializers (gtype, t);
-			AddInterfaces (gtype, t, ref handlers_overridden);
 			return gtype;
 		}
 


### PR DESCRIPTION
GObject upstream has started disabling support for installing interfaces
in GTypes after they have already been initialized (class_init) [1], so
we need to add GInterfaces a bit earlier during initialization, and avoid
the use of GetClassPtr() (whose calls to either g_type_class_peek or
g_type_class_ref causes the class_init to be called).

[1] http://bugzilla.gnome.org/687659

Simplest way to test this is launching the sample/treemodeldemo.exe in
Ubuntu 13.04 beta. Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=11510
