### PR TITLE
Fixed memory leaks caused by sinking everything

### DIFF
--- a/glib/Object.cs
+++ b/glib/Object.cs
@@ -92,6 +92,7 @@ namespace GLib {
 				Console.WriteLine ("Exception while disposing a " + this + " in Gtk#");
 				throw e;
 			}
+			g_object_unref (handle);
 			handle = IntPtr.Zero;
 			GC.SuppressFinalize (this);
 		}

--- a/glib/Object.cs
+++ b/glib/Object.cs
@@ -134,9 +134,6 @@ namespace GLib {
 					return obj;
 				}
 
-				if (!owned_ref)
-					g_object_ref (o);
-
 				obj = GLib.ObjectManager.CreateObject(o);
 			}
 			if (obj == null) {

--- a/glib/Object.cs
+++ b/glib/Object.cs
@@ -34,6 +34,7 @@ namespace GLib {
 		IntPtr handle;
 		ToggleRef tref;
 		bool disposed = false;
+		bool owned = true;
 		Hashtable data;
 		static Hashtable Objects = new Hashtable();
 		static ArrayList PendingDestroys = new ArrayList ();
@@ -92,7 +93,8 @@ namespace GLib {
 				Console.WriteLine ("Exception while disposing a " + this + " in Gtk#");
 				throw e;
 			}
-			g_object_unref (handle);
+			if (owned)
+				g_object_unref (handle);
 			handle = IntPtr.Zero;
 			GC.SuppressFinalize (this);
 		}
@@ -142,6 +144,7 @@ namespace GLib {
 				return null;
 			}
 
+			obj.owned = owned_ref;
 			return obj;
 		}
 

--- a/glib/ToggleRef.cs
+++ b/glib/ToggleRef.cs
@@ -39,7 +39,6 @@ namespace GLib {
 			gch = GCHandle.Alloc (this);
 			reference = target;
 			g_object_add_toggle_ref (target.Handle, ToggleNotifyCallback, (IntPtr) gch);
-			g_object_unref (target.Handle);
 		}
 
 		public bool IsAlive {

--- a/gtk/Object.custom
+++ b/gtk/Object.custom
@@ -124,6 +124,8 @@
 		{
 			if (Handle == IntPtr.Zero)
 				return;
+			if (IsFloating)//We have to check or we will increment ref_count
+				IsFloating = false;
 			gtk_object_destroy (Handle);
 			InternalDestroyed -= NativeDestroyHandler;
 		}

--- a/gtk/Object.custom
+++ b/gtk/Object.custom
@@ -105,16 +105,11 @@
 			base.Dispose ();
 		}
 
-		[DllImport("libgobject-2.0-0.dll", CallingConvention=CallingConvention.Cdecl)]
-		private static extern void g_object_ref_sink (IntPtr raw);
-
 		protected override IntPtr Raw {
 			get {
 				return base.Raw;
 			}
 			set {
-				if (value != IntPtr.Zero)
-					g_object_ref_sink (value);
 				base.Raw = value;
 				if (value != IntPtr.Zero)
 					InternalDestroyed += NativeDestroyHandler;

--- a/gtk/Object.custom
+++ b/gtk/Object.custom
@@ -99,10 +99,11 @@
 
 		public override void Dispose ()
 		{
-			if (Handle == IntPtr.Zero)
-				return;
-			InternalDestroyed -= NativeDestroyHandler;
-			base.Dispose ();
+			// Don't call base.Dispose because it's calling g_object_unref
+			// which is done by gtk_object_destroy for Gtk.Object
+
+			//Should line below be uncommented?(but it breaks backward compatiblity)
+			//throw new InvalidOperationException("Calling Dispose is invalid for Gtk objects. Call Destroy().");
 		}
 
 		protected override IntPtr Raw {


### PR DESCRIPTION
Sinking is done when object is attached to parent... Sinking everything
when Raw is set results into incrementing ref count for no reason, hence
memory leak...
g_object_ref and g_object_unref is just so random code that is not even
worth explaining why it's deleted