### PR TITLE
Add generation of abstract GInterface base class

### DIFF
--- a/generator/GObjectVM.cs
+++ b/generator/GObjectVM.cs
@@ -187,9 +187,26 @@ namespace GtkSharp.Generation {
 			sw.Write ("\t\t{0} ", this.Protection);
 			if (this.modifiers != "")
 				sw.Write ("{0} ", this.modifiers);
-			sw.WriteLine ("virtual {0} On{1} ({2})", retval.CSType, this.Name, Signature.ToString ());
+			string ret, signature;
+			if (IsAccessor) {
+				ret = Signature.AccessorType;
+				signature = Signature.AsAccessor;
+			} else {
+				ret = retval.CSType;
+				signature = Signature.ToString ();
+			}
+
+			sw.WriteLine ("virtual {0} On{1} ({2})", ret, this.Name, signature);
 			sw.WriteLine ("\t\t{");
+			var accessorParamName = Signature.AccessorName;
+			if (IsAccessor) {
+				sw.WriteLine ("\t\t\t{0} {1};", ret, accessorParamName);
+			}
+
 			sw.WriteLine ("\t\t\t{0}Internal{1} ({2});", retval.IsVoid ? "" : "return ", this.Name, Signature.GetCallString (false));
+			if (IsAccessor) {
+				sw.WriteLine ("\t\t\treturn {0};", accessorParamName);
+			}
 			sw.WriteLine ("\t\t}");
 			sw.WriteLine ();
 			// This method is to be invoked from existing VM implementations in the custom code

--- a/generator/InterfaceVM.cs
+++ b/generator/InterfaceVM.cs
@@ -81,7 +81,9 @@ namespace GtkSharp.Generation {
 				}
 			} else if (IsSetter) 
 				sw.WriteLine ("\t\t" + parms[0].CSType + " " + Name.Substring (3) + " { set; }");
-			else
+			else if (IsAccessor) {
+				sw.WriteLine ("\t\t" + Signature.AccessorType + " " + Name + " (" + Signature.AsAccessor + ");");
+			} else
 				sw.WriteLine ("\t\t" + retval.CSType + " " + Name + " (" + Signature + ");");
 		}
 

--- a/generator/VMSignature.cs
+++ b/generator/VMSignature.cs
@@ -55,6 +55,57 @@ namespace GtkSharp.Generation {
 			}
 		}
 
+		public bool IsAccessor {
+			get {
+				int count = 0;
+				foreach (Parameter p in parms) {
+					if (p.PassAs == "out")
+						count++;
+
+					if (count > 1)
+						return false;
+				}
+				return count == 1;
+			}
+		}
+
+		public string AccessorType {
+			get {
+				foreach (Parameter p in parms)
+					if (p.PassAs == "out")
+						return p.CSType;
+
+				return null;
+			}
+		}
+
+		public string AccessorName {
+			get {
+				foreach (Parameter p in parms)
+					if (p.PassAs == "out")
+						return p.Name;
+
+				return null;
+			}
+		}
+
+		public string AsAccessor {
+			get {
+				string[] result = new string [parms.Count - 1];
+				int i = 0;
+
+				foreach (Parameter p in parms) {
+					if (p.PassAs == "out")
+						continue;
+
+					result [i] = p.PassAs != "" ? p.PassAs + " " : "";
+					result [i++] += p.CSType + " " + p.Name;
+				}
+
+				return String.Join (", ", result);
+			}
+		}
+
 		public string GetCallString (bool use_place_holders)
 		{
 			if (parms.Count == 0)


### PR DESCRIPTION
UPDATE: This PR depends on PR #133. The first two commits (20450a8 and 414e7b1) belong to PR #133 and should be discussed and eventually merged there.

This PR aims to solve the issue that GInterface usage in gtk-sharp is cumbersome. This issue has been discussed thoroughly in PR #113. The solution presented in this PR is in accordance with comment https://github.com/mono/gtk-sharp/pull/113#issuecomment-108797624 in PR #113.
In this PR a new additional class is generated for each GInterface. Up until now there were the 3 types `IFoo`, `FooAdapter` and `IFooImplementor`. In addition an abstract class `Foo` is generated that subclasses `GLib.Object` and implements `IFoo` and `IFooImplementor`. Thus, it is now possible to simply create a custom implementation of `IFoo` by writing

```
public class MyFoo : Foo
{
}
```

To accomplish this, several other changes were necessary (or convenient):
- ~~The ToolsVersion in csproj files was updated from 3.5 to 4.0.~~
- In some places there were custom additions to GInterface interfaces. This made it necessary to extend the new abstract (partial) base classes to account for those custom interface members. (0818e95)
- ~~To facilitate a consistent interface of `IFoo` and `FooAdapter` on one side and `IFooImplementor` (and subsequentially) `Foo` on the other side, accessor methods are now handled differently. For details see the commit message of b9f1d58. This change also affected the overrides implementation in GObjectVM (a808599).~~

All changes in the generated code can be viewed here: ~~https://github.com/antoniusriha/gtk-generated-files-compare/commit/b591d47e88b1286913b9d8b61295aad946ae9812~~ https://github.com/antoniusriha/gtk-generated-files-compare/commit/4d215f947b21bd3181e35e467d1d0f833e2f963a.

All changes to the API can be viewed here: https://gist.github.com/antoniusriha/532dda0ca6fa9bb1332d. This information has been generated using the tools `mono-api-info.exe` and `mono-api-html.exe` from the mono repository. (I've noticed that the member description is not always correct: `abstract` members are displayed as `virtual`.)
