### PR TITLE
MSBuild: fix the solution build (except audit and sample projects)

### DIFF
--- a/gdk/gdk.csproj
+++ b/gdk/gdk.csproj
@@ -229,5 +229,17 @@
       <Project>{3BF1D531-8840-4F15-8066-A9788D8C398B}</Project>
       <Name>glib</Name>
     </ProjectReference>
+    <ProjectReference Include="..\gio\gio.csproj">
+      <Project>{1C3BB17B-336D-432A-8952-4E979BC90867}</Project>
+      <Name>gio</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\cairo\cairo.csproj">
+      <Project>{364577DB-9728-4951-AC2C-EDF7A6FCC09D}</Project>
+      <Name>cairo</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\pango\pango.csproj">
+      <Project>{FF422D8C-562F-4EA6-8590-9D1A5CD40AD4}</Project>
+      <Name>pango</Name>
+    </ProjectReference>
   </ItemGroup>
 </Project>

--- a/gio/DBusInterfaceVTable.cs
+++ b/gio/DBusInterfaceVTable.cs
@@ -21,6 +21,7 @@ using System.Runtime.InteropServices;
 
 namespace GLib {
 
+	// FIXME: this file was not included in the build when it was created, as it is just a stub
 	public partial class DBusInterfaceVTable {
 
 		[StructLayout(LayoutKind.Sequential)]

--- a/gio/Makefile.am
+++ b/gio/Makefile.am
@@ -11,6 +11,7 @@ glue_includes = gio/gio.h
 
 POLICY_VERSIONS=
 
+# FIXME: include DBusInterfaceVTable.cs (custom) or remove the file
 sources =			\
 	AppInfoAdapter.cs	\
 	FileAdapter.cs		\

--- a/gio/gio.csproj
+++ b/gio/gio.csproj
@@ -21,6 +21,7 @@
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>x86</PlatformTarget>
     <ConsolePause>false</ConsolePause>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
     <DebugType>none</DebugType>
@@ -30,11 +31,11 @@
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>x86</PlatformTarget>
     <ConsolePause>false</ConsolePause>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
     <Compile Include="AppInfoAdapter.cs" />
-    <Compile Include="DBusInterfaceVTable.cs" />
     <Compile Include="IFile.cs" />
     <Compile Include="FileAdapter.cs" />
     <Compile Include="FileEnumerator.cs" />
@@ -366,11 +367,15 @@
     <Compile Include="generated\IInitable.cs" />
     <Compile Include="generated\ILoadableIcon.cs" />
     <Compile Include="generated\IMount.cs" />
+    <Compile Include="generated\SocketSourceFunc.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\glib\glib.csproj">
       <Project>{3BF1D531-8840-4F15-8066-A9788D8C398B}</Project>
       <Name>glib</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="System" />
   </ItemGroup>
 </Project>

--- a/gtk/gtk.csproj
+++ b/gtk/gtk.csproj
@@ -926,6 +926,16 @@
     <Compile Include="generated\ICellLayout.cs" />
     <Compile Include="generated\IEditable.cs" />
     <Compile Include="generated\IFileChooser.cs" />
+    <Compile Include="generated\IToolShell.cs" />
+    <Compile Include="generated\ITreeDragDest.cs" />
+    <Compile Include="generated\ITreeDragSource.cs" />
+    <Compile Include="generated\ITreeModel.cs" />
+    <Compile Include="generated\ITreeSortable.cs" />
+    <Compile Include="generated\IOrientable.cs" />
+    <Compile Include="generated\IPrintOperationPreview.cs" />
+    <Compile Include="generated\IRecentChooser.cs" />
+    <Compile Include="generated\IScrollable.cs" />
+    <Compile Include="generated\IStyleProvider.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -946,6 +956,14 @@
     <ProjectReference Include="..\cairo\cairo.csproj">
       <Project>{364577DB-9728-4951-AC2C-EDF7A6FCC09D}</Project>
       <Name>cairo</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\gio\gio.csproj">
+      <Project>{1C3BB17B-336D-432A-8952-4E979BC90867}</Project>
+      <Name>gio</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\pango\pango.csproj">
+      <Project>{FF422D8C-562F-4EA6-8590-9D1A5CD40AD4}</Project>
+      <Name>pango</Name>
     </ProjectReference>
   </ItemGroup>
 </Project>

--- a/pango/pango.csproj
+++ b/pango/pango.csproj
@@ -21,6 +21,7 @@
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>x86</PlatformTarget>
     <ConsolePause>false</ConsolePause>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
     <DebugType>none</DebugType>
@@ -30,6 +31,7 @@
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>x86</PlatformTarget>
     <ConsolePause>false</ConsolePause>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
@@ -186,5 +188,15 @@
     <Compile Include="generated\Win32GlyphInfo.cs" />
     <Compile Include="generated\Win32MetricsInfo.cs" />
     <Compile Include="generated\WrapMode.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\glib\glib.csproj">
+      <Project>{3BF1D531-8840-4F15-8066-A9788D8C398B}</Project>
+      <Name>glib</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\cairo\cairo.csproj">
+      <Project>{364577DB-9728-4951-AC2C-EDF7A6FCC09D}</Project>
+      <Name>cairo</Name>
+    </ProjectReference>
   </ItemGroup>
 </Project>

--- a/sample/ManagedTreeViewDemo.cs
+++ b/sample/ManagedTreeViewDemo.cs
@@ -10,7 +10,7 @@ namespace GtkSamples {
 
 	using Gtk;
 
-	public class TreeViewDemo {
+	public class ManagedTreeViewDemo {
 		private static ListStore store = null;
 		
 		private class Pair {

--- a/sample/Subclass.cs
+++ b/sample/Subclass.cs
@@ -9,7 +9,7 @@ namespace GtkSamples {
 	using Gtk;
 	using System;
 
-	public class ButtonApp  {
+	public class ButtonAppSubclass  {
 
 		public static int Main (string[] args)
 		{


### PR DESCRIPTION
This commit makes it possible to build any project of the gtk-sharp.sln
from an IDE (except audit and sample projects, which require a bit more
work). This doesn't mean that AUTOTOOLS is deprecated, but just that it
is more comfortable to use an IDE when working on gtk-sharp because it
will offer better auto-completion, and will stop highlight misleading
semantic errors, from now on.
