### PR TITLE
generator: provide a GType static property for adapters

### DIFF
--- a/generator/InterfaceGen.cs
+++ b/generator/InterfaceGen.cs
@@ -197,11 +197,22 @@ namespace GtkSharp.Generation {
 			m.GenerateImport (sw);
 			sw.WriteLine ("\t\tprivate static GLib.GType _gtype = new GLib.GType ({0} ());", m.CName);
 			sw.WriteLine ();
-			sw.WriteLine ("\t\tpublic override GLib.GType GType {");
+
+			// by convention, all GTypes generated have a static GType property
+			sw.WriteLine ("\t\tpublic static GLib.GType GType {");
 			sw.WriteLine ("\t\t\tget {");
 			sw.WriteLine ("\t\t\t\treturn _gtype;");
 			sw.WriteLine ("\t\t\t}");
 			sw.WriteLine ("\t\t}");
+			sw.WriteLine ();
+
+			// we need same property but non-static, because it is being accessed via a GInterfaceAdapter instance
+			sw.WriteLine ("\t\tpublic override GLib.GType GInterfaceGType {");
+			sw.WriteLine ("\t\t\tget {");
+			sw.WriteLine ("\t\t\t\treturn _gtype;");
+			sw.WriteLine ("\t\t\t}");
+			sw.WriteLine ("\t\t}");
+
 			sw.WriteLine ();
 		}
 

--- a/glib/GInterfaceAdapter.cs
+++ b/glib/GInterfaceAdapter.cs
@@ -50,7 +50,7 @@ namespace GLib {
 			}
 		}
 
-		public abstract GType GType { get; }
+		public abstract GType GInterfaceGType { get; }
 
 		public abstract IntPtr Handle { get; }
 

--- a/glib/Object.cs
+++ b/glib/Object.cs
@@ -225,7 +225,7 @@ namespace GLib {
 					if (!iface.IsAssignableFrom (Type.BaseType)) {
 						GInterfaceInfo info = adapter.Info;
 						info.Data = gtype.Val;
-						g_type_add_interface_static (gtype.Val, adapter.GType.Val, ref info);
+						g_type_add_interface_static (gtype.Val, adapter.GInterfaceGType.Val, ref info);
 						adapters.Add (adapter);
 					}
 				}
@@ -341,7 +341,7 @@ namespace GLib {
 						PropertyInfo declared_prop = Type.GetProperty (p.Name, BindingFlags.Public | BindingFlags.Instance);
 						if (declared_prop == null)
 							continue;
-						IntPtr param_spec = FindInterfaceProperty (adapter.GType, property_attr.Name);
+						IntPtr param_spec = FindInterfaceProperty (adapter.GInterfaceGType, property_attr.Name);
 
 						Dictionary<IntPtr, PropertyInfo> props;
 						if (!Properties.TryGetValue (Type, out props)) {

--- a/glib/Value.cs
+++ b/glib/Value.cs
@@ -134,7 +134,7 @@ namespace GLib {
 			g_value_set_object (ref this, val == null ? IntPtr.Zero : val.Handle);
 		}
 
-		public Value (GLib.GInterfaceAdapter val) : this (val == null ? GType.Object : val.GType)
+		public Value (GLib.GInterfaceAdapter val) : this (val == null ? GType.Object : val.GInterfaceGType)
 		{
 			g_value_set_object (ref this, val == null ? IntPtr.Zero : val.Handle);
 		}


### PR DESCRIPTION
In the same way all GLib.Object-derived classes provided by the
generator have a GType static property (i.e. Gtk.Widget), we need
the same for *Adapter classes, to access their GType without having
an instance of it. (The first use case would be GStreamerSharp's
Gst.Bin.IterateAllByInterface ().)

For this, we cannot simply add the property to all adapter classes
and be done, because it would clash with a property which is already
there, but is non-static, that has the same name and same value
(this property is needed for complying GInterfaceAdapter abstract
class), so we rename this property to GInterfaceGType because
using this name for the static one would not be consistent with the
rest of the classes generated which already provide the static one
with the name "GType".
