### PR TITLE
generator: Added option to hide parameters

### DIFF
--- a/generator/Parameter.cs
+++ b/generator/Parameter.cs
@@ -266,6 +266,18 @@ namespace GtkSharp.Generation {
 			}
 		}
 
+		bool hidden = false;
+		public bool IsHidden {
+			get {
+				if (!hidden && elem.HasAttribute ("hidden"))
+					hidden = elem.GetAttributeAsBoolean ("hidden");
+				return hidden;
+			}
+			set {
+				hidden = value;
+			}
+		}
+
 		public virtual string[] Prepare {
 			get {
 				IGeneratable gen = Generatable;

--- a/generator/Parameters.cs
+++ b/generator/Parameters.cs
@@ -88,6 +88,9 @@ namespace GtkSharp.Generation {
 			if (p.IsCount)
 				return true;
 
+			if (p.IsHidden)
+				return true;
+
 			if (p.CType == "GError**" && Throws)
 				return true;
 


### PR DESCRIPTION
A hidden parameter is dropped from the signature and the default value is filled in.
