### PR TITLE
glib: install properties before class_init finishes

### DIFF
--- a/glib/Object.cs
+++ b/glib/Object.cs
@@ -206,7 +206,6 @@ namespace GLib {
 				AddGInterfaces ();
 				gtype.EnsureClass (); //calls class_init
 
-				AddProperties ();
 				ConnectDefaultHandlers ();
 				InvokeTypeInitializers ();
 				AddInterfaceProperties ();
@@ -242,6 +241,8 @@ namespace GLib {
 				foreach (GInterfaceAdapter adapter in adapters) {
 					InitializeProperties (adapter, gobject_class_handle);
 				}
+
+				AddProperties (gobject_class_handle);
 			}
 
 			private void InitializeProperties (GInterfaceAdapter adapter, IntPtr gobject_class_handle)
@@ -288,12 +289,11 @@ namespace GLib {
 				HandlersOverriden = true;
 			}
 
-			void AddProperties ()
+			void AddProperties (IntPtr gobject_class_handle)
 			{
 				if (is_first_subclass) {
-					IntPtr declaring_class = gtype.GetClassPtr ();
 					ParamSpec pspec = new ParamSpec ("gtk-sharp-managed-instance", "", "", GType.Pointer, ParamFlags.Writable | ParamFlags.ConstructOnly);
-					g_object_class_install_property (declaring_class, idx, pspec.Handle);
+					g_object_class_install_property (gobject_class_handle, idx, pspec.Handle);
 					idx++;
 				}
 


### PR DESCRIPTION
Recently glib started to warn about the future deprecation of adding
interfaces after class_init, which we fixed here [1].

Now, a similar warning has started to happen for the addition of
properties, example:

(Nereid:23225): GLib-GObject-WARNING **: Attempt to add property __gtksharp_33_Banshee_Widgets_TileView::gtk-sharp-managed-instance after class was initialised

So we need to add them before class_init finishes too, and this
change makes it this way.

[1] https://github.com/mono/gtk-sharp/commit/9ff7ec8b2c6a1727f61601bd934d65a790f5adda
