### PR TITLE
Msi improvements

### DIFF
--- a/msi/Makefile.am
+++ b/msi/Makefile.am
@@ -20,10 +20,6 @@ gtk-sharp-3.0.msi: gtk-sharp-3.0.wxs
 		cp $(top_builddir)/$$a/*.dll binaries/$$a; \
 		cp $(top_builddir)/$$a/*.pdb binaries/$$a; \
 	done
-	mv binaries/libatksharpglue-3.dll   binaries/atksharpglue-3.dll
-	mv binaries/libgiosharpglue-3.dll   binaries/giosharpglue-3.dll
-	mv binaries/libgtksharpglue-3.dll   binaries/gtksharpglue-3.dll
-	mv binaries/libpangosharpglue-3.dll binaries/pangosharpglue-3.dll
 
 	cp $(top_builddir)/sample/GtkDemo/GtkDemo.exe binaries
 	candle -ext WixUIExtension gtk-sharp-3.0.wxs

--- a/msi/gtk-sharp-3.0.wxs.in
+++ b/msi/gtk-sharp-3.0.wxs.in
@@ -90,13 +90,13 @@
               <Directory Id="gtksharp20" Name="gtk-sharp-3.0">
                 <!-- Installs GACd assemblies to an addressable location - see http://blogs.msdn.com/astebner/archive/2007/06/21/3450539.aspx -->
                 <Component Id="gtksharpinstassembly" Guid="BC078476-3336-4871-B9E1-3598BD724407">
-                  <RegistryKey Root='HKLM' Key='SOFTWARE\GtkSharp\Version'>
+                  <RegistryKey Root='HKLM' Key='SOFTWARE\GtkSharp\3\Version'>
                     <RegistryValue Type="string" Value="[ProductVersion]" />
                   </RegistryKey>
-                  <RegistryKey Root='HKLM' Key='SOFTWARE\Microsoft\.NetFramework\v4.0.30319\AssemblyFoldersEx\GtkSharp'>
+                  <RegistryKey Root='HKLM' Key='SOFTWARE\Microsoft\.NetFramework\v4.0.30319\AssemblyFoldersEx\GtkSharp3'>
                     <RegistryValue Type="string" Value="[INSTALLLOCATION]lib\gtk-sharp-3.0" />
                   </RegistryKey>
-                  <RegistryKey Root='HKLM' Key='SOFTWARE\GtkSharp\InstallFolder'>
+                  <RegistryKey Root='HKLM' Key='SOFTWARE\GtkSharp\3\InstallFolder'>
                     <RegistryValue Type="string" Value="[INSTALLLOCATION]" />
                   </RegistryKey>
                   <File Id="atksharpdll_inst" Source="binaries/atk/atk-sharp.dll" />


### PR DESCRIPTION
Changed the AssemblyFoldersEx reg key from "GtkSharp" to "GtkSharp3" to enable seamless side-by-side installation of Gtk# 2 and Gtk# 3. Also moved the "InstallFolder" and "Version" keys into "GtkSharp\3" so that future versions can be installed under the same reg key-prefix "GtkSharp".
