### PR TITLE
gtk: fix a KeyNotFoundException regression in Destroyed event

### DIFF
--- a/gtk/Widget.cs
+++ b/gtk/Widget.cs
@@ -330,11 +330,15 @@ namespace Gtk {
 		[GLib.Signal("destroy")]
 		public event EventHandler Destroyed {
 			add {
-				EventHandler handler = (EventHandler) DestroyHandlers [Handle];
+				Delegate delegate_handler;
+				DestroyHandlers.TryGetValue (Handle, out delegate_handler);
+				var handler = delegate_handler as EventHandler;
 				DestroyHandlers [Handle] = Delegate.Combine (handler, value);
 			}
 			remove {
-				EventHandler handler = (EventHandler) DestroyHandlers [Handle];
+				Delegate delegate_handler;
+				DestroyHandlers.TryGetValue (Handle, out delegate_handler);
+				var handler = delegate_handler as EventHandler;
 				handler = (EventHandler) Delegate.Remove (handler, value);
 				if (handler != null)
 					DestroyHandlers [Handle] = handler;


### PR DESCRIPTION
The migration to generic collections [1] caused another regression: a
KeyNotFoundException was being thrown (instead of returning null like
HashTable did) when using the Destroyed event of the Gtk.Widget class.

A particular example of this problem is Banshee's Import Media feature,
which was generating the following stacktrace: [2].

[1] https://github.com/mono/gtk-sharp/commit/6850b343ca10c1f12294ec864508a8a7153351f5

[2] [1 Debug 23:24:36.898] Starting - Importing Media
Marshaling activate signal
Exception in Gtk# callback delegate
  Note: Applications can use GLib.ExceptionManager.UnhandledException
to handle the exception.
System.Reflection.TargetInvocationException: Exception has been thrown
by the target of an invocation. --->
System.Collections.Generic.KeyNotFoundException: The given key was not
present in the dictionary.
  at System.Collections.Generic.Dictionary`2[System.IntPtr,System.Delegate].get_Item
(IntPtr key) [0x00000] in <filename unknown>:0
  at Gtk.Widget.add_Destroyed (System.EventHandler value) [0x00000] in
/home/knocte/gtk-sharp/gtk/Widget.cs:333
  at Hyena.Widgets.AnimatedWidget..ctor (Gtk.Widget widget, UInt32
duration, Easing easing, Blocking blocking, Boolean horizontal)
[0x0004d] in /home/knocte/banshee/src/Hyena/Hyena.Gui/Hyena.Widgets/AnimatedWidget.cs:78
  at Hyena.Widgets.AnimatedBox.Pack (Gtk.Widget widget, UInt32
duration, Easing easing, Blocking blocking, Boolean end) [0x00011] in
/home/knocte/banshee/src/Hyena/Hyena.Gui/Hyena.Widgets/AnimatedBox.cs:402
  at Hyena.Widgets.AnimatedBox.PackEnd (Gtk.Widget widget, UInt32
duration, Easing easing, Blocking blocking) [0x00000] in
/home/knocte/banshee/src/Hyena/Hyena.Gui/Hyena.Widgets/AnimatedBox.cs:393
  at Hyena.Widgets.AnimatedBox.PackEnd (Gtk.Widget widget, Easing
easing) [0x00000] in
/home/knocte/banshee/src/Hyena/Hyena.Gui/Hyena.Widgets/AnimatedBox.cs:368
  at Banshee.Gui.Widgets.UserJobTileHost.AddJob (Hyena.Jobs.Job job)
[0x00076] in /home/knocte/banshee/src/Core/Banshee.ThickClient/Banshee.Gui.Widgets/UserJobTileHost.cs:88
  at Banshee.Gui.Widgets.UserJobTileHost+<OnJobAdded>c__AnonStorey17.<>m__90
() [0x0002c] in
/home/knocte/banshee/src/Core/Banshee.ThickClient/Banshee.Gui.Widgets/UserJobTileHost.cs:108
  at Hyena.ThreadAssist.ProxyToMain (Hyena.InvokeHandler handler)
[0x0001a] in /home/knocte/banshee/src/Hyena/Hyena/Hyena/ThreadAssist.cs:103
  at Banshee.Gui.Widgets.UserJobTileHost.OnJobAdded (Hyena.Jobs.Job
job) [0x00025] in
/home/knocte/banshee/src/Core/Banshee.ThickClient/Banshee.Gui.Widgets/UserJobTileHost.cs:100
  at (wrapper delegate-invoke) <Module>:invoke_void__this___Job (Hyena.Jobs.Job)
  at Hyena.Jobs.Scheduler.Add (Hyena.Jobs.Job job) [0x000b5] in
/home/knocte/banshee/src/Hyena/Hyena/Hyena.Jobs/Scheduler.cs:88
  at Banshee.ServiceStack.UserJob.Register () [0x00000] in
/home/knocte/banshee/src/Core/Banshee.Services/Banshee.ServiceStack/UserJob.cs:58
  at Banshee.Collection.ImportManager.CreateUserJob () [0x000e7] in
/home/knocte/banshee/src/Core/Banshee.Services/Banshee.Collection/ImportManager.cs:147
  at Banshee.Collection.ImportManager.Enqueue (System.String[] paths)
[0x00000] in /home/knocte/banshee/src/Core/Banshee.Services/Banshee.Collection/ImportManager.cs:109
  at Banshee.Library.Gui.FolderImportSource.Import () [0x0001e] in
/home/knocte/banshee/src/Core/Banshee.ThickClient/Banshee.Library.Gui/FolderImportSource.cs:46
  at Banshee.Gui.GlobalActions.OnImport (System.Object o,
System.EventArgs args) [0x00022] in
/home/knocte/banshee/src/Core/Banshee.ThickClient/Banshee.Gui/GlobalActions.cs:163
  at (wrapper managed-to-native)
System.Reflection.MonoMethod:InternalInvoke
(System.Reflection.MonoMethod,object,object[],System.Exception&)
  at System.Reflection.MonoMethod.Invoke (System.Object obj,
BindingFlags invokeAttr, System.Reflection.Binder binder,
System.Object[] parameters, System.Globalization.CultureInfo culture)
[0x00000] in <filename unknown>:0
  --- End of inner exception stack trace ---
  at System.Reflection.MonoMethod.Invoke (System.Object obj,
BindingFlags invokeAttr, System.Reflection.Binder binder,
System.Object[] parameters, System.Globalization.CultureInfo culture)
[0x00000] in <filename unknown>:0
  at System.Reflection.MethodBase.Invoke (System.Object obj,
System.Object[] parameters) [0x00000] in <filename unknown>:0
  at System.Delegate.DynamicInvokeImpl (System.Object[] args)
[0x00000] in <filename unknown>:0
  at System.MulticastDelegate.DynamicInvokeImpl (System.Object[] args)
[0x00000] in <filename unknown>:0
  at System.Delegate.DynamicInvoke (System.Object[] args) [0x00000] in
<filename unknown>:0
  at GLib.Signal.ClosureInvokedCB (System.Object o,
GLib.ClosureInvokedArgs args) [0x00025] in
/home/knocte/gtk-sharp/glib/Signal.cs:201
  at GLib.SignalClosure.Invoke (GLib.ClosureInvokedArgs args)
[0x0000c] in /home/knocte/gtk-sharp/glib/SignalClosure.cs:126
  at GLib.SignalClosure.MarshalCallback (IntPtr raw_closure, IntPtr
return_val, UInt32 n_param_vals, IntPtr param_values, IntPtr
invocation_hint, IntPtr marshal_data) [0x00075] in
/home/knocte/gtk-sharp/glib/SignalClosure.cs:154
   at GLib.ExceptionManager.RaiseUnhandledException(System.Exception
e, Boolean is_terminal) in
/home/knocte/gtk-sharp/glib/ExceptionManager.cs:line 58
   at GLib.SignalClosure.MarshalCallback(IntPtr raw_closure, IntPtr
return_val, UInt32 n_param_vals, IntPtr param_values, IntPtr
invocation_hint, IntPtr marshal_data) in
/home/knocte/gtk-sharp/glib/SignalClosure.cs:line 181
   at Gtk.Application.gtk_main()
   at Gtk.Application.Run() in
/home/knocte/gtk-sharp/gtk/Application.cs:line 131
   at Banshee.Gui.GtkBaseClient.Run() in
/home/knocte/banshee/src/Core/Banshee.ThickClient/Banshee.Gui/GtkBaseClient.cs:line
224
   at Banshee.Gui.GtkBaseClient.Startup() in
/home/knocte/banshee/src/Core/Banshee.ThickClient/Banshee.Gui/GtkBaseClient.cs:line
79
   at Hyena.Gui.CleanRoomStartup.Startup(Hyena.Gui.StartupInvocationHandler
startup) in /home/knocte/banshee/src/Hyena/Hyena.Gui/Hyena.Gui/CleanRoomStartup.cs:line
54
   at Banshee.Gui.GtkBaseClient.Startup() in
/home/knocte/banshee/src/Core/Banshee.ThickClient/Banshee.Gui/GtkBaseClient.cs:line
74
   at Banshee.Gui.GtkBaseClient.Startup(System.String[] args) in
/home/knocte/banshee/src/Core/Banshee.ThickClient/Banshee.Gui/GtkBaseClient.cs:line
64
   at Nereid.Client.Main(System.String[] args) in
/home/knocte/banshee/src/Clients/Nereid/Nereid/Client.cs:line 54
