### PR TITLE
Take the burden from the developer to have to call Dispose() manually.

### DIFF
--- a/cairo/Pattern.cs
+++ b/cairo/Pattern.cs
@@ -76,6 +76,7 @@ namespace Cairo {
 
 		~Pattern ()
 		{
+			Dispose (false);
 		}
 		
                 [Obsolete ("Use the SurfacePattern constructor")]


### PR DESCRIPTION
Without this, a programmer has to ADDITIONALLY call Dispose() manually everywhere.
In case he doesn't, at application shutdown time Gtk will complain about all the missing Dispose() calls.
But that's something the destructor needs to do on its own.
