### PR TITLE
sample: fix CustomScrollable sample to prevent too high Upper values

### DIFF
--- a/sample/CustomScrollableWidget.cs
+++ b/sample/CustomScrollableWidget.cs
@@ -184,6 +184,9 @@ class CustomScrollableWidget<T> : CustomBase, IScrollableImplementor {
 			if (hadjustment.Value + hadjustment.PageSize > hadjustment.Upper) {
 				hadjustment.Value = hadjustment.Upper - hadjustment.PageSize;
 			}
+			if (hadjustment.Upper > 0 && hadjustment.Upper < hadjustment.PageSize) {
+				hadjustment.Upper = hadjustment.PageSize;
+			}
 			hadjustment.Change ();
 		}
 		
@@ -192,6 +195,9 @@ class CustomScrollableWidget<T> : CustomBase, IScrollableImplementor {
 			vadjustment.StepIncrement = layoutHeight;
 			if (vadjustment.Value + vadjustment.PageSize > vadjustment.Upper) {
 				vadjustment.Value = vadjustment.Upper - vadjustment.PageSize;
+			}
+			if (vadjustment.Upper > 0 && vadjustment.Upper < vadjustment.PageSize) {
+				vadjustment.Upper = vadjustment.PageSize;
 			}
 			vadjustment.Change ();
 		}


### PR DESCRIPTION
Upper values having higher values than PageSize or PageIncrement cause
rendering issues. This commit is a small adaptation of a fix from one
of the edge cases pointed out in this commit in hyena:
https://git.gnome.org/browse/hyena/commit/?h=gtk3&id=0745bfb75809886925dfa49a57c79e5f71565d08
