### PR TITLE
cairo: check earlier for IntPtr.Zero in Dispose(bool) method

### DIFF
--- a/cairo/Context.cs
+++ b/cairo/Context.cs
@@ -112,11 +112,11 @@ namespace Cairo {
 
 		protected virtual void Dispose (bool disposing)
 		{
-			if (!disposing || CairoDebug.Enabled)
-				CairoDebug.OnDisposed<Context> (handle, disposing);
-
 			if (!disposing || handle == IntPtr.Zero)
 				return;
+
+			if (!disposing || CairoDebug.Enabled)
+				CairoDebug.OnDisposed<Context> (handle, disposing);
 
 			NativeMethods.cairo_destroy (handle);
 			handle = IntPtr.Zero;


### PR DESCRIPTION
This prevents applications spam the console by printing CairoDebug
messages about objects that can't be disposed or were already
disposed.
