### PR TITLE
generator: avoid another Implementor suffix hardcode

### DIFF
--- a/generator/VirtualMethod.cs
+++ b/generator/VirtualMethod.cs
@@ -90,7 +90,7 @@ namespace GtkSharp.Generation {
 				if (implementor != null)
 					type = implementor.QualifiedName;
 				else if (this.container_type is InterfaceGen)
-					type = this.container_type.Name + "Implementor"; // We are in an interface/adaptor, invoke the method in the implementor class
+					type = (this.container_type as InterfaceGen).ImplementorName; // We are in an interface/adaptor, invoke the method in the implementor class
 				else
 					type = this.container_type.Name;
 


### PR DESCRIPTION
This "Implementor" suffix was refactored recently (in this commit:
6cb03440c1a3fb52c23d5d681e44f772d687333c) to be accessed via the
ImplementorName property. So we eliminate now the last occurrence
of it in hardcoded form.
