### PR TITLE
simplify bits about choosing the wrong prefix

### DIFF
--- a/README
+++ b/README
@@ -21,13 +21,9 @@ Building & Installing Gtk#:
     to make it so mono (and mint) can find your assemblies.  In other words,
     doing something like:
 
-        ./configure --prefix=/the/path/that/was/used/for/mono
+        ./configure --prefix=`pkg-config --variable=prefix mono`
         make
         make install
-
-    (Of course, replace "/the/path/that/was/used/for/mono" with whatever path
-    which was used for Mono.  This might have been "/usr", "/usr/local", or
-    something similar.)
 
     If you are compiling from GIT, you will need libtool and the auto* tools
     and will need to replace the configure above with autogen.sh.

--- a/configure.ac
+++ b/configure.ac
@@ -292,3 +292,11 @@ if test "x$enable_monodoc" = "xyes" -a "x$doc_sources_dir" != "x$prefix/lib/mono
 fi
 echo "---"
 
+mono_prefix=`pkg-config --variable=prefix mono`
+if test "x$mono_prefix" != "x$prefix"; then
+        AC_WARN(Prefix to use ($prefix) is not the same as Mono's ($mono_prefix). Consider using
+		    ./autogen.sh --prefix=$mono_prefix
+		    See the README for more information.
+	)
+fi
+


### PR DESCRIPTION
Clarifying the README thanks to the use of pkg-config,
and added a configure-time warning so people notice
about the problem without the need of reading the
README (like it is done in other repos, i.e. https://github.com/fsharp/fsharp/blob/master/configure.ac#L111 )
