### PR TITLE
cure warning CS0253: Possible unintended reference comparison; to get a ...

### DIFF
--- a/glib/Idle.cs
+++ b/glib/Idle.cs
@@ -110,7 +110,7 @@ namespace GLib {
 				foreach (uint code in Source.source_handlers.Keys) {
 					IdleProxy p = Source.source_handlers [code] as IdleProxy;
 				
-					if (p != null && p.real_handler == hndlr) {
+					if (p != null && p.real_handler == (System.Delegate) hndlr) {
 						keys.Add (code);
 						result = g_source_remove (code);
 					}


### PR DESCRIPTION
...value comparison, cast the right hand side to type 'System.Delegate'

A value comparison is what we want here. The C# equality operator will exactly do what is wanted here:
check if a function is already in the list and, if yes, remove it.

cf http://msdn.microsoft.com/en-us/library/system.delegate.op_equality(v=vs.100).aspx

Change-Id: I64e85006140fca3d81e733f13d7e8cf17bfaa336