### PR TITLE
Opaque: Check for self-assignment of Raw pointer

### DIFF
--- a/glib/Opaque.cs
+++ b/glib/Opaque.cs
@@ -67,6 +67,9 @@ namespace GLib {
 				return _obj;
 			}
 			set {
+				if (_obj == value)
+					return;
+
 				if (_obj != IntPtr.Zero) {
 					Unref (_obj);
 					if (owned)


### PR DESCRIPTION
otherwise the Opaque could be free-ed
