### PR TITLE
generator: Fix handle being passed when type is a struct

### DIFF
--- a/generator/Method.cs
+++ b/generator/Method.cs
@@ -243,7 +243,7 @@ namespace GtkSharp.Generation {
 						return;
 					else {
 						is_set = false;
-						call = "(Handle, " + Body.GetCallString (false) + ")";
+						call = "(" + (IsStatic ? "" : container_type.CallByName () + (parms.Count > 0 ? ", " : "")) + Body.GetCallString (false) + ")";
 						comp = null;
 					}
 				}


### PR DESCRIPTION
A static getter method would always generate a Handle parameter even though some types do not have a Handle like structs.
