### PR TITLE
Value: Make GetMethod more specific to avoid ambiguous matches

### DIFF
--- a/glib/Value.cs
+++ b/glib/Value.cs
@@ -424,7 +424,7 @@ namespace GLib {
 			else if (t.IsSubclassOf (typeof (GLib.Opaque)))
 				return (GLib.Opaque) this;
 
-			MethodInfo mi = t.GetMethod ("New", BindingFlags.Static | BindingFlags.Public | BindingFlags.FlattenHierarchy);
+			MethodInfo mi = t.GetMethod ("New", BindingFlags.Static | BindingFlags.Public | BindingFlags.FlattenHierarchy, null, new Type[] { typeof(IntPtr) }, null);
 			if (mi != null)
 				return mi.Invoke (null, new object[] {boxed_ptr});
 


### PR DESCRIPTION
This patch prevents GetMethod from throwing an AmbiguousMatchException because several constructors were found.
