### PR TITLE
generator: Set Owned to false when ownership changes

### DIFF
--- a/generator/Parameter.cs
+++ b/generator/Parameter.cs
@@ -290,7 +290,8 @@ namespace GtkSharp.Generation {
 					return new string [] { gen.MarshalType + " native_" + CallName + ";" };
 				} else if (PassAs == "ref" && CSType != MarshalType) {
 					return new string [] { gen.MarshalType + " native_" + CallName + " = (" + gen.MarshalType + ") " + CallName + ";" };
-				}
+				} else if (gen is OpaqueGen && Owned)
+					return new String [] { CallName + ".Owned = false;" };
 
 				return new string [0];
 			}


### PR DESCRIPTION
This patch fixes an issue where unref would get called too often because the ownership has changed when passing an instance to the native side.
For example gst_element_post_message takes a message which is then owned by the native side after the call. So unref is eventually called at the native side. Without this patch the object would still be marked as owned on the managed side eventually leading to a call to Unref(). In this case the managed side must not call Unref() because it will be called on the native side eventually.
In g-i metadata these parameters are marked as transfer-ownership="full" which is then converted to the owned flag in gapi.
The problem is probably the same with GObjects, but GObjects have no public Owned flag, which could be modified.

``` XML
      <method name="PostMessage" cname="gst_element_post_message">
        <return-type type="gboolean"/>
        <parameters>
          <parameter name="message" type="GstMessage*" owned="true"/>
        </parameters>
      </method>
```

Now generates to:

``` C#
        public bool PostMessage(Gst.Message message) {
            bool raw_ret = gst_element_post_message(Handle, message == null ? IntPtr.Zero : message.Handle);
            bool ret = raw_ret;
            message.Owned = false;
            return ret;
        }
```
