### PR TITLE
Convert some dynamic casts to static casts

### DIFF
--- a/generator/GObjectVM.cs
+++ b/generator/GObjectVM.cs
@@ -81,7 +81,7 @@ namespace GtkSharp.Generation {
 
 		VMCodeType CodeType {
 			get {
-				if (!(container_type as ObjectBase).CanGenerateClassStruct || force_glue_generation) {
+				if (!((ObjectBase)container_type).CanGenerateClassStruct || force_glue_generation) {
 					if (BlockGlue)
 						return VMCodeType.None;
 					else

--- a/glib/ToggleRef.cs
+++ b/glib/ToggleRef.cs
@@ -52,7 +52,7 @@ namespace GLib {
 				else if (reference is GLib.Object)
 					return reference as GLib.Object;
 
-				WeakReference weak = reference as WeakReference;
+				WeakReference weak = (WeakReference)reference;
 				return weak.Target as GLib.Object;
 			}
 		}
@@ -108,7 +108,7 @@ namespace GLib {
 		{
 			try {
 				GCHandle gch = (GCHandle) data;
-				ToggleRef tref = gch.Target as ToggleRef;
+				ToggleRef tref = (ToggleRef)gch.Target;
 				tref.Toggle (is_last_ref);
 			} catch (Exception e) {
 				ExceptionManager.RaiseUnhandledException (e, false);

--- a/glib/Value.cs
+++ b/glib/Value.cs
@@ -534,7 +534,7 @@ namespace GLib {
 					if(value is GLib.Object)
 						g_value_set_object (ref this, (value as GLib.Object).Handle);
 					else
-						g_value_set_object (ref this, (value as GLib.GInterfaceAdapter).Handle);
+						g_value_set_object (ref this, ((GInterfaceAdapter)value).Handle);
 				else if (GType.Is (type, GType.Boxed)) {
 					if (value is IWrapper) {
 						g_value_set_boxed (ref this, ((IWrapper)value).Handle);


### PR DESCRIPTION
There is no null check after these casts so if they fail they would
generate a NullReferenceException. By changing them to static casts
we would get InvalidCastException which are much less misleading.
