### PR TITLE
.gitignore: add autotools' `compile`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@
 aclocal.m4
 autom4te.cache
 audit/data
+compile
 config.*
 configure
 depcomp


### PR DESCRIPTION
autotools now[1] generate a symbolic link named `compile` (that
targets /usr/share/automake-1.14/compile) in the root of the
repository when running, so let's include it in .gitignore to
achieve a clean `git status` after compiling (or avoid breaking
the build via `git clean -fd`).

[1] This started happening to me since the usage of Ubuntu14.04
