### PR TITLE
glib: fix FindClassProperty()'s copy-paste error

### DIFF
--- a/glib/Object.cs
+++ b/glib/Object.cs
@@ -451,9 +451,9 @@ namespace GLib {
 
 		static IntPtr FindClassProperty (GType type, string name)
 		{
-			IntPtr g_iface = type.GetDefaultInterfacePtr ();
+			IntPtr g_class = type.GetClassPtr ();
 			IntPtr native_name = GLib.Marshaller.StringToPtrGStrdup (name);
-			return g_object_class_find_property (g_iface, native_name);
+			return g_object_class_find_property (g_class, native_name);
 		}
 
 		[DllImport ("libgobject-2.0-0.dll", CallingConvention = CallingConvention.Cdecl)]


### PR DESCRIPTION
The implementation of FindClassProperty() was the same as the
implementation of FindInterfaceProperty(), both receiving an iface
instead of a GObjectClass\* [1].

The reason of this oversight can well be explained by the fact that
FindClassProperty() is private and not used, actually. However, we
may need it soonish as a good bind to g_object_class_find_property.

[1] https://developer.gnome.org/gobject/unstable/gobject-The-Base-Object-Type.html#g-object-class-find-property
