### PR TITLE
Change accessor API to output accessor parameter as return value instead of out parameter

### DIFF
--- a/generator/GObjectVM.cs
+++ b/generator/GObjectVM.cs
@@ -187,9 +187,26 @@ namespace GtkSharp.Generation {
 			sw.Write ("\t\t{0} ", this.Protection);
 			if (this.modifiers != "")
 				sw.Write ("{0} ", this.modifiers);
-			sw.WriteLine ("virtual {0} On{1} ({2})", retval.CSType, this.Name, Signature.ToString ());
+			string ret, signature;
+			if (IsAccessor) {
+				ret = Signature.AccessorType;
+				signature = Signature.AsAccessor;
+			} else {
+				ret = retval.CSType;
+				signature = Signature.ToString ();
+			}
+
+			sw.WriteLine ("virtual {0} On{1} ({2})", ret, this.Name, signature);
 			sw.WriteLine ("\t\t{");
+			var accessorParamName = Signature.AccessorName;
+			if (IsAccessor) {
+				sw.WriteLine ("\t\t\t{0} {1};", ret, accessorParamName);
+			}
+
 			sw.WriteLine ("\t\t\t{0}Internal{1} ({2});", retval.IsVoid ? "" : "return ", this.Name, Signature.GetCallString (false));
+			if (IsAccessor) {
+				sw.WriteLine ("\t\t\treturn {0};", accessorParamName);
+			}
 			sw.WriteLine ("\t\t}");
 			sw.WriteLine ();
 			// This method is to be invoked from existing VM implementations in the custom code

--- a/generator/InterfaceVM.cs
+++ b/generator/InterfaceVM.cs
@@ -81,7 +81,9 @@ namespace GtkSharp.Generation {
 				}
 			} else if (IsSetter) 
 				sw.WriteLine ("\t\t" + parms[0].CSType + " " + Name.Substring (3) + " { set; }");
-			else
+			else if (IsAccessor) {
+				sw.WriteLine ("\t\t" + Signature.AccessorType + " " + Name + " (" + Signature.AsAccessor + ");");
+			} else
 				sw.WriteLine ("\t\t" + retval.CSType + " " + Name + " (" + Signature + ");");
 		}
 

--- a/generator/VMSignature.cs
+++ b/generator/VMSignature.cs
@@ -55,6 +55,57 @@ namespace GtkSharp.Generation {
 			}
 		}
 
+		public bool IsAccessor {
+			get {
+				int count = 0;
+				foreach (Parameter p in parms) {
+					if (p.PassAs == "out")
+						count++;
+
+					if (count > 1)
+						return false;
+				}
+				return count == 1;
+			}
+		}
+
+		public string AccessorType {
+			get {
+				foreach (Parameter p in parms)
+					if (p.PassAs == "out")
+						return p.CSType;
+
+				return null;
+			}
+		}
+
+		public string AccessorName {
+			get {
+				foreach (Parameter p in parms)
+					if (p.PassAs == "out")
+						return p.Name;
+
+				return null;
+			}
+		}
+
+		public string AsAccessor {
+			get {
+				string[] result = new string [parms.Count - 1];
+				int i = 0;
+
+				foreach (Parameter p in parms) {
+					if (p.PassAs == "out")
+						continue;
+
+					result [i] = p.PassAs != "" ? p.PassAs + " " : "";
+					result [i++] += p.CSType + " " + p.Name;
+				}
+
+				return String.Join (", ", result);
+			}
+		}
+
 		public string GetCallString (bool use_place_holders)
 		{
 			if (parms.Count == 0)


### PR DESCRIPTION
This PR changes the API of interface methods and GObject virtual method overrides to return the accessor parameter as return value instead of an out parameter. This also makes the API of GInterface interfaces and adapters on one side and implementor interfaces on the other side more consistent (because accessor methods now have matching signatures).

All API changes can be viewed here: https://gist.github.com/antoniusriha/04a8e3f7e87c9a4714b2

All changes in the generated code files can be viewed here: https://github.com/antoniusriha/gtk-generated-files-compare/commit/875f8a49bb86169bc27829829d58ffc27e160c86
