### PR TITLE
Don't try to include "makefile.win32" in EXTRA_DIST

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3,7 +3,6 @@ SUBDIRS = sources generator parser glib cairo pango atk gdk gtk glade gtkdotnet 
 EXTRA_DIST = 			\
 	mono.snk		\
 	gtk-sharp.snk		\
-	makefile.win32		\
 	policy.config.in	\
 	AssemblyInfo.cs.in	\
 	ChangeLog		\


### PR DESCRIPTION
As per the former contents of that file, makefile.win32 is dead.
Having it in EXTRA_DIST when it no longer exists prevents "make
dist" from running.