### PR TITLE
gtk: fix Application to be more robust when embedding mono

### DIFF
--- a/gtk/Application.cs
+++ b/gtk/Application.cs
@@ -64,7 +64,9 @@ namespace Gtk {
 
 		static void SetPrgname ()
 		{
-			GLib.Global.ProgramName = System.IO.Path.GetFileNameWithoutExtension (Environment.GetCommandLineArgs () [0]);
+			var args = Environment.GetCommandLineArgs ();
+			if (args != null && args.Length > 0)
+				GLib.Global.ProgramName = System.IO.Path.GetFileNameWithoutExtension (args [0]);
 		}
 
 		public static void Init ()


### PR DESCRIPTION
When embedding mono, Environment.GetCommandLineArgs() would not return
an array with any element.

Reported in the mailing list, by Vardar Sahin.
