### PR TITLE
atk: add metadata fixup to avoid crash due to ABI break

### DIFF
--- a/atk/Atk.metadata
+++ b/atk/Atk.metadata
@@ -39,4 +39,8 @@
   <attr path="/api/namespace/interface[@cname='AtkText']/*[@name='GetDefaultAttributes']/return-type" name="element_type">AtkAttribute*</attr>
   <attr path="/api/namespace/interface[@cname='AtkEditableText']/*[@name='GetRunAttributes']/return-type" name="element_type">AtkAttribute*</attr>
   <attr path="/api/namespace/interface[@cname='AtkEditableText']/*[@name='GetDefaultAttributes']/return-type" name="element_type">AtkAttribute*</attr>
+
+  <!-- below is a workaround for an ABI break in recent ATK: https://git.gnome.org/browse/atk/commit/?id=b1f70e81ef1d7287dcb2cafa9a115ff5752ece55 -->
+  <remove-node path="/api/namespace/interface//field[@cname='pad1' or @cname='pad2' or @cname='pad3' or @cname='pad4']" />
+
 </metadata>


### PR DESCRIPTION
The ABI of ATK has been broken recently [1], so the best way
to deal with this is removing the pads from all the interfaces
found by GAPI in the atk namespace.

This avoids that some mono-based apps crash with new version
of Atk (i.e. 2.10.0, the one that Ubuntu 13.10 ships), and
still works for older versions (i.e. 2.8.0, the one that
Ubuntu 13.04 ships).

[1] https://git.gnome.org/browse/atk/commit/?id=b1f70e81ef1d7287dcb2cafa9a115ff5752ece55
