### PR TITLE
cairo: fix remaining leaks when finalizer gets called

### DIFF
--- a/cairo/Context.cs
+++ b/cairo/Context.cs
@@ -118,7 +118,7 @@ namespace Cairo {
 			if (handle == IntPtr.Zero)
 				return;
 
-			NativeMethods.cairo_destroy (handle);
+			Global.QueueUnref (NativeMethods.cairo_destroy, handle);
 			handle = IntPtr.Zero;
 		}
 

--- a/cairo/FontFace.cs
+++ b/cairo/FontFace.cs
@@ -61,7 +61,7 @@ namespace Cairo
 			if (!disposing || CairoDebug.Enabled)
 				CairoDebug.OnDisposed<FontFace> (handle, disposing);
 
-			if (!disposing|| handle == IntPtr.Zero)
+			if (handle == IntPtr.Zero)
 				return;
 
 			NativeMethods.cairo_font_face_destroy (handle);

--- a/cairo/FontFace.cs
+++ b/cairo/FontFace.cs
@@ -64,7 +64,7 @@ namespace Cairo
 			if (handle == IntPtr.Zero)
 				return;
 
-			NativeMethods.cairo_font_face_destroy (handle);
+			Global.QueueUnref (NativeMethods.cairo_font_face_destroy, handle);
 			handle = IntPtr.Zero;
 		}
 

--- a/cairo/FontOptions.cs
+++ b/cairo/FontOptions.cs
@@ -72,7 +72,7 @@ namespace Cairo
 			if (!disposing || CairoDebug.Enabled)
 				CairoDebug.OnDisposed<FontOptions> (handle, disposing);
 
-			if (!disposing|| handle == IntPtr.Zero)
+			if (handle == IntPtr.Zero)
 				return;
 
 			NativeMethods.cairo_font_options_destroy (handle);

--- a/cairo/FontOptions.cs
+++ b/cairo/FontOptions.cs
@@ -75,7 +75,7 @@ namespace Cairo
 			if (handle == IntPtr.Zero)
 				return;
 
-			NativeMethods.cairo_font_options_destroy (handle);
+			Global.QueueUnref (NativeMethods.cairo_font_options_destroy, handle);
 			handle = IntPtr.Zero;
 		}
 

--- a/cairo/Global.cs
+++ b/cairo/Global.cs
@@ -1,4 +1,10 @@
-// Copyright (c) 2011 Novell, Inc.
+//
+// Mono.Cairo.Global.cs
+//
+// Authors:
+//    Andrés G. Aragoneses
+//
+// (C) Andrés G. Aragoneses, 2013.
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -24,62 +30,15 @@ using System;
 
 namespace Cairo
 {
-
-	public enum DeviceType {
-		Drm,
-		GL,
-		Script,
-		Xcb,
-		Xlib,
-		Xml,
-	}
-
-	public class Device : IDisposable
+	internal class Global
 	{
-
-		IntPtr handle;
-
-		internal Device (IntPtr handle)
+		internal static void QueueUnref (Action<IntPtr> unref_native_function, IntPtr handle)
 		{
-			this.handle = NativeMethods.cairo_device_reference (handle);
+			GLib.Timeout.Add (50, () => {
+				unref_native_function (handle);
+				return false;
+			});
 		}
-
-		public Status Acquire ()
-		{
-			return NativeMethods.cairo_device_acquire (handle);
-		}
-
-		public void Dispose ()
-		{
-			if (handle != IntPtr.Zero)
-				Global.QueueUnref (NativeMethods.cairo_device_destroy, handle);
-			handle = IntPtr.Zero;
-			GC.SuppressFinalize (this);
-		}
-
-		public void Finish ()
-		{
-			NativeMethods.cairo_device_finish (handle);
-		}
-
-		public void Flush ()
-		{
-			NativeMethods.cairo_device_flush (handle);
-		}
-
-		public void Release ()
-		{
-			NativeMethods.cairo_device_release (handle);
-		}
-
-		public Status Status {
-			get { return NativeMethods.cairo_device_status (handle); }
-		}
-
-		public DeviceType Type {
-			get { return NativeMethods.cairo_device_get_type (handle); }
-		}
-
 	}
 }
 

--- a/cairo/Makefile.am
+++ b/cairo/Makefile.am
@@ -1,6 +1,7 @@
 ASSEMBLY_NAME = cairo-sharp
 ASSEMBLY_NAME_VERSION = $(ASSEMBLY_NAME),Version=$(CAIRO_API_VERSION)
 ASSEMBLY = $(ASSEMBLY_NAME).dll
+references = -r:$(top_builddir)/glib/glib-sharp.dll
 SNK = $(srcdir)/mono.snk
 
 TARGET=$(ASSEMBLY)
@@ -29,6 +30,7 @@ sources = \
 	FontType.cs \
 	FontWeight.cs \
 	Format.cs \
+	Global.cs \
 	GlitzSurface.cs \
 	Glyph.cs \
 	Gradient.cs \

--- a/cairo/NativeMethods.cs
+++ b/cairo/NativeMethods.cs
@@ -700,7 +700,7 @@ namespace Cairo
 		internal static extern IntPtr cairo_scaled_font_create (IntPtr fontFace, Matrix matrix, Matrix ctm, IntPtr options);
 		
 		[DllImport (cairo, CallingConvention=CallingConvention.Cdecl)]
