### PR TITLE
generator: fix possible unhandled KeyNotFoundException (regression)

### DIFF
--- a/generator/SymbolTable.cs
+++ b/generator/SymbolTable.cs
@@ -214,7 +214,12 @@ namespace GtkSharp.Generation {
 			IGeneratable cur_type = null;
 			while (types.TryGetValue (type, out cur_type) && cur_type is AliasGen) {
 				IGeneratable igen = cur_type as AliasGen;
-				types [type] = types [igen.Name];
+
+				IGeneratable new_type;
+				if (!types.TryGetValue (igen.Name, out new_type))
+					new_type = null;
+
+				types [type] = new_type;
 				type = igen.Name;
 			}
 


### PR DESCRIPTION
This regression surfaced after 82a957b [1],
when many collections were migrated to generic collections. HashTables
simply return null when queried for certain key, while Dictionary objects
throw KeyNotFoundException.

The regression could be noticed, more particularly, when trying to
compile the gtk3 branch of the gudevsharp project [2].

[1] https://github.com/mono/gtk-sharp/commit/82a957bc9d3d1fcc44c715a1020fe2afd16c7f4a
[2] https://github.com/mono/gudev-sharp/commits/gtk3
