### PR TITLE
Variant: Fix crash when casting a Variant to string

### DIFF
--- a/glib/Variant.cs
+++ b/glib/Variant.cs
@@ -283,12 +283,12 @@ namespace GLib {
 		}
 
 		[DllImport (Global.GLibNativeDll, CallingConvention = CallingConvention.Cdecl)]
-		static extern IntPtr g_variant_get_string (IntPtr handle);
+		static extern IntPtr g_variant_get_string (IntPtr handle, IntPtr length);
 
 		public static explicit operator string (Variant val)
 		{
-			IntPtr str = g_variant_get_string (val.Handle);
-			return str == IntPtr.Zero ? null : GLib.Marshaller.Utf8PtrToString (str);
+			IntPtr str = g_variant_get_string (val.Handle, IntPtr.Zero);
+			return GLib.Marshaller.Utf8PtrToString (str);
 		}
 
 		[DllImport (Global.GLibNativeDll, CallingConvention = CallingConvention.Cdecl)]

--- a/sample/VariantDemo.cs
+++ b/sample/VariantDemo.cs
@@ -27,6 +27,7 @@ namespace sample
 			var dict = new Dictionary<string, Variant> ();
 			dict.Add ("strv", new Variant (strv));
 			dict.Add ("unit", Variant.NewTuple (null));
+			dict.Add ("str", new Variant ("String 6"));
 			variant = new Variant (dict);
 			Console.WriteLine (variant.Print (true));
 
@@ -35,6 +36,11 @@ namespace sample
 			Console.WriteLine ("unit: " + asv["unit"].Print(true));
 
 			Console.WriteLine ("type: " + variant.Type.ToString ());
+
+			Variant tmp;
+			asv.TryGetValue ("str", out tmp);
+			var str = (string) tmp;
+			Console.WriteLine ("out str " + str);
 		}
 
 		public static void Main (string[] args)


### PR DESCRIPTION
If we don't pass NULL to the length argument it makes C
code write the length at random places in memory and bad
things happens.
