### PR TITLE
gui-thread-check: use fflush() after printf()

### DIFF
--- a/gtk/gui-thread-check/profiler/gui-thread-check.c
+++ b/gtk/gui-thread-check/profiler/gui-thread-check.c
@@ -26,6 +26,7 @@
 #include <string.h>
 #include <glib.h>
 #include <mono/metadata/profiler.h>
+#include <stdio.h>
 
 
 extern pthread_t pthread_self (void);
@@ -62,7 +63,8 @@ simple_method_enter (MonoProfiler *prof, MonoMethod *method)
 		if (!guithread_set && strcmp (klass_name, "Application")==0 && strcmp (method_name, "Init")==0) {
 			guithread_set = TRUE;
 			guithread = current_thread_id;
-			printf ("*** GUI THREAD INITIALIZED: %u\n", guithread); 
+			printf ("*** GUI THREAD INITIALIZED: %u\n", guithread);
+			fflush (NULL);
 			return;
 		}
 		if (!guithread_set) {
@@ -77,6 +79,7 @@ simple_method_enter (MonoProfiler *prof, MonoMethod *method)
 		) {
 			printf ("*** GTK CALL NOT IN GUI THREAD: %s.%s\n", klass_name, method_name);
 	        mono_stack_walk_no_il (stack_walk_fn, NULL);
+			fflush (NULL);
 		}
 	}
 }


### PR DESCRIPTION
Using fflush() right away after printf() calls avoids the buffers to
be written in an apparently complete-out-of-sync way from the point
of view of the developer. This problem would specially occur when
redirecting all output to a file this way:

  mono Foo.exe > out.txt 2>&1

Without this fix, all the output from gui-thread-check would appear
at the end of the file, instead of in between the output generated by
the program.

Cherry-picked from https://github.com/slluis/gui-thread-check/commit/6988cd4cd2deb21d0a8006d63e1090996f18b92f
