### PR TITLE
Optimize ListStore.AppendValues

### DIFF
--- a/gtk/ListStore.custom
+++ b/gtk/ListStore.custom
@@ -105,22 +105,18 @@
 		{
 			Gtk.TreeIter iter = Append();
 
-			int col = 0;
-			foreach (object value in values) {
-				if (value != null) {
-					GLib.Value val = new GLib.Value (value);
-					SetValue (iter, col, val);
-					val.Dispose ();
-				}
-				col++;
-			}
+			SetValues (iter, values);
 
 			return iter;
 		}
 
 		public Gtk.TreeIter AppendValues (params object[] values)
 		{
-			return AppendValues ((Array) values);
+			Gtk.TreeIter iter = Append();
+
+			SetValues (iter, values);
+
+			return iter;
 		}
 
 		[DllImport("libgtk-win32-2.0-0.dll", CallingConvention=CallingConvention.Cdecl)]


### PR DESCRIPTION
This patch introduces changes to `Gtk.ListStore.AppendValues` so it reduces the number of calls to value setting.

Particularly, this was 3 times as slower on inserting values than `InsertWithValues` in a ListStore with 860 rows and 9 columns.

Given the documentation at [0], it seems that the latter would trigger `row_changed` and `rows_reordered` many more times than intended, at least once for each column on each row. With this patch, it would be triggered just once for each row.

[0] - https://developer.gnome.org/gtk3/stable/GtkListStore.html#gtk-list-store-insert-with-values