### PR TITLE
Signal: Check if val is null before updating

### DIFF
--- a/glib/Value.cs
+++ b/glib/Value.cs
@@ -556,7 +556,7 @@ namespace GLib {
 
 		internal void Update (object val)
 		{
-			if (GType.Is (type, GType.Boxed) && !(val is IWrapper)) {
+			if (GType.Is (type, GType.Boxed) && !(val is IWrapper) && val != null) {
 				MethodInfo mi = val.GetType ().GetMethod ("Update", BindingFlags.NonPublic | BindingFlags.Instance);
 				IntPtr boxed_ptr = g_value_get_boxed (ref this);
 				if (mi == null)


### PR DESCRIPTION
When a Value is null then Update would fail with an NPE. So if val is null then we do not update the value at all.