-		internal static extern IntPtr cairo_scaled_font_destroy (IntPtr scaled_font);
+		internal static extern void cairo_scaled_font_destroy (IntPtr scaled_font);
 		
 		[DllImport (cairo, CallingConvention=CallingConvention.Cdecl)]
 		internal static extern void cairo_scaled_font_extents (IntPtr scaled_font, out FontExtents extents);

--- a/cairo/Path.cs
+++ b/cairo/Path.cs
@@ -66,7 +66,7 @@ namespace Cairo {
 			if (handle == IntPtr.Zero)
 				return;
 
-			NativeMethods.cairo_path_destroy (handle);
+			Global.QueueUnref (NativeMethods.cairo_path_destroy, handle);
 			handle = IntPtr.Zero;
 		}
 	}

--- a/cairo/Path.cs
+++ b/cairo/Path.cs
@@ -63,7 +63,7 @@ namespace Cairo {
 			if (!disposing || CairoDebug.Enabled)
 				CairoDebug.OnDisposed<Path> (handle, disposing);
 
-			if (!disposing || handle == IntPtr.Zero)
+			if (handle == IntPtr.Zero)
 				return;
 
 			NativeMethods.cairo_path_destroy (handle);

--- a/cairo/Pattern.cs
+++ b/cairo/Pattern.cs
@@ -102,7 +102,7 @@ namespace Cairo {
 			if (Handle == IntPtr.Zero)
 				return;
 
-			NativeMethods.cairo_pattern_destroy (Handle);
+			Global.QueueUnref (NativeMethods.cairo_pattern_destroy, Handle);
 			Handle = IntPtr.Zero;
 		}
 

--- a/cairo/Pattern.cs
+++ b/cairo/Pattern.cs
@@ -99,7 +99,7 @@ namespace Cairo {
 			if (!disposing || CairoDebug.Enabled)
 				CairoDebug.OnDisposed<Pattern> (Handle, disposing);
 
-			if (!disposing|| Handle == IntPtr.Zero)
+			if (Handle == IntPtr.Zero)
 				return;
 
 			NativeMethods.cairo_pattern_destroy (Handle);

--- a/cairo/Region.cs
+++ b/cairo/Region.cs
@@ -97,7 +97,7 @@ namespace Cairo
 			if (handle == IntPtr.Zero)
 				return;
 
-			NativeMethods.cairo_region_destroy (Handle);
+			Global.QueueUnref (NativeMethods.cairo_region_destroy, handle);
 			handle = IntPtr.Zero;
 		}
 

--- a/cairo/Region.cs
+++ b/cairo/Region.cs
@@ -94,7 +94,7 @@ namespace Cairo
 			if (!disposing || CairoDebug.Enabled)
 				CairoDebug.OnDisposed<Region> (handle, disposing);
 
-			if (!disposing|| handle == IntPtr.Zero)
+			if (handle == IntPtr.Zero)
 				return;
 
 			NativeMethods.cairo_region_destroy (Handle);

--- a/cairo/ScaledFont.cs
+++ b/cairo/ScaledFont.cs
@@ -106,7 +106,7 @@ namespace Cairo {
 			if (!disposing || CairoDebug.Enabled)
 				CairoDebug.OnDisposed<ScaledFont> (handle, disposing);
 
-			if (!disposing|| handle == IntPtr.Zero)
+			if (handle == IntPtr.Zero)
 				return;
 
 			NativeMethods.cairo_scaled_font_destroy (handle);

--- a/cairo/ScaledFont.cs
+++ b/cairo/ScaledFont.cs
@@ -109,7 +109,7 @@ namespace Cairo {
 			if (handle == IntPtr.Zero)
 				return;
 
-			NativeMethods.cairo_scaled_font_destroy (handle);
+			Global.QueueUnref (NativeMethods.cairo_scaled_font_destroy, handle);
 			handle = IntPtr.Zero;
 		}
 

--- a/cairo/Surface.cs
+++ b/cairo/Surface.cs
@@ -147,7 +147,7 @@ namespace Cairo {
 			if (handle == IntPtr.Zero)
 				return;
 
-			NativeMethods.cairo_surface_destroy (handle);
+			Global.QueueUnref (NativeMethods.cairo_surface_destroy, handle);
 			handle = IntPtr.Zero;
 		}
 

--- a/cairo/Surface.cs
+++ b/cairo/Surface.cs
@@ -144,7 +144,7 @@ namespace Cairo {
 			if (!disposing || CairoDebug.Enabled)
 				CairoDebug.OnDisposed<Surface> (handle, disposing);
 
-			if (!disposing || handle == IntPtr.Zero)
+			if (handle == IntPtr.Zero)
 				return;
 
 			NativeMethods.cairo_surface_destroy (handle);

--- a/cairo/cairo.csproj
+++ b/cairo/cairo.csproj
@@ -88,5 +88,12 @@
     <Compile Include="Distance.cs" />
     <Compile Include="Point.cs" />
     <Compile Include="PointD.cs" />
+    <Compile Include="Global.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\glib\glib.csproj">
+      <Project>{3BF1D531-8840-4F15-8066-A9788D8C398B}</Project>
+      <Name>glib</Name>
+    </ProjectReference>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Apply same finalizer leak fix to the rest of IDisposable-ownership
cairo classes as the one recently committed for Cairo.Context[1].

[1] https://github.com/mono/gtk-sharp/commit/41eeecbf9a6d84fa29ccee9adfee98ada1f1de66
