### PR TITLE
build: fix automake warning about preprocessor C flags

### DIFF
--- a/atk/glue/Makefile.am
+++ b/atk/glue/Makefile.am
@@ -13,7 +13,7 @@ nodist_libatksharpglue_3_la_SOURCES = generated.c
 
 libatksharpglue_3_la_LIBADD = $(ATK_LIBS)
 
-INCLUDES = $(ATK_CFLAGS) $(GTK_SHARP_VERSION_CFLAGS) -I$(top_srcdir)
+AM_CPPFLAGS = $(ATK_CFLAGS) $(GTK_SHARP_VERSION_CFLAGS) -I$(top_srcdir)
 
 libatksharpglue.dll: $(libatksharpglue_3_la_OBJECTS) libatksharpglue.rc libatksharpglue.def
 	./build-dll libatksharpglue-3 $(VERSION)

--- a/gio/glue/Makefile.am
+++ b/gio/glue/Makefile.am
@@ -8,7 +8,7 @@ libgiosharpglue_3_la_LDFLAGS = -module -avoid-version -no-undefined
 
 libgiosharpglue_3_la_LIBADD = $(GIO_LIBS)
 
-INCLUDES = $(GIO_CFLAGS) $(GTK_SHARP_VERSION_CFLAGS) -I$(top_srcdir)
+AM_CPPFLAGS = $(GIO_CFLAGS) $(GTK_SHARP_VERSION_CFLAGS) -I$(top_srcdir)
 
 libgiosharpglue.dll: $(libgiosharpglue_3_la_OBJECTS) libgiosharpglue.rc libgiosharpglue.def
 	./build-dll libgiosharpglue-3 $(VERSION)

--- a/gtk/glue/Makefile.am
+++ b/gtk/glue/Makefile.am
@@ -15,7 +15,7 @@ libgtksharpglue_3_la_LDFLAGS = -module -avoid-version -no-undefined
 
 libgtksharpglue_3_la_LIBADD = $(GTK_LIBS)
 
-INCLUDES = $(GTK_CFLAGS) $(GTK_SHARP_VERSION_CFLAGS) -I$(top_srcdir)
+AM_CPPFLAGS = $(GTK_CFLAGS) $(GTK_SHARP_VERSION_CFLAGS) -I$(top_srcdir)
 
 libgtksharpglue.dll: $(libgtksharpglue_3_la_OBJECTS) libgtksharpglue.rc libgtksharpglue.def
 	./build-dll libgtksharpglue-3 $(VERSION)

--- a/gtk/gui-thread-check/profiler/Makefile.am
+++ b/gtk/gui-thread-check/profiler/Makefile.am
@@ -5,4 +5,4 @@ libmono_profiler_gui_thread_check_la_SOURCES = gui-thread-check.c
 
 libmono_profiler_gui_thread_check_la_LIBADD = @PROFILER_LIBS@
 
-INCLUDES = @PROFILER_CFLAGS@ -Wall
+AM_CPPFLAGS = @PROFILER_CFLAGS@ -Wall

--- a/pango/glue/Makefile.am
+++ b/pango/glue/Makefile.am
@@ -10,7 +10,7 @@ libpangosharpglue_3_la_LDFLAGS = -module -avoid-version -no-undefined
 
 libpangosharpglue_3_la_LIBADD = $(PANGO_LIBS)
 
-INCLUDES = $(PANGO_CFLAGS) $(GTK_SHARP_VERSION_CFLAGS) -I$(top_srcdir)
+AM_CPPFLAGS = $(PANGO_CFLAGS) $(GTK_SHARP_VERSION_CFLAGS) -I$(top_srcdir)
 
 libpangosharpglue.dll: $(libpangosharpglue_3_la_OBJECTS) libpangosharpglue.rc libpangosharpglue.def
 	./build-dll libpangosharpglue-3 $(VERSION)

--- a/sample/opaquetest/Makefile.am
+++ b/sample/opaquetest/Makefile.am
@@ -15,7 +15,7 @@ libopaque_la_LDFLAGS = -module -avoid-version -no-undefined
 
 libopaque_la_LIBADD = $(GTK_LIBS)
 
-INCLUDES = $(GTK_CFLAGS)
+AM_CPPFLAGS = $(GTK_CFLAGS)
 
 generated/*.cs: opaque-api.xml
 	$(RUNTIME) ../../generator/gapi_codegen.exe --generate $(srcdir)/opaque-api.xml	\

--- a/sample/valtest/Makefile.am
+++ b/sample/valtest/Makefile.am
@@ -15,7 +15,7 @@ libvalobj_la_LDFLAGS = -module -avoid-version -no-undefined
 
 libvalobj_la_LIBADD = $(GTK_LIBS)
 
-INCLUDES = $(GTK_CFLAGS)
+AM_CPPFLAGS = $(GTK_CFLAGS)
 
 Valobj.cs: valobj-api.xml
 	$(RUNTIME) ../../generator/gapi_codegen.exe --generate $(srcdir)/valobj-api.xml	\


### PR DESCRIPTION
With automake version 1.13.2 (which comes in debian testing/jessie),
we were starting to get these warnings by default:

...
Running automake --foreign  ...
atk/glue/Makefile.am:16: warning: 'INCLUDES' is the old name for 'AM_CPPFLAGS' (or '__CPPFLAGS')
gio/glue/Makefile.am:11: warning: 'INCLUDES' is the old name for 'AM_CPPFLAGS' (or '__CPPFLAGS')
gtk/glue/Makefile.am:18: warning: 'INCLUDES' is the old name for 'AM_CPPFLAGS' (or '__CPPFLAGS')
gtk/gui-thread-check/profiler/Makefile.am:8: warning: 'INCLUDES' is the old name for 'AM_CPPFLAGS' (or '__CPPFLAGS')
pango/glue/Makefile.am:13: warning: 'INCLUDES' is the old name for 'AM_CPPFLAGS' (or '__CPPFLAGS')
sample/opaquetest/Makefile.am:18: warning: 'INCLUDES' is the old name for 'AM_CPPFLAGS' (or '__CPPFLAGS')
sample/valtest/Makefile.am:18: warning: 'INCLUDES' is the old name for 'AM_CPPFLAGS' (or '*_CPPFLAGS')
Running autoconf ...
...

We simply follow the warning's recommendation of using AM_CPPFLAGS instead
(CPP meaning C PreProcessor, not C Plus Plus), as explained in
http://www.gnu.org/software/automake/manual/html_node/Program-Variables.html

The deprecation of INCLUDES has been there for very long already (since 2002,
therefore Automake 1.7), and we already depend on Automake 1.10.
