### PR TITLE
Making custom widgets work in Gtk.Builder

### DIFF
--- a/glib/Makefile.am
+++ b/glib/Makefile.am
@@ -90,6 +90,7 @@ sources =		 			\
 	ToggleRef.cs				\
 	TypeFundamentals.cs			\
 	TypeInitializerAttribute.cs		\
+	TypeNameAttribute.cs		\
 	ValueArray.cs				\
 	Value.cs				\
 	Variant.cs				\

--- a/glib/Object.cs
+++ b/glib/Object.cs
@@ -619,7 +619,7 @@ namespace GLib {
 		protected virtual void CreateNativeObject (string[] names, GLib.Value[] vals)
 		{
 			GType gtype = LookupGType ();
-			bool is_managed_subclass = gtype.ToString ().StartsWith ("__gtksharp");
+			bool is_managed_subclass = GType.IsManaged (gtype);
 			GParameter[] parms = new GParameter [is_managed_subclass ? names.Length + 1 : names.Length];
 			for (int i = 0; i < names.Length; i++) {
 				parms [i].name = GLib.Marshaller.StringToPtrGStrdup (names [i]);

--- a/glib/SignalClosure.cs
+++ b/glib/SignalClosure.cs
@@ -56,6 +56,9 @@ namespace GLib {
 		public IntPtr notifiers;
 	}
 
+	[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+	public delegate void ClosureMarshal (IntPtr closure, IntPtr return_val, uint n_param_vals, IntPtr param_values, IntPtr invocation_hint, IntPtr marshal_data);
+
 	internal delegate void ClosureInvokedHandler (object o, ClosureInvokedArgs args);
 
 	internal class SignalClosure : IDisposable {
@@ -89,6 +92,12 @@ namespace GLib {
 			handle = obj;
 			name = signal_name;
 			this.custom_marshaler = custom_marshaler;
+		}
+
+		public static IntPtr CreateClosure (ClosureMarshal marshaler) {
+			IntPtr raw_closure = g_closure_new_simple (Marshal.SizeOf (typeof (GClosure)), IntPtr.Zero);
+			g_closure_set_marshal (raw_closure, marshaler);
+			return raw_closure;
 		}
 
 		public event EventHandler Disposed;
@@ -134,9 +143,6 @@ namespace GLib {
 				return marshaler;
 			}
 		}
-
-		[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
-		delegate void ClosureMarshal (IntPtr closure, IntPtr return_val, uint n_param_vals, IntPtr param_values, IntPtr invocation_hint, IntPtr marshal_data);
 
 		static void MarshalCallback (IntPtr raw_closure, IntPtr return_val, uint n_param_vals, IntPtr param_values, IntPtr invocation_hint, IntPtr marshal_data)
 		{

--- a/glib/TypeNameAttribute.cs
+++ b/glib/TypeNameAttribute.cs
@@ -1,0 +1,41 @@
+// TypeNameAttribute.cs
+//
+// Copyright (c) 2015 Martin Kupec
+// Copyright (c) 2015 Ales Kurecka
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of version 2 of the Lesser GNU General
+// Public License as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this program; if not, write to the
+// Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+// Boston, MA 02111-1307, USA.
+
+
+namespace GLib {
+
+	using System;
+
+	[AttributeUsage (AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+	public sealed class TypeNameAttribute : Attribute {
+		private readonly string name;
+
+		public TypeNameAttribute (string name)
+		{
+			this.name = name;
+		}
+
+		public string Name
+		{
+			get {
+				return name;
+			}
+		}
+	}
+}

--- a/glib/glib.csproj
+++ b/glib/glib.csproj
@@ -102,6 +102,7 @@
     <Compile Include="SourceFuncs.cs" />
     <Compile Include="GLibSharp.SourceDummyMarshalNative.cs" />
     <Compile Include="GLibSharp.SourceFuncNative.cs" />
+    <Compile Include="TypeNameAttribute.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Core" />

--- a/sample/CustomWidgetBuilder.cs
+++ b/sample/CustomWidgetBuilder.cs
@@ -27,7 +27,17 @@ namespace CustomWidgetBuilder
 
 		private void Init()
 		{
+			this.Changed += (sender, e) => {
+				if (this.MySignal != null)
+					this.MySignal(sender, e);
+
+				GLib.Signal.Emit(this, "my-signal");
+			};
 		}
+
+
+		[GLib.Signal("my-signal")]
+		public event EventHandler MySignal = null;
 
 
 		[GLib.Property("my-text")]
@@ -64,6 +74,12 @@ namespace CustomWidgetBuilder
 				Gtk.Application.Quit();
 				args.RetVal = true;
 			};
+		}
+
+
+		private void MySignalHandler(object sender, EventArgs e)
+		{
+			this.m_mywidget.MyText = this.m_mywidget.MyText.ToUpper();
 		}
 	}
 }

--- a/sample/CustomWidgetBuilder.cs
+++ b/sample/CustomWidgetBuilder.cs
@@ -1,0 +1,69 @@
+﻿using Gtk;
+using System;
+using UI = Gtk.Builder.ObjectAttribute;
+
+namespace CustomWidgetBuilder
+{
+	[GLib.TypeName("MyWidget")]
+	public class MyWidget : Entry
+	{
+		public MyWidget()
+		{
+			this.Init();
+		}
+
+
+		public MyWidget(IntPtr ptr) : base(ptr)
+		{
+			this.Init();
+		}
+
+
+		static public void Register()
+		{
+			GLib.Object.RegisterGType(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+		}
+
+
+		private void Init()
+		{
+		}
+
+
+		[GLib.Property("my-text")]
+		public string MyText
+		{
+			get { return base.Text; }
+			set { base.Text = value; }
+		}
+	}
+
+
+	public class MainWindow : Window
+	{
+		#pragma warning disable 169
+		[UI] MyWidget m_mywidget;
+		#pragma warning restore 169
+
+
+		static void Main(string[] args)
+		{
+			Application.Init();
+			MyWidget.Register();
+			Builder builder = new Builder(new System.IO.FileStream("CustomWidgetBuilder.ui", System.IO.FileMode.Open));
+			MainWindow wnd = new MainWindow(builder, builder.GetObject("m_window").Handle);
+			wnd.Show();
+			Application.Run();
+		}
+
+
+		public MainWindow(Builder builder, IntPtr handle) : base(handle)
+		{
+			builder.Autoconnect(this);
+			this.DeleteEvent +=  (o, args) => {
+				Gtk.Application.Quit();
+				args.RetVal = true;
+			};
+		}
+	}
+}

--- a/sample/CustomWidgetBuilder.ui
+++ b/sample/CustomWidgetBuilder.ui
@@ -5,6 +5,7 @@
 			<object class="MyWidget" id="m_mywidget">
 				<property name="visible">True</property>
 				<property name="my-text">Hello world!</property>
+				<signal name="my-signal" handler="MySignalHandler"/>
 			</object>
 		</child>
 	</object>

--- a/sample/CustomWidgetBuilder.ui
+++ b/sample/CustomWidgetBuilder.ui
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+	<object class="GtkWindow" id="m_window">
+		<child>
+			<object class="MyWidget" id="m_mywidget">
+				<property name="visible">True</property>
+				<property name="my-text">Hello world!</property>
+			</object>
+		</child>
+	</object>
+</interface>

--- a/sample/Makefile.am
+++ b/sample/Makefile.am
@@ -8,7 +8,7 @@ DOTNET_TARGETS=
 DOTNET_ASSEMBLY=
 endif
 
-TARGETS = gtk-hello-world.exe async-sample.exe button.exe calendar.exe subclass.exe menu.exe treeviewdemo.exe managedtreeviewdemo.exe nodeviewdemo.exe treemodeldemo.exe actions.exe spawn.exe assistant.exe registerprop.exe gexceptiontest.exe native-instantiation.exe polarfixed.exe cairo-sample.exe scribble.exe testdnd.exe custom-cellrenderer.exe custom-widget.exe custom-scrollable.exe cairo-png.exe variantdemo.exe #scribble-xinput.exe $(DOTNET_TARGETS)
+TARGETS = gtk-hello-world.exe async-sample.exe button.exe calendar.exe subclass.exe menu.exe treeviewdemo.exe managedtreeviewdemo.exe nodeviewdemo.exe treemodeldemo.exe actions.exe spawn.exe assistant.exe registerprop.exe gexceptiontest.exe native-instantiation.exe polarfixed.exe cairo-sample.exe scribble.exe testdnd.exe custom-cellrenderer.exe custom-widget.exe custom-widget-builder.exe custom-scrollable.exe cairo-png.exe variantdemo.exe #scribble-xinput.exe $(DOTNET_TARGETS)
 
 DEBUGS = $(addsuffix .mdb, $(TARGETS))
 
@@ -81,6 +81,9 @@ drawing-sample.exe: $(srcdir)/DrawingSample.cs $(assemblies) $(DOTNET_ASSEMBLIES
 
 custom-widget.exe: $(srcdir)/CustomWidget.cs $(assemblies)
 	$(CSC) $(CSFLAGS) -out:custom-widget.exe $(references) $(srcdir)/CustomWidget.cs
+
+custom-widget-builder.exe: $(srcdir)/CustomWidgetBuilder.cs $(assemblies)
+	$(CSC) $(CSFLAGS) -out:custom-widget-builder.exe $(references) $(srcdir)/CustomWidgetBuilder.cs
 
 custom-scrollable.exe: $(srcdir)/CustomScrollableWidget.cs $(assemblies)
 	$(CSC) $(CSFLAGS) -out:custom-scrollable.exe $(references) $(srcdir)/CustomScrollableWidget.cs


### PR DESCRIPTION
This series of commits is supposed to fix and enchant the use of Gtk.Builder with custom widgets.

It enables to pick GLib type name of custom class.
It also fixes old problem with pairing native and managed objects during class creation.

There is problem with Gtk.Builder with gtk+ > 3.12 as it newly check for existence of signals during parsing phase. This is fixed by properly creating native signals for custom widgets.
