### PR TITLE
Fix generation of SetGValue method

### DIFF
--- a/generator/OpaqueGen.cs
+++ b/generator/OpaqueGen.cs
@@ -59,8 +59,8 @@ namespace GtkSharp.Generation {
 
 			SymbolTable table = SymbolTable.Table;
 
-			Method ref_, unref, dispose;
-			GetSpecialMethods (out ref_, out unref, out dispose);
+			Method ref_, unref, dispose, setGValue;
+			GetSpecialMethods (out ref_, out unref, out dispose, out setGValue);
 
 			if (IsDeprecated)
 				sw.WriteLine ("\t[Obsolete]");
@@ -184,6 +184,17 @@ namespace GtkSharp.Generation {
 				sw.WriteLine ();
 			}
 #endif
+			if (setGValue != null) {
+				sw.WriteLine ("\t\t[DllImport(\"{0}\", CallingConvention = CallingConvention.Cdecl)]", LibraryName);
+				sw.WriteLine ("\t\tstatic extern void {0}(ref GLib.Value val, IntPtr obj);", setGValue.CName);
+				sw.WriteLine ();
+				sw.WriteLine ("\t\tpublic void SetGValue (ref GLib.Value val)");
+				sw.WriteLine ("\t\t{");
+				sw.WriteLine ("\t\t\t{0} (ref val, Handle);", setGValue.CName);
+				sw.WriteLine ("\t\t}");
+				sw.WriteLine ();
+			}
+
 			sw.WriteLine ("#endregion");
 
 			sw.WriteLine ("\t}");
@@ -194,7 +205,7 @@ namespace GtkSharp.Generation {
 			Statistics.OpaqueCount++;
 		}
 
-		void GetSpecialMethods (out Method ref_, out Method unref, out Method dispose)
+		void GetSpecialMethods (out Method ref_, out Method unref, out Method dispose, out Method setGValue)
 		{
 			ref_ = CheckSpecialMethod (GetMethod ("Ref"));
 			unref = CheckSpecialMethod (GetMethod ("Unref"));
@@ -206,6 +217,9 @@ namespace GtkSharp.Generation {
 					dispose = GetMethod ("Dispose");
 			}
 			dispose = CheckSpecialMethod (dispose);
+
+			setGValue = GetMethod ("SetGValue");
+			Methods.Remove ("SetGValue");
 		}
 
 		Method CheckSpecialMethod (Method method)


### PR DESCRIPTION
Some types need special methods to convert a object to a gvalue.
The type system will look for an SetGValue method with an ref GLib.Value parameter and invoke it.
Manual generation is needed because this is a non-static method with the Handle being passed as the second parameter and the GLib.Value as the first. Without this fix, the generator would generate the Handle for the first parameter and then the GLib.Value.

The new generated method looks like this:

``` csharp
[DllImport("cogl", CallingConvention = CallingConvention.Cdecl)]
static extern void cogl_object_value_set_object(ref GLib.Value val, IntPtr obj);

public void SetGValue (ref GLib.Value val)
{
    cogl_object_value_set_object (ref val, Handle);
}
```
