### PR TITLE
Value fixes

### DIFF
--- a/glib/Value.cs
+++ b/glib/Value.cs
@@ -576,6 +576,9 @@ namespace GLib {
 			if (GType.Is (type, GType.Boxed) && !(val is IWrapper)) {
 				MethodInfo mi = val.GetType ().GetMethod ("Update", BindingFlags.NonPublic | BindingFlags.Instance);
 				IntPtr boxed_ptr = g_value_get_boxed (ref this);
+
+				if (mi == null && !val.GetType().IsDefined (typeof(StructLayoutAttribute), false))
+					return;
 				if (mi == null)
 					Marshal.StructureToPtr (val, boxed_ptr, false);
 				else


### PR DESCRIPTION
This PR fixes some errors with Cairo types in signals because these are no value types and the default constructor does not take a ref.
