### PR TITLE
gui-thread-check: add two more methods to the whitelist

### DIFF
--- a/gtk/gui-thread-check/profiler/gui-thread-check.c
+++ b/gtk/gui-thread-check/profiler/gui-thread-check.c
@@ -72,9 +72,11 @@ simple_method_enter (MonoProfiler *prof, MonoMethod *method)
 		}
 		if (current_thread_id != guithread &&
 			!(strcmp (klass_name, "Object")==0 && strcmp (method_name, "Dispose")==0) &&
+			!(strcmp (klass_name, "Widget")==0 && strcmp (method_name, "Dispose")==0) &&
 			!(strcmp (klass_name, "Application")==0 && strcmp (method_name, "Invoke")==0) &&
 			!(strcmp (method_name, "Finalize")==0) &&
 			!(strcmp (method_name, "get_NativeDestroyHandler")==0) &&
+			!(strcmp (method_name, "remove_InternalDestroyed")==0) &&
 			!(strcmp (method_name, "remove_Destroyed")==0)
 		) {
 			printf ("*** GTK CALL NOT IN GUI THREAD: %s.%s\n", klass_name, method_name);


### PR DESCRIPTION
At application shutdown, it's very likely to be spammed by
gui-thread-check with a river of:

**\* GTK CALL NOT IN GUI THREAD: Widget.Dispose
**\* GTK CALL NOT IN GUI THREAD: Widget.remove_InternalDestroyed
**\* GTK CALL NOT IN GUI THREAD: Widget.Dispose
**\* GTK CALL NOT IN GUI THREAD: Widget.remove_InternalDestroyed
...

From what I gather, these two methods (in gtk-sharp master[1]) could
be called by the finalizers, but do not call any unmanaged functions,
so it should be ok to not report them as violations.

[1] https://github.com/mono/gtk-sharp/blob/master/gtk/Widget.cs

Cherry-picked from https://github.com/slluis/gui-thread-check/commit/77a40599ca621db418d4e2d85e70a254088d975f
