### PR TITLE
Fix ambiguous references

### DIFF
--- a/sample/gtk-gio/MountOperation.cs
+++ b/sample/gtk-gio/MountOperation.cs
@@ -46,14 +46,14 @@ public class TestMount
 		Window w = new Window ("test");
 		operation = new Gtk.MountOperation (w);
 		Button b = new Button ("Mount");
-		b.Clicked += new EventHandler (HandleButtonClicked);
+		b.Clicked += new System.EventHandler (HandleButtonClicked);
 		b.Show ();
 		w.Add (b);
 		w.Show ();
 		Gtk.Application.Run ();
 	}
 
-	static void HandleButtonClicked (object sender, EventArgs args)
+	static void HandleButtonClicked (object sender, System.EventArgs args)
 	{
 		System.Console.WriteLine ("clicked");
 		file.MountEnclosingVolume (0, operation, null, new GLib.AsyncReadyCallback (HandleMountFinished));


### PR DESCRIPTION
Using `mono 4.4.0.40`:

```
`MountOperation.cs(56,50): error CS0104: `EventArgs' is an ambiguous reference between`System.EventArgs' and `GLib.EventArgs'
```