### PR TITLE
Fix Gtk.Builder ctor

### DIFF
--- a/gtk/Builder.cs
+++ b/gtk/Builder.cs
@@ -26,8 +26,10 @@
 namespace Gtk {
 
 	using System;
+	using System.IO;
 	using System.Reflection;
 	using System.Runtime.InteropServices;
+	using System.Text;
 
 	public partial class Builder {
 
@@ -159,13 +161,7 @@ namespace Gtk {
 			if (s == null)
 				throw new ArgumentNullException ("s");
 		
-			int size = (int) s.Length;
-			byte[] buffer = new byte[size];
-			s.Read (buffer, 0, size);
-			s.Close ();
-		
-			AddFromString(System.Text.Encoding.UTF8.GetString (buffer));
-		
+			AddFromStream (s);
 			TranslationDomain = translation_domain;
 		}
 		
@@ -191,13 +187,7 @@ namespace Gtk {
 				throw new ArgumentException ("Cannot get resource file '" + resource_name + "'",
 				                             "resource_name");
 		
-			int size = (int) s.Length;
-			byte[] buffer = new byte[size];
-			s.Read (buffer, 0, size);
-			s.Close ();
-		
-			AddFromString(System.Text.Encoding.UTF8.GetString (buffer));
-		
+			AddFromStream (s);
 			TranslationDomain = translation_domain;
 		}
 		
@@ -368,6 +358,22 @@ namespace Gtk {
 		
 		}
 		
+		void AddFromStream (Stream stream)
+		{
+			var size = (int)stream.Length;
+			var buffer = new byte[size];
+			stream.Read (buffer, 0, size);
+			stream.Close ();
+
+			// If buffer contains a BOM, omit it while reading; otherwise method AddFromString crashes
+			var offset = 0;
+			if (size >= 3 && buffer [0] == 239 && buffer [1] == 187 && buffer [2] == 191) {
+				offset = 3;
+			}
+
+			var text = Encoding.UTF8.GetString (buffer, offset, size - offset);
+			AddFromString (text);
+		}
 		
 		void BindFields (object target)
 		{


### PR DESCRIPTION
This PR fixes
- the behaviour of 2 ctors in Gtk.Builder and
- a crash, when creating a Gtk.Builder object from a stream or resource file, where the stream contains a BOM.
