### PR TITLE
Val/Opaquetest: Fix compilation on osx

### DIFF
--- a/sample/opaquetest/Makefile.am
+++ b/sample/opaquetest/Makefile.am
@@ -4,7 +4,7 @@ lib_LTLIBRARIES = libopaque.la
 assemblies=../../glib/glib-sharp.dll ../../gio/gio-sharp.dll ../../pango/pango-sharp.dll ../../atk/atk-sharp.dll ../../gdk/gdk-sharp.dll ../../gtk/gtk-sharp.dll
 references=$(addprefix -r:, $(assemblies))
 
-opaquetest.exe: OpaqueTest.cs $(GENERATED_SOURCES_FILES) $(assemblies)
+opaquetest.exe: generated-stamp OpaqueTest.cs $(assemblies)
 	$(CSC) $(CSFLAGS) -out:opaquetest.exe $(references) $(srcdir)/OpaqueTest.cs $(GENERATED_SOURCES_OPTION)
 
 libopaque_la_SOURCES =	\
@@ -17,11 +17,13 @@ libopaque_la_LIBADD = $(GTK_LIBS)
 
 AM_CPPFLAGS = $(GTK_CFLAGS)
 
-$(GENERATED_SOURCES_FILES): opaque-api.xml
-	$(RUNTIME) ../../generator/gapi_codegen.exe --generate $(srcdir)/opaque-api.xml	\
-	--include=../../gtk/gtk-api.xml --include=../../gdk/gdk-api.xml 				\
-	--outdir=generated --assembly-name=opaque-sharp									\
-	--schema=$(top_srcdir)/gapi.xsd
+generated-stamp: opaque-api.xml
+	rm -rf generated/* &&	\
+	$(RUNTIME) ../../generator/gapi_codegen.exe --generate $(srcdir)/opaque-api.xml \
+	--include=../../gtk/gtk-api.xml --include=../../gdk/gdk-api.xml \
+	--outdir=generated --assembly-name=opaque-sharp	\
+	--schema=$(top_srcdir)/gapi.xsd							\
+	&& touch generated-stamp
 
 api:
 	PATH=../../parser:$(PATH) $(RUNTIME) ../../parser/gapi-parser.exe opaque-sources.xml
@@ -32,6 +34,7 @@ install:
 CLEANFILES =			\
 	opaquetest.exe		\
 	opaquetest.exe.mdb	\
+	generated-stamp		\
 	$(GENERATED_SOURCES_FILES)
 
 EXTRA_DIST =		\

--- a/sample/valtest/Makefile.am
+++ b/sample/valtest/Makefile.am
@@ -4,7 +4,7 @@ lib_LTLIBRARIES = libvalobj.la
 assemblies=../../glib/glib-sharp.dll ../../gio/gio-sharp.dll ../../cairo/cairo-sharp.dll ../../pango/pango-sharp.dll ../../atk/atk-sharp.dll ../../gdk/gdk-sharp.dll ../../gtk/gtk-sharp.dll
 references=$(addprefix -r:, $(assemblies))
 
-valtest.exe: Valtest.cs $(GENERATED_SOURCES_FILES) $(assemblies)
+valtest.exe: generated-stamp Valtest.cs $(assemblies)
 	$(CSC) $(CSFLAGS) -out:valtest.exe $(references) $(srcdir)/Valtest.cs $(GENERATED_SOURCES_OPTION)
 
 libvalobj_la_SOURCES =	\
@@ -17,11 +17,13 @@ libvalobj_la_LIBADD = $(GTK_LIBS)
 
 AM_CPPFLAGS = $(GTK_CFLAGS)
 
-$(GENERATED_SOURCES_FILES): valobj-api.xml
+generated-stamp: valobj-api.xml
+	rm -rf generated/* && \
 	$(RUNTIME) ../../generator/gapi_codegen.exe --generate $(srcdir)/valobj-api.xml	\
 	--include=../../gtk/gtk-api.xml --include=../../gdk/gdk-api.xml					\
 	--outdir=generated --assembly-name=valobj-sharp											\
-	--schema=$(top_srcdir)/gapi.xsd
+	--schema=$(top_srcdir)/gapi.xsd && \
+	touch generated-stamp
 
 api:
 	PATH=../../parser:$(PATH) $(RUNTIME) ../../parser/gapi-parser.exe valobj-sources.xml
@@ -31,6 +33,7 @@ install:
 CLEANFILES =		\
 	valtest.exe	\
 	valtest.exe.mdb	\
+	generated-stamp \
 	$(GENERATED_SOURCES_FILES)
 
 EXTRA_DIST =		\


### PR DESCRIPTION
Using regular expressions for targets is not supported, that's why now a generated-stamp is used to determine whether the files have been generated.
This bug might not be related to osx but newer automake versions at least >= 1.14.1

Also thanks to @davidnielsen for testing the patch and extending it to valtest.