### PR TITLE
glib: Add GVariant to fundamental types

### DIFF
--- a/glib/GType.cs
+++ b/glib/GType.cs
@@ -92,6 +92,8 @@ namespace GLib {
 		public static readonly GType Boxed = new GType ((IntPtr) TypeFundamentals.TypeBoxed);
 		public static readonly GType Param = new GType ((IntPtr) TypeFundamentals.TypeParam);
 		public static readonly GType Object = new GType ((IntPtr) TypeFundamentals.TypeObject);
+		public static readonly GType Variant = new GType ((IntPtr) TypeFundamentals.TypeVariant);
+
 
 		static IDictionary<IntPtr, Type> types = new Dictionary<IntPtr, Type> ();
 		static IDictionary<Type, GType> gtypes = new Dictionary<Type, GType> ();
@@ -126,6 +128,7 @@ namespace GLib {
 			Register (GType.Pointer, typeof (IntPtr));
 			Register (GType.Object, typeof (GLib.Object));
 			Register (GType.Pointer, typeof (IntPtr));
+			Register (GType.Variant, typeof (GLib.Variant));
 
 			// One-way mapping
 			gtypes[typeof (char)] = GType.UInt;

--- a/glib/TypeFundamentals.cs
+++ b/glib/TypeFundamentals.cs
@@ -43,5 +43,6 @@ namespace GLib {
 		TypeBoxed	= 18 << 2,
 		TypeParam	= 19 << 2,
 		TypeObject	= 20 << 2,
+		TypeVariant	= 21 << 2
 	}
 }

--- a/glib/Value.cs
+++ b/glib/Value.cs
@@ -121,6 +121,11 @@ namespace GLib {
 			g_value_set_pointer (ref this, val); 
 		}
 
+		public Value (Variant variant) : this (GType.Variant)
+		{
+			g_value_set_variant (ref this, variant == null ? IntPtr.Zero : variant.Handle);
+		}
+
 		public Value (Opaque val, string type_name)
 		{
 			type = IntPtr.Zero;
@@ -173,7 +178,6 @@ namespace GLib {
 				GLib.Marshaller.Free (Marshal.ReadIntPtr (native_array, i * IntPtr.Size));
 			Marshal.FreeHGlobal (native_array);
 		}
-
 
 		public void Dispose () 
 		{
@@ -269,6 +273,11 @@ namespace GLib {
 		public static explicit operator GLib.Opaque (Value val)
 		{
 			return GLib.Opaque.GetOpaque (g_value_get_boxed (ref val), (Type) new GType (val.type), false);
+		}
+
+		public static explicit operator GLib.Variant (Value Val)
+		{
+			return new Variant (g_value_get_variant (ref Val));
 		}
 
 		public static explicit operator GLib.VariantType (Value val)
@@ -467,6 +476,8 @@ namespace GLib {
 					return (string) this;
 				else if (type == GType.Pointer.Val)
 					return (IntPtr) this;
+				else if (type == GType.Variant.Val)
+					return (GLib.Variant) this;
 				else if (type == GType.Param.Val)
 					return g_value_get_param (ref this);
 				else if (type == ValueArray.GType.Val)
@@ -511,6 +522,8 @@ namespace GLib {
 					g_value_set_float (ref this, (float) value);
 				else if (type == GType.Double.Val)
 					g_value_set_double (ref this, (double) value);
+				else if (type == GType.Variant.Val)
+					g_value_set_variant (ref this, ((GLib.Variant) value).Handle);
 				else if (type == GType.String.Val) {
 					IntPtr native = GLib.Marshaller.StringToPtrGStrdup ((string)value);
 					g_value_set_string (ref this, native);
@@ -657,8 +670,12 @@ namespace GLib {
 
 		[DllImport (Global.GObjectNativeDll, CallingConvention = CallingConvention.Cdecl)]
 		static extern void g_value_set_enum (ref Value val, int data);
+
 		[DllImport (Global.GObjectNativeDll, CallingConvention = CallingConvention.Cdecl)]
 		static extern void g_value_set_flags (ref Value val, uint data);
+
+		[DllImport (Global.GObjectNativeDll, CallingConvention = CallingConvention.Cdecl)]
+		static extern void g_value_set_variant (ref Value val, IntPtr data);
 		
 		[DllImport (Global.GObjectNativeDll, CallingConvention = CallingConvention.Cdecl)]
 		static extern bool g_value_get_boolean (ref Value val);
@@ -716,10 +733,14 @@ namespace GLib {
 
 		[DllImport (Global.GObjectNativeDll, CallingConvention = CallingConvention.Cdecl)]
 		static extern int g_value_get_enum (ref Value val);
+
 		[DllImport (Global.GObjectNativeDll, CallingConvention = CallingConvention.Cdecl)]
 		static extern uint g_value_get_flags (ref Value val);
 
 		[DllImport (Global.GObjectNativeDll, CallingConvention = CallingConvention.Cdecl)]
 		static extern IntPtr g_strv_get_type ();
+
+		[DllImport (Global.GObjectNativeDll, CallingConvention = CallingConvention.Cdecl)]
+		static extern IntPtr g_value_get_variant (ref Value val);
 	}
 }


### PR DESCRIPTION
GVariant is a fundamental type since 2.26, this commit adds it to the fundamental type list and adds operators to construct and convert from and to a GValue.

https://github.com/GNOME/glib/blob/master/gobject/gtype.h#L196
