### PR TITLE
Add SetValue function for long type

### DIFF
--- a/gtk/ListStore.cs
+++ b/gtk/ListStore.cs
@@ -71,6 +71,13 @@ namespace Gtk {
 			SetValue (iter, column, val);
 			val.Dispose ();
 		}
+		
+		public void SetValue (Gtk.TreeIter iter, int column, long value)
+		{
+			GLib.Value val = new GLib.Value (value);
+			SetValue (iter, column, val);
+			val.Dispose ();
+		}
 
 		public void SetValue (Gtk.TreeIter iter, int column, string value) 
 		{


### PR DESCRIPTION
If use SetValue function with long type of value, compiler don't show any error, because used SetValue function for flat type. But Glib can not convert from gflat type to long.
