### PR TITLE
configure: use canonical paths when comparing prefixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -300,9 +300,10 @@ echo "---"
 
 if test "x$has_mono" = "xtrue"; then
 	mono_prefix=`pkg-config --variable=prefix mono`
-	if test "x$mono_prefix" != "x$prefix"; then
-		AC_MSG_WARN(Prefix to use ($prefix) is not the same as Mono's ($mono_prefix).
-			Consider using ./configure --prefix=$mono_prefix
+	mono_prefix_canonical=`readlink -m $mono_prefix`
+	if test "x$mono_prefix_canonical" != "x$prefix"; then
+		AC_MSG_WARN(Prefix to use ($prefix) is not the same as Mono's ($mono_prefix_canonical).
+			Consider using ./configure --prefix=$mono_prefix_canonical
 			See the README for more information.
 		)
 	fi


### PR DESCRIPTION
A user reported in the mailing list [1] to be advised to use
`/usr/lib64/pkgconfig/../..` as a prefix. This path is too
convoluted, could give problems, and also shouldn't be the
one to be compared against the prefix flag used, so use
readlink -m to follow '..' subfolders to transform it, in
this example, to simply `/usr`

[1] http://lists.ximian.com/pipermail/gtk-sharp-list/2014-May/011436.html
