### PR TITLE
Update GTK+ to version 3.14.15

### DIFF
--- a/gdk/gdk-api.raw
+++ b/gdk/gdk-api.raw
@@ -28,6 +28,9 @@
       <member cname="GDK_CROSSING_GTK_GRAB" name="GtkGrab" />
       <member cname="GDK_CROSSING_GTK_UNGRAB" name="GtkUngrab" />
       <member cname="GDK_CROSSING_STATE_CHANGED" name="StateChanged" />
+      <member cname="GDK_CROSSING_TOUCH_BEGIN" name="TouchBegin" />
+      <member cname="GDK_CROSSING_TOUCH_END" name="TouchEnd" />
+      <member cname="GDK_CROSSING_DEVICE_SWITCH" name="DeviceSwitch" />
     </enum>
     <enum name="CursorType" cname="GdkCursorType" gtype="gdk_cursor_type_get_type" type="enum">
       <member cname="GDK_X_CURSOR" name="XCursor" />
@@ -132,6 +135,7 @@
       <member cname="GDK_DRAG_PROTO_WIN32_DROPFILES" name="Win32Dropfiles" />
       <member cname="GDK_DRAG_PROTO_OLE2" name="Ole2" />
       <member cname="GDK_DRAG_PROTO_LOCAL" name="Local" />
+      <member cname="GDK_DRAG_PROTO_WAYLAND" name="Wayland" />
     </enum>
     <enum name="EventMask" cname="GdkEventMask" gtype="gdk_event_mask_get_type" type="flags">
       <member cname="GDK_EXPOSURE_MASK" name="ExposureMask" value="1 &lt;&lt; 1" />
@@ -155,7 +159,9 @@
       <member cname="GDK_PROXIMITY_OUT_MASK" name="ProximityOutMask" value="1 &lt;&lt; 19" />
       <member cname="GDK_SUBSTRUCTURE_MASK" name="SubstructureMask" value="1 &lt;&lt; 20" />
       <member cname="GDK_SCROLL_MASK" name="ScrollMask" value="1 &lt;&lt; 21" />
-      <member cname="GDK_ALL_EVENTS_MASK" name="AllEventsMask" value="0x3FFFFE" />
+      <member cname="GDK_TOUCH_MASK" name="TouchMask" value="1 &lt;&lt; 22" />
+      <member cname="GDK_SMOOTH_SCROLL_MASK" name="SmoothScrollMask" value="1 &lt;&lt; 23" />
+      <member cname="GDK_ALL_EVENTS_MASK" name="AllEventsMask" value="0xFFFFFE" />
     </enum>
     <enum name="EventType" cname="GdkEventType" gtype="gdk_event_type_get_type" type="enum">
       <member cname="GDK_NOTHING" name="Nothing" value="-1" />
@@ -165,7 +171,9 @@
       <member cname="GDK_MOTION_NOTIFY" name="MotionNotify" value="3" />
       <member cname="GDK_BUTTON_PRESS" name="ButtonPress" value="4" />
       <member cname="GDK_2BUTTON_PRESS" name="TwoButtonPress" value="5" />
+      <member cname="GDK_DOUBLE_BUTTON_PRESS" name="DoubleButtonPress" value="TwoButtonPress" />
       <member cname="GDK_3BUTTON_PRESS" name="ThreeButtonPress" value="6" />
+      <member cname="GDK_TRIPLE_BUTTON_PRESS" name="TripleButtonPress" value="ThreeButtonPress" />
       <member cname="GDK_BUTTON_RELEASE" name="ButtonRelease" value="7" />
       <member cname="GDK_KEY_PRESS" name="KeyPress" value="8" />
       <member cname="GDK_KEY_RELEASE" name="KeyRelease" value="9" />
@@ -195,17 +203,30 @@
       <member cname="GDK_OWNER_CHANGE" name="OwnerChange" value="34" />
       <member cname="GDK_GRAB_BROKEN" name="GrabBroken" value="35" />
       <member cname="GDK_DAMAGE" name="Damage" value="36" />
+      <member cname="GDK_TOUCH_BEGIN" name="TouchBegin" value="37" />
+      <member cname="GDK_TOUCH_UPDATE" name="TouchUpdate" value="38" />
+      <member cname="GDK_TOUCH_END" name="TouchEnd" value="39" />
+      <member cname="GDK_TOUCH_CANCEL" name="TouchCancel" value="40" />
       <member cname="GDK_EVENT_LAST" name="EventLast" />
-    </enum>
-    <enum name="ExtensionMode" cname="GdkExtensionMode" gtype="gdk_extension_mode_get_type" type="enum">
-      <member cname="GDK_EXTENSION_EVENTS_NONE" name="None" />
-      <member cname="GDK_EXTENSION_EVENTS_ALL" name="All" />
-      <member cname="GDK_EXTENSION_EVENTS_CURSOR" name="Cursor" />
     </enum>
     <enum name="FilterReturn" cname="GdkFilterReturn" gtype="gdk_filter_return_get_type" type="enum">
       <member cname="GDK_FILTER_CONTINUE" name="Continue" />
       <member cname="GDK_FILTER_TRANSLATE" name="Translate" />
       <member cname="GDK_FILTER_REMOVE" name="Remove" />
+    </enum>
+    <enum name="FrameClockPhase" cname="GdkFrameClockPhase" gtype="gdk_frame_clock_phase_get_type" type="flags">
+      <member cname="GDK_FRAME_CLOCK_PHASE_NONE" name="None" />
+      <member cname="GDK_FRAME_CLOCK_PHASE_FLUSH_EVENTS" name="FlushEvents" value="1 &lt;&lt; 0" />
+      <member cname="GDK_FRAME_CLOCK_PHASE_BEFORE_PAINT" name="BeforePaint" value="1 &lt;&lt; 1" />
+      <member cname="GDK_FRAME_CLOCK_PHASE_UPDATE" name="Update" value="1 &lt;&lt; 2" />
+      <member cname="GDK_FRAME_CLOCK_PHASE_LAYOUT" name="Layout" value="1 &lt;&lt; 3" />
+      <member cname="GDK_FRAME_CLOCK_PHASE_PAINT" name="Paint" value="1 &lt;&lt; 4" />
+      <member cname="GDK_FRAME_CLOCK_PHASE_RESUME_EVENTS" name="ResumeEvents" value="1 &lt;&lt; 5" />
+      <member cname="GDK_FRAME_CLOCK_PHASE_AFTER_PAINT" name="AfterPaint" value="1 &lt;&lt; 6" />
+    </enum>
+    <enum name="FullscreenMode" cname="GdkFullscreenMode" gtype="gdk_fullscreen_mode_get_type" type="enum">
+      <member cname="GDK_FULLSCREEN_ON_CURRENT_MONITOR" name="CurrentMonitor" />
+      <member cname="GDK_FULLSCREEN_ON_ALL_MONITORS" name="AllMonitors" />
     </enum>
     <enum name="GrabOwnership" cname="GdkGrabOwnership" gtype="gdk_grab_ownership_get_type" type="enum">
       <member cname="GDK_OWNERSHIP_NONE" name="None" />
@@ -242,6 +263,16 @@
       <member cname="GDK_SOURCE_ERASER" name="Eraser" />
       <member cname="GDK_SOURCE_CURSOR" name="Cursor" />
       <member cname="GDK_SOURCE_KEYBOARD" name="Keyboard" />
+      <member cname="GDK_SOURCE_TOUCHSCREEN" name="Touchscreen" />
+      <member cname="GDK_SOURCE_TOUCHPAD" name="Touchpad" />
+    </enum>
+    <enum name="ModifierIntent" cname="GdkModifierIntent" gtype="gdk_modifier_intent_get_type" type="enum">
+      <member cname="GDK_MODIFIER_INTENT_PRIMARY_ACCELERATOR" name="PrimaryAccelerator" />
+      <member cname="GDK_MODIFIER_INTENT_CONTEXT_MENU" name="ContextMenu" />
+      <member cname="GDK_MODIFIER_INTENT_EXTEND_SELECTION" name="ExtendSelection" />
+      <member cname="GDK_MODIFIER_INTENT_MODIFY_SELECTION" name="ModifySelection" />
+      <member cname="GDK_MODIFIER_INTENT_NO_TEXT_INPUT" name="NoTextInput" />
+      <member cname="GDK_MODIFIER_INTENT_SHIFT_GROUP" name="ShiftGroup" />
     </enum>
     <enum name="ModifierType" cname="GdkModifierType" gtype="gdk_modifier_type_get_type" type="flags">
       <member cname="GDK_SHIFT_MASK" name="ShiftMask" value="1 &lt;&lt; 0" />
@@ -257,9 +288,23 @@
       <member cname="GDK_BUTTON3_MASK" name="Button3Mask" value="1 &lt;&lt; 10" />
       <member cname="GDK_BUTTON4_MASK" name="Button4Mask" value="1 &lt;&lt; 11" />
       <member cname="GDK_BUTTON5_MASK" name="Button5Mask" value="1 &lt;&lt; 12" />
+      <member cname="GDK_MODIFIER_RESERVED_13_MASK" name="ModifierReserved13Mask" value="1 &lt;&lt; 13" />
+      <member cname="GDK_MODIFIER_RESERVED_14_MASK" name="ModifierReserved14Mask" value="1 &lt;&lt; 14" />
+      <member cname="GDK_MODIFIER_RESERVED_15_MASK" name="ModifierReserved15Mask" value="1 &lt;&lt; 15" />
+      <member cname="GDK_MODIFIER_RESERVED_16_MASK" name="ModifierReserved16Mask" value="1 &lt;&lt; 16" />
+      <member cname="GDK_MODIFIER_RESERVED_17_MASK" name="ModifierReserved17Mask" value="1 &lt;&lt; 17" />
+      <member cname="GDK_MODIFIER_RESERVED_18_MASK" name="ModifierReserved18Mask" value="1 &lt;&lt; 18" />
+      <member cname="GDK_MODIFIER_RESERVED_19_MASK" name="ModifierReserved19Mask" value="1 &lt;&lt; 19" />
+      <member cname="GDK_MODIFIER_RESERVED_20_MASK" name="ModifierReserved20Mask" value="1 &lt;&lt; 20" />
+      <member cname="GDK_MODIFIER_RESERVED_21_MASK" name="ModifierReserved21Mask" value="1 &lt;&lt; 21" />
+      <member cname="GDK_MODIFIER_RESERVED_22_MASK" name="ModifierReserved22Mask" value="1 &lt;&lt; 22" />
+      <member cname="GDK_MODIFIER_RESERVED_23_MASK" name="ModifierReserved23Mask" value="1 &lt;&lt; 23" />
+      <member cname="GDK_MODIFIER_RESERVED_24_MASK" name="ModifierReserved24Mask" value="1 &lt;&lt; 24" />
+      <member cname="GDK_MODIFIER_RESERVED_25_MASK" name="ModifierReserved25Mask" value="1 &lt;&lt; 25" />
       <member cname="GDK_SUPER_MASK" name="SuperMask" value="1 &lt;&lt; 26" />
       <member cname="GDK_HYPER_MASK" name="HyperMask" value="1 &lt;&lt; 27" />
       <member cname="GDK_META_MASK" name="MetaMask" value="1 &lt;&lt; 28" />
+      <member cname="GDK_MODIFIER_RESERVED_29_MASK" name="ModifierReserved29Mask" value="1 &lt;&lt; 29" />
       <member cname="GDK_RELEASE_MASK" name="ReleaseMask" value="1 &lt;&lt; 30" />
       <member cname="GDK_MODIFIER_MASK" name="ModifierMask" value="0x5c001fff" />
     </enum>
@@ -290,6 +335,7 @@
       <member cname="GDK_SCROLL_DOWN" name="Down" />
       <member cname="GDK_SCROLL_LEFT" name="Left" />
       <member cname="GDK_SCROLL_RIGHT" name="Right" />
+      <member cname="GDK_SCROLL_SMOOTH" name="Smooth" />
     </enum>
     <enum name="SettingAction" cname="GdkSettingAction" gtype="gdk_setting_action_get_type" type="enum">
       <member cname="GDK_SETTING_ACTION_NEW" name="New" />
@@ -372,6 +418,8 @@
       <member cname="GDK_WINDOW_STATE_FULLSCREEN" name="Fullscreen" value="1 &lt;&lt; 4" />
       <member cname="GDK_WINDOW_STATE_ABOVE" name="Above" value="1 &lt;&lt; 5" />
       <member cname="GDK_WINDOW_STATE_BELOW" name="Below" value="1 &lt;&lt; 6" />
+      <member cname="GDK_WINDOW_STATE_FOCUSED" name="Focused" value="1 &lt;&lt; 7" />
+      <member cname="GDK_WINDOW_STATE_TILED" name="Tiled" value="1 &lt;&lt; 8" />
     </enum>
     <enum name="WindowType" cname="GdkWindowType" gtype="gdk_window_type_get_type" type="enum">
       <member cname="GDK_WINDOW_ROOT" name="Root" />
@@ -380,6 +428,7 @@
       <member cname="GDK_WINDOW_TEMP" name="Temp" />
       <member cname="GDK_WINDOW_FOREIGN" name="Foreign" />
       <member cname="GDK_WINDOW_OFFSCREEN" name="Offscreen" />
+      <member cname="GDK_WINDOW_SUBSURFACE" name="Subsurface" />
     </enum>
     <enum name="WindowTypeHint" cname="GdkWindowTypeHint" gtype="gdk_window_type_hint_get_type" type="enum">
       <member cname="GDK_WINDOW_TYPE_HINT_NORMAL" name="Normal" />
@@ -421,6 +470,13 @@
       <parameters>
         <parameter type="GdkWindow*" name="window" />
         <parameter type="gpointer" name="user_data" />
+      </parameters>
+    </callback>
+    <callback name="WindowInvalidateHandlerFunc" cname="GdkWindowInvalidateHandlerFunc">
+      <return-type type="void" />
+      <parameters>
+        <parameter type="GdkWindow*" name="window" />
+        <parameter type="cairo_region_t*" name="region" />
       </parameters>
     </callback>
     <object name="AppLaunchContext" cname="GdkAppLaunchContext" parent="GAppLaunchContext">
@@ -469,13 +525,16 @@
     <object name="Cursor" cname="GdkCursor" parent="GObject">
       <class_struct cname="GdkCursorClass">
         <field name="ParentClass" cname="parent_class" type="GObjectClass" />
-        <method vm="get_image" />
+        <method vm="get_surface" />
       </class_struct>
       <property name="CursorType" cname="cursor-type" type="GdkCursorType" readable="true" writeable="true" construct-only="true" />
       <property name="Display" cname="display" type="GdkDisplay" readable="true" writeable="true" construct-only="true" />
-      <virtual_method name="GetImage" cname="get_image">
-        <return-type type="GdkPixbuf*" />
-        <parameters />
+      <virtual_method name="GetSurface" cname="get_surface">
+        <return-type type="cairo_surface_t*" />
+        <parameters>
+          <parameter type="gdouble*" name="x_hot" />
+          <parameter type="gdouble*" name="y_hot" />
+        </parameters>
       </virtual_method>
       <method name="GetCursorType" cname="gdk_cursor_get_cursor_type">
         <return-type type="GdkCursorType" />
@@ -485,6 +544,13 @@
       </method>
       <method name="GetImage" cname="gdk_cursor_get_image">
         <return-type type="GdkPixbuf*" />
+      </method>
+      <method name="GetSurface" cname="gdk_cursor_get_surface">
+        <return-type type="cairo_surface_t*" />
+        <parameters>
+          <parameter type="gdouble*" name="x_hot" />
+          <parameter type="gdouble*" name="y_hot" />
+        </parameters>
       </method>
       <method name="GetType" cname="gdk_cursor_get_type" shared="true">
         <return-type type="GType" />
@@ -512,6 +578,14 @@
           <parameter type="GdkPixbuf*" name="pixbuf" />
           <parameter type="gint" name="x" />
           <parameter type="gint" name="y" />
+        </parameters>
+      </constructor>
+      <constructor cname="gdk_cursor_new_from_surface">
+        <parameters>
+          <parameter type="GdkDisplay*" name="display" />
+          <parameter type="cairo_surface_t*" name="surface" />
+          <parameter type="gdouble" name="x" />
+          <parameter type="gdouble" name="y" />
         </parameters>
       </constructor>
       <method name="Ref" cname="gdk_cursor_ref" deprecated="1">
@@ -576,20 +650,20 @@
         <return-type type="void" />
         <parameters>
           <parameter type="GdkScreen*" name="screen" />
-          <parameter type="gint" name="x" />
-          <parameter type="gint" name="y" />
+          <parameter type="gdouble" name="x" />
+          <parameter type="gdouble" name="y" />
         </parameters>
       </virtual_method>
       <virtual_method name="QueryState" cname="query_state">
-        <return-type type="gboolean" />
+        <return-type type="void" />
         <parameters>
           <parameter type="GdkWindow*" name="window" />
           <parameter type="GdkWindow**" name="root_window" />
           <parameter type="GdkWindow**" name="child_window" />
-          <parameter type="gint*" name="root_x" />
-          <parameter type="gint*" name="root_y" />
-          <parameter type="gint*" name="win_x" />
-          <parameter type="gint*" name="win_y" />
+          <parameter type="gdouble*" name="root_x" />
+          <parameter type="gdouble*" name="root_y" />
+          <parameter type="gdouble*" name="win_x" />
+          <parameter type="gdouble*" name="win_y" />
           <parameter type="GdkModifierType*" name="mask" />
         </parameters>
       </virtual_method>
@@ -613,8 +687,8 @@
       <virtual_method name="WindowAtPosition" cname="window_at_position">
         <return-type type="GdkWindow*" />
         <parameters>
-          <parameter type="gint*" name="win_x" />
-          <parameter type="gint*" name="win_y" />
+          <parameter type="double*" name="win_x" />
+          <parameter type="double*" name="win_y" />
           <parameter type="GdkModifierType*" name="mask" />
           <parameter type="gboolean" name="get_toplevel" />
         </parameters>
@@ -685,6 +759,9 @@
           <parameter type="GdkModifierType*" name="modifiers" />
         </parameters>
       </method>
+      <method name="GetLastEventWindow" cname="gdk_device_get_last_event_window">
+        <return-type type="GdkWindow*" />
+      </method>
       <method name="GetMode" cname="gdk_device_get_mode">
         <return-type type="GdkInputMode" />
       </method>
@@ -703,6 +780,14 @@
           <parameter type="GdkScreen**" name="screen" />
           <parameter type="gint*" name="x" />
           <parameter type="gint*" name="y" />
+        </parameters>
+      </method>
+      <method name="GetPositionDouble" cname="gdk_device_get_position_double">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GdkScreen**" name="screen" />
+          <parameter type="gdouble*" name="x" />
+          <parameter type="gdouble*" name="y" />
         </parameters>
       </method>
       <method name="GetSource" cname="gdk_device_get_source">
@@ -724,6 +809,13 @@
         <parameters>
           <parameter type="gint*" name="win_x" />
           <parameter type="gint*" name="win_y" />
+        </parameters>
+      </method>
+      <method name="GetWindowAtPositionDouble" cname="gdk_device_get_window_at_position_double">
+        <return-type type="GdkWindow*" />
+        <parameters>
+          <parameter type="gdouble*" name="win_x" />
+          <parameter type="gdouble*" name="win_y" />
         </parameters>
       </method>
       <method name="Grab" cname="gdk_device_grab">
@@ -847,14 +939,13 @@
         <field name="ParentClass" cname="parent_class" type="GObjectClass" />
         <field name="WindowType" cname="window_type" type="GType" />
         <method vm="get_name" />
-        <method vm="get_n_screens" />
-        <method vm="get_screen" />
         <method vm="get_default_screen" />
         <method vm="beep" />
         <method vm="sync" />
         <method vm="flush" />
         <method vm="has_pending" />
         <method vm="queue_events" />
+        <method vm="make_default" />
         <method vm="get_default_group" />
         <method vm="supports_selection_notification" />
         <method vm="request_selection_notification" />
@@ -869,7 +960,7 @@
         <method vm="get_maximal_cursor_size" />
         <method vm="get_cursor_for_type" />
         <method vm="get_cursor_for_name" />
-        <method vm="get_cursor_for_pixbuf" />
+        <method vm="get_cursor_for_surface" />
         <method vm="list_devices" />
         <method vm="get_app_launch_context" />
         <method vm="before_process_all_updates" />
@@ -889,9 +980,10 @@
         <method vm="convert_selection" />
         <method vm="text_property_to_utf8_list" />
         <method vm="utf8_to_string_target" />
+        <method signal_vm="opened" />
         <method signal_vm="closed" />
       </class_struct>
-      <signal name="Opened" cname="opened" when="LAST">
+      <signal name="Opened" cname="opened" when="LAST" field_name="opened">
         <return-type type="void" />
         <parameters />
       </signal>
@@ -902,18 +994,8 @@
         </parameters>
       </signal>
       <virtual_method name="GetName" cname="get_name">
-        <return-type type="const-gchar*" />
+        <return-type type="gchar*" />
         <parameters />
-      </virtual_method>
-      <virtual_method name="GetNScreens" cname="get_n_screens">
-        <return-type type="gint" />
-        <parameters />
-      </virtual_method>
-      <virtual_method name="GetScreen" cname="get_screen">
-        <return-type type="GdkScreen*" />
-        <parameters>
-          <parameter type="gint" name="screen_num" />
-        </parameters>
       </virtual_method>
       <virtual_method name="GetDefaultScreen" cname="get_default_screen">
         <return-type type="GdkScreen*" />
@@ -936,6 +1018,10 @@
         <parameters />
       </virtual_method>
       <virtual_method name="QueueEvents" cname="queue_events">
+        <return-type type="void" />
+        <parameters />
+      </virtual_method>
+      <virtual_method name="MakeDefault" cname="make_default">
         <return-type type="void" />
         <parameters />
       </virtual_method>
@@ -1012,12 +1098,12 @@
           <parameter type="const-gchar*" name="name" />
         </parameters>
       </virtual_method>
-      <virtual_method name="GetCursorForPixbuf" cname="get_cursor_for_pixbuf">
+      <virtual_method name="GetCursorForSurface" cname="get_cursor_for_surface">
         <return-type type="GdkCursor*" />
         <parameters>
-          <parameter type="GdkPixbuf*" name="pixbuf" />
-          <parameter type="gint" name="x" />
-          <parameter type="gint" name="y" />
+          <parameter type="cairo_surface_t*" name="surface" />
+          <parameter type="gdouble" name="x" />
+          <parameter type="gdouble" name="y" />
         </parameters>
       </virtual_method>
       <virtual_method name="ListDevices" cname="list_devices">
@@ -1186,7 +1272,7 @@
           <parameter type="guint*" name="height" />
         </parameters>
       </method>
-      <method name="GetNScreens" cname="gdk_display_get_n_screens">
+      <method name="GetNScreens" cname="gdk_display_get_n_screens" deprecated="1">
         <return-type type="gint" />
       </method>
       <method name="GetName" cname="gdk_display_get_name">
@@ -1328,15 +1414,6 @@
     <object name="DisplayManager" cname="GdkDisplayManager" parent="GObject">
       <class_struct cname="GdkDisplayManagerClass">
         <field name="ParentClass" cname="parent_class" type="GObjectClass" />
-        <method vm="list_displays" />
-        <method vm="get_default_display" />
-        <method vm="set_default_display" />
-        <method vm="open_display" />
-        <method vm="atom_intern" />
-        <method vm="get_atom_name" />
-        <method vm="lookup_keyval" />
-        <method vm="get_keyval_name" />
-        <method vm="keyval_convert_case" />
         <method signal_vm="display_opened" />
       </class_struct>
       <signal name="DisplayOpened" cname="display-opened" when="LAST" field_name="display_opened">
@@ -1346,59 +1423,6 @@
         </parameters>
       </signal>
       <property name="DefaultDisplay" cname="default-display" type="GdkDisplay" readable="true" writeable="true" />
-      <virtual_method name="ListDisplays" cname="list_displays">
-        <return-type type="GSList*" />
-        <parameters />
-      </virtual_method>
-      <virtual_method name="GetDefaultDisplay" cname="get_default_display">
-        <return-type type="GdkDisplay*" />
-        <parameters />
-      </virtual_method>
-      <virtual_method name="SetDefaultDisplay" cname="set_default_display">
-        <return-type type="void" />
-        <parameters>
-          <parameter type="GdkDisplay*" name="display" />
-        </parameters>
-      </virtual_method>
-      <virtual_method name="OpenDisplay" cname="open_display">
-        <return-type type="GdkDisplay*" />
-        <parameters>
-          <parameter type="const-gchar*" name="name" />
-        </parameters>
-      </virtual_method>
-      <virtual_method name="AtomIntern" cname="atom_intern">
-        <return-type type="GdkAtom" />
-        <parameters>
-          <parameter type="const-gchar*" name="atom_name" />
-          <parameter type="gboolean" name="copy_name" />
-        </parameters>
-      </virtual_method>
-      <virtual_method name="GetAtomName" cname="get_atom_name">
-        <return-type type="gchar*" />
-        <parameters>
-          <parameter type="GdkAtom" name="atom" />
-        </parameters>
-      </virtual_method>
-      <virtual_method name="LookupKeyval" cname="lookup_keyval">
-        <return-type type="guint" />
-        <parameters>
-          <parameter type="const-gchar*" name="name" />
-        </parameters>
-      </virtual_method>
-      <virtual_method name="GetKeyvalName" cname="get_keyval_name">
-        <return-type type="gchar*" />
-        <parameters>
-          <parameter type="guint" name="keyval" />
-        </parameters>
-      </virtual_method>
-      <virtual_method name="KeyvalConvertCase" cname="keyval_convert_case">
-        <return-type type="void" />
-        <parameters>
-          <parameter type="guint" name="keyval" />
-          <parameter type="guint*" name="lower" />
-          <parameter type="guint*" name="upper" />
-        </parameters>
-      </virtual_method>
       <method name="Get" cname="gdk_display_manager_get" shared="true">
         <return-type type="GdkDisplayManager*" />
       </method>
@@ -1534,6 +1558,121 @@
         </parameters>
       </method>
     </object>
+    <object name="FrameClock" cname="GdkFrameClock" parent="GObject">
+      <class_struct cname="GdkFrameClockClass">
+        <field name="ParentClass" cname="parent_class" type="GObjectClass" />
+        <method vm="get_frame_time" />
+        <method vm="request_phase" />
+        <method vm="begin_updating" />
+        <method vm="end_updating" />
+        <method vm="freeze" />
+        <method vm="thaw" />
+      </class_struct>
+      <signal name="FlushEvents" cname="flush-events" when="LAST">
+        <return-type type="void" />
+        <parameters />
+      </signal>
+      <signal name="BeforePaint" cname="before-paint" when="LAST">
+        <return-type type="void" />
+        <parameters />
+      </signal>
+      <signal name="Update" cname="update" when="LAST">
+        <return-type type="void" />
+        <parameters />
+      </signal>
+      <signal name="Layout" cname="layout" when="LAST">
+        <return-type type="void" />
+        <parameters />
+      </signal>
+      <signal name="Paint" cname="paint" when="LAST">
+        <return-type type="void" />
+        <parameters />
+      </signal>
+      <signal name="AfterPaint" cname="after-paint" when="LAST">
+        <return-type type="void" />
+        <parameters />
+      </signal>
+      <signal name="ResumeEvents" cname="resume-events" when="LAST">
+        <return-type type="void" />
+        <parameters />
+      </signal>
+      <virtual_method name="GetFrameTime" cname="get_frame_time">
+        <return-type type="gint64" />
+        <parameters />
+      </virtual_method>
+      <virtual_method name="RequestPhase" cname="request_phase">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GdkFrameClockPhase" name="phase" />
+        </parameters>
+      </virtual_method>
+      <virtual_method name="BeginUpdating" cname="begin_updating">
+        <return-type type="void" />
+        <parameters />
+      </virtual_method>
+      <virtual_method name="EndUpdating" cname="end_updating">
+        <return-type type="void" />
+        <parameters />
+      </virtual_method>
+      <virtual_method name="Freeze" cname="freeze">
+        <return-type type="void" />
+        <parameters />
+      </virtual_method>
+      <virtual_method name="Thaw" cname="thaw">
+        <return-type type="void" />
+        <parameters />
+      </virtual_method>
+      <method name="BeginUpdating" cname="gdk_frame_clock_begin_updating">
+        <return-type type="void" />
+      </method>
+      <method name="EndUpdating" cname="gdk_frame_clock_end_updating">
+        <return-type type="void" />
+      </method>
+      <method name="GetCurrentTimings" cname="gdk_frame_clock_get_current_timings">
+        <return-type type="GdkFrameTimings*" />
+      </method>
+      <method name="GetFrameCounter" cname="gdk_frame_clock_get_frame_counter">
+        <return-type type="gint64" />
+      </method>
+      <method name="GetFrameTime" cname="gdk_frame_clock_get_frame_time">
+        <return-type type="gint64" />
+      </method>
+      <method name="GetHistoryStart" cname="gdk_frame_clock_get_history_start">
+        <return-type type="gint64" />
+      </method>
+      <method name="GetRefreshInfo" cname="gdk_frame_clock_get_refresh_info">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gint64" name="base_time" />
+          <parameter type="gint64*" name="refresh_interval_return" />
+          <parameter type="gint64*" name="presentation_time_return" />
+        </parameters>
+      </method>
+      <method name="GetTimings" cname="gdk_frame_clock_get_timings">
+        <return-type type="GdkFrameTimings*" />
+        <parameters>
+          <parameter type="gint64" name="frame_counter" />
+        </parameters>
+      </method>
+      <method name="GetType" cname="gdk_frame_clock_get_type" shared="true">
+        <return-type type="GType" />
+      </method>
+      <method name="RequestPhase" cname="gdk_frame_clock_request_phase">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GdkFrameClockPhase" name="phase" />
+        </parameters>
+      </method>
+    </object>
+    <object name="FrameClockIdle" cname="GdkFrameClockIdle" parent="GdkFrameClock">
+      <class_struct cname="GdkFrameClockIdleClass">
+        <field name="ParentClass" cname="parent_class" type="GdkFrameClockClass" />
+      </class_struct>
+      <field name="Priv" cname="priv" type="GdkFrameClockIdlePrivate*" />
+      <method name="GetType" cname="gdk_frame_clock_idle_get_type" shared="true">
+        <return-type type="GType" />
+      </method>
+    </object>
     <object name="Keymap" cname="GdkKeymap" parent="GObject">
       <class_struct cname="GdkKeymapClass">
         <field name="ParentClass" cname="parent_class" type="GObjectClass" />
@@ -1547,6 +1686,8 @@
         <method vm="translate_keyboard_state" />
         <method vm="add_virtual_modifiers" />
         <method vm="map_virtual_modifiers" />
+        <method vm="get_modifier_mask" />
+        <method vm="get_modifier_state" />
         <method signal_vm="direction_changed" />
         <method signal_vm="keys_changed" />
         <method signal_vm="state_changed" />
@@ -1626,6 +1767,16 @@
           <parameter type="GdkModifierType*" name="state" />
         </parameters>
       </virtual_method>
+      <virtual_method name="GetModifierMask" cname="get_modifier_mask">
+        <return-type type="GdkModifierType" />
+        <parameters>
+          <parameter type="GdkModifierIntent" name="intent" />
+        </parameters>
+      </virtual_method>
+      <virtual_method name="GetModifierState" cname="get_modifier_state">
+        <return-type type="guint" />
+        <parameters />
+      </virtual_method>
       <method name="AddVirtualModifiers" cname="gdk_keymap_add_virtual_modifiers">
         <return-type type="void" />
         <parameters>
@@ -1663,6 +1814,15 @@
         <parameters>
           <parameter type="GdkDisplay*" name="display" />
         </parameters>
+      </method>
+      <method name="GetModifierMask" cname="gdk_keymap_get_modifier_mask">
+        <return-type type="GdkModifierType" />
+        <parameters>
+          <parameter type="GdkModifierIntent" name="intent" />
+        </parameters>
+      </method>
+      <method name="GetModifierState" cname="gdk_keymap_get_modifier_state">
+        <return-type type="guint" />
       </method>
       <method name="GetNumLockState" cname="gdk_keymap_get_num_lock_state">
         <return-type type="gboolean" />
@@ -1714,6 +1874,7 @@
         <method vm="get_monitor_height_mm" />
         <method vm="get_monitor_plug_name" />
         <method vm="get_monitor_geometry" />
+        <method vm="get_monitor_workarea" />
         <method vm="list_visuals" />
         <method vm="get_system_visual" />
         <method vm="get_rgba_visual" />
@@ -1731,6 +1892,7 @@
         <method vm="visual_get_best_with_both" />
         <method vm="query_depths" />
         <method vm="query_visual_types" />
+        <method vm="get_monitor_scale_factor" />
         <method signal_vm="size_changed" />
         <method signal_vm="composited_changed" />
         <method signal_vm="monitors_changed" />
@@ -1804,6 +1966,13 @@
         </parameters>
       </virtual_method>
       <virtual_method name="GetMonitorGeometry" cname="get_monitor_geometry">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gint" name="monitor_num" />
+          <parameter type="GdkRectangle*" name="dest" />
+        </parameters>
+      </virtual_method>
+      <virtual_method name="GetMonitorWorkarea" cname="get_monitor_workarea">
         <return-type type="void" />
         <parameters>
           <parameter type="gint" name="monitor_num" />
@@ -1896,6 +2065,12 @@
           <parameter type="gint*" name="count" />
         </parameters>
       </virtual_method>
+      <virtual_method name="GetMonitorScaleFactor" cname="get_monitor_scale_factor">
+        <return-type type="gint" />
+        <parameters>
+          <parameter type="gint" name="monitor_num" />
+        </parameters>
+      </virtual_method>
       <method name="GetActiveWindow" cname="gdk_screen_get_active_window">
         <return-type type="GdkWindow*" />
       </method>
@@ -1946,10 +2121,23 @@
           <parameter type="gint" name="monitor_num" />
         </parameters>
       </method>
+      <method name="GetMonitorScaleFactor" cname="gdk_screen_get_monitor_scale_factor">
+        <return-type type="gint" />
+        <parameters>
+          <parameter type="gint" name="monitor_num" />
+        </parameters>
+      </method>
       <method name="GetMonitorWidthMm" cname="gdk_screen_get_monitor_width_mm">
         <return-type type="gint" />
         <parameters>
           <parameter type="gint" name="monitor_num" />
+        </parameters>
+      </method>
+      <method name="GetMonitorWorkarea" cname="gdk_screen_get_monitor_workarea">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gint" name="monitor_num" />
+          <parameter type="GdkRectangle*" name="dest" />
         </parameters>
       </method>
       <method name="GetNMonitors" cname="gdk_screen_get_n_monitors">
@@ -2190,7 +2378,7 @@
           <parameter type="gpointer" name="data" />
         </parameters>
       </method>
-      <method name="AtPointer" cname="gdk_window_at_pointer" shared="true">
+      <method name="AtPointer" cname="gdk_window_at_pointer" deprecated="1" shared="true">
         <return-type type="GdkWindow*" />
         <parameters>
           <parameter type="gint*" name="win_x" />
@@ -2203,6 +2391,16 @@
       <method name="BeginMoveDrag" cname="gdk_window_begin_move_drag">
         <return-type type="void" />
         <parameters>
+          <parameter type="gint" name="button" />
+          <parameter type="gint" name="root_x" />
+          <parameter type="gint" name="root_y" />
+          <parameter type="guint32" name="timestamp" />
+        </parameters>
+      </method>
+      <method name="BeginMoveDragForDevice" cname="gdk_window_begin_move_drag_for_device">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GdkDevice*" name="device" />
           <parameter type="gint" name="button" />
           <parameter type="gint" name="root_x" />
           <parameter type="gint" name="root_y" />
@@ -2231,14 +2429,25 @@
           <parameter type="guint32" name="timestamp" />
         </parameters>
       </method>
-      <method name="ConfigureFinished" cname="gdk_window_configure_finished">
+      <method name="BeginResizeDragForDevice" cname="gdk_window_begin_resize_drag_for_device">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GdkWindowEdge" name="edge" />
+          <parameter type="GdkDevice*" name="device" />
+          <parameter type="gint" name="button" />
+          <parameter type="gint" name="root_x" />
+          <parameter type="gint" name="root_y" />
+          <parameter type="guint32" name="timestamp" />
+        </parameters>
+      </method>
+      <method name="ConfigureFinished" cname="gdk_window_configure_finished" deprecated="1">
         <return-type type="void" />
       </method>
       <method name="ConstrainSize" cname="gdk_window_constrain_size" shared="true">
         <return-type type="void" />
         <parameters>
           <parameter type="GdkGeometry*" name="geometry" />
-          <parameter type="guint" name="flags" />
+          <parameter type="GdkWindowHints" name="flags" />
           <parameter type="gint" name="width" />
           <parameter type="gint" name="height" />
           <parameter type="gint*" name="new_width" />
@@ -2263,6 +2472,15 @@
           <parameter type="gdouble*" name="parent_y" />
         </parameters>
       </method>
+      <method name="CreateSimilarImageSurface" cname="gdk_window_create_similar_image_surface">
+        <return-type type="cairo_surface_t*" />
+        <parameters>
+          <parameter type="cairo_format_t" name="format" />
+          <parameter type="int" name="width" />
+          <parameter type="int" name="height" />
+          <parameter type="int" name="scale" />
+        </parameters>
+      </method>
       <method name="CreateSimilarSurface" cname="gdk_window_create_similar_surface">
         <return-type type="cairo_surface_t*" />
         <parameters>
@@ -2277,7 +2495,7 @@
       <method name="Destroy" cname="gdk_window_destroy">
         <return-type type="void" />
       </method>
-      <method name="EnableSynchronizedConfigure" cname="gdk_window_enable_synchronized_configure">
+      <method name="EnableSynchronizedConfigure" cname="gdk_window_enable_synchronized_configure" deprecated="1">
         <return-type type="void" />
       </method>
       <method name="EndPaint" cname="gdk_window_end_paint">
@@ -2286,7 +2504,7 @@
       <method name="EnsureNative" cname="gdk_window_ensure_native">
         <return-type type="gboolean" />
       </method>
-      <method name="Flush" cname="gdk_window_flush">
+      <method name="Flush" cname="gdk_window_flush" deprecated="1">
         <return-type type="void" />
       </method>
       <method name="Focus" cname="gdk_window_focus">
@@ -2315,6 +2533,12 @@
       </method>
       <method name="GetChildren" cname="gdk_window_get_children">
         <return-type type="GList*" />
+      </method>
+      <method name="GetChildrenWithUserData" cname="gdk_window_get_children_with_user_data">
+        <return-type type="GList*" />
+        <parameters>
+          <parameter type="gpointer" name="user_data" />
+        </parameters>
       </method>
       <method name="GetClipRegion" cname="gdk_window_get_clip_region">
         <return-type type="cairo_region_t*" />
@@ -2352,6 +2576,15 @@
           <parameter type="GdkModifierType*" name="mask" />
         </parameters>
       </method>
+      <method name="GetDevicePositionDouble" cname="gdk_window_get_device_position_double">
+        <return-type type="GdkWindow*" />
+        <parameters>
+          <parameter type="GdkDevice*" name="device" />
+          <parameter type="gdouble*" name="x" />
+          <parameter type="gdouble*" name="y" />
+          <parameter type="GdkModifierType*" name="mask" />
+        </parameters>
+      </method>
       <method name="GetDisplay" cname="gdk_window_get_display">
         <return-type type="GdkDisplay*" />
       </method>
@@ -2367,17 +2600,26 @@
       <method name="GetEffectiveToplevel" cname="gdk_window_get_effective_toplevel">
         <return-type type="GdkWindow*" />
       </method>
+      <method name="GetEventCompression" cname="gdk_window_get_event_compression">
+        <return-type type="gboolean" />
+      </method>
       <method name="GetEvents" cname="gdk_window_get_events">
         <return-type type="GdkEventMask" />
       </method>
       <method name="GetFocusOnMap" cname="gdk_window_get_focus_on_map">
         <return-type type="gboolean" />
       </method>
+      <method name="GetFrameClock" cname="gdk_window_get_frame_clock">
+        <return-type type="GdkFrameClock*" />
+      </method>
       <method name="GetFrameExtents" cname="gdk_window_get_frame_extents">
         <return-type type="void" />
         <parameters>
           <parameter type="GdkRectangle*" name="rect" />
         </parameters>
+      </method>
+      <method name="GetFullscreenMode" cname="gdk_window_get_fullscreen_mode">
+        <return-type type="GdkFullscreenMode" />
       </method>
       <method name="GetGeometry" cname="gdk_window_get_geometry">
         <return-type type="void" />
@@ -2407,7 +2649,7 @@
       <method name="GetParent" cname="gdk_window_get_parent">
         <return-type type="GdkWindow*" />
       </method>
-      <method name="GetPointer" cname="gdk_window_get_pointer">
+      <method name="GetPointer" cname="gdk_window_get_pointer" deprecated="1">
         <return-type type="GdkWindow*" />
         <parameters>
           <parameter type="gint*" name="x" />
@@ -2437,6 +2679,9 @@
           <parameter type="gint*" name="x" />
           <parameter type="gint*" name="y" />
         </parameters>
+      </method>
+      <method name="GetScaleFactor" cname="gdk_window_get_scale_factor">
+        <return-type type="gint" />
       </method>
       <method name="GetScreen" cname="gdk_window_get_screen">
         <return-type type="GdkScreen*" />
@@ -2640,7 +2885,7 @@
           <parameter type="gboolean" name="accept_focus" />
         </parameters>
       </method>
-      <method name="SetBackground" cname="gdk_window_set_background">
+      <method name="SetBackground" cname="gdk_window_set_background" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="const-GdkColor*" name="color" />
@@ -2655,7 +2900,7 @@
       <method name="SetBackgroundRgba" cname="gdk_window_set_background_rgba">
         <return-type type="void" />
         <parameters>
-          <parameter type="GdkRGBA*" name="rgba" />
+          <parameter type="const-GdkRGBA*" name="rgba" />
         </parameters>
       </method>
       <method name="SetChildInputShapes" cname="gdk_window_set_child_input_shapes">
@@ -2702,6 +2947,12 @@
           <parameter type="GdkEventMask" name="event_mask" />
         </parameters>
       </method>
+      <method name="SetEventCompression" cname="gdk_window_set_event_compression">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gboolean" name="event_compression" />
+        </parameters>
+      </method>
       <method name="SetEvents" cname="gdk_window_set_events">
         <return-type type="void" />
         <parameters>
@@ -2712,6 +2963,12 @@
         <return-type type="void" />
         <parameters>
           <parameter type="gboolean" name="focus_on_map" />
+        </parameters>
+      </method>
+      <method name="SetFullscreenMode" cname="gdk_window_set_fullscreen_mode">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GdkFullscreenMode" name="mode" />
         </parameters>
       </method>
       <method name="SetFunctions" cname="gdk_window_set_functions">
@@ -2745,6 +3002,12 @@
           <parameter type="const-gchar*" name="name" />
         </parameters>
       </method>
+      <method name="SetInvalidateHandler" cname="gdk_window_set_invalidate_handler">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GdkWindowInvalidateHandlerFunc" name="handler" />
+        </parameters>
+      </method>
       <method name="SetKeepAbove" cname="gdk_window_set_keep_above">
         <return-type type="void" />
         <parameters>
@@ -2769,6 +3032,12 @@
           <parameter type="gdouble" name="opacity" />
         </parameters>
       </method>
+      <method name="SetOpaqueRegion" cname="gdk_window_set_opaque_region">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="cairo_region_t*" name="region" />
+        </parameters>
+      </method>
       <method name="SetOverrideRedirect" cname="gdk_window_set_override_redirect">
         <return-type type="void" />
         <parameters>
@@ -2779,6 +3048,15 @@
         <return-type type="void" />
         <parameters>
           <parameter type="const-gchar*" name="role" />
+        </parameters>
+      </method>
+      <method name="SetShadowWidth" cname="gdk_window_set_shadow_width">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gint" name="left" />
+          <parameter type="gint" name="right" />
+          <parameter type="gint" name="top" />
+          <parameter type="gint" name="bottom" />
         </parameters>
       </method>
       <method name="SetSkipPagerHint" cname="gdk_window_set_skip_pager_hint">
@@ -2862,6 +3140,12 @@
       <method name="ShowUnraised" cname="gdk_window_show_unraised">
         <return-type type="void" />
       </method>
+      <method name="ShowWindowMenu" cname="gdk_window_show_window_menu">
+        <return-type type="gboolean" />
+        <parameters>
+          <parameter type="GdkEvent*" name="event" />
+        </parameters>
+      </method>
       <method name="Stick" cname="gdk_window_stick">
         <return-type type="void" />
       </method>
@@ -2887,38 +3171,39 @@
     <struct name="ArgContext" cname="GdkArgContext" opaque="true" />
     <struct name="ArgDesc" cname="GdkArgDesc" opaque="true" />
     <struct name="AxisInfo" cname="GdkAxisInfo" opaque="true" />
+    <struct name="Backend" cname="GdkBackend" opaque="true" />
     <struct name="ClientFilter" cname="GdkClientFilter" opaque="true" />
     <boxed name="Color" cname="GdkColor">
       <field name="Pixel" cname="pixel" type="guint32" />
       <field name="Red" cname="red" type="guint16" />
       <field name="Green" cname="green" type="guint16" />
       <field name="Blue" cname="blue" type="guint16" />
-      <method name="Copy" cname="gdk_color_copy">
+      <method name="Copy" cname="gdk_color_copy" deprecated="1">
         <return-type type="GdkColor*" owned="true" />
       </method>
-      <method name="Equal" cname="gdk_color_equal">
+      <method name="Equal" cname="gdk_color_equal" deprecated="1">
         <return-type type="gboolean" />
         <parameters>
           <parameter type="const-GdkColor*" name="colorb" />
         </parameters>
       </method>
-      <method name="Free" cname="gdk_color_free">
+      <method name="Free" cname="gdk_color_free" deprecated="1">
         <return-type type="void" />
       </method>
-      <method name="GetType" cname="gdk_color_get_type" shared="true">
+      <method name="GetType" cname="gdk_color_get_type" deprecated="1" shared="true">
         <return-type type="GType" />
       </method>
-      <method name="Hash" cname="gdk_color_hash">
+      <method name="Hash" cname="gdk_color_hash" deprecated="1">
         <return-type type="guint" />
       </method>
-      <method name="Parse" cname="gdk_color_parse" shared="true">
+      <method name="Parse" cname="gdk_color_parse" deprecated="1" shared="true">
         <return-type type="gboolean" />
         <parameters>
           <parameter type="const-gchar*" name="spec" />
           <parameter type="GdkColor*" name="color" />
         </parameters>
       </method>
-      <method name="ToString" cname="gdk_color_to_string">
+      <method name="ToString" cname="gdk_color_to_string" deprecated="1">
         <return-type type="gchar*" />
       </method>
     </boxed>
@@ -3063,6 +3348,8 @@
       <field name="Device" cname="device" type="GdkDevice*" />
       <field name="XRoot" cname="x_root" type="gdouble" />
       <field name="YRoot" cname="y_root" type="gdouble" />
+      <field name="DeltaX" cname="delta_x" type="gdouble" />
+      <field name="DeltaY" cname="delta_y" type="gdouble" />
     </struct>
     <struct name="EventSelection" cname="GdkEventSelection">
       <field name="Type" cname="type" type="GdkEventType" />
@@ -3074,12 +3361,32 @@
       <field name="Time" cname="time" type="guint32" />
       <field name="Requestor" cname="requestor" type="GdkWindow*" />
     </struct>
+    <boxed name="EventSequence" cname="GdkEventSequence" opaque="true">
+      <method name="GetType" cname="gdk_event_sequence_get_type" shared="true">
+        <return-type type="GType" />
+      </method>
+    </boxed>
     <struct name="EventSetting" cname="GdkEventSetting">
       <field name="Type" cname="type" type="GdkEventType" />
       <field name="Window" cname="window" type="GdkWindow*" />
       <field name="SendEvent" cname="send_event" type="gint8" />
       <field name="Action" cname="action" type="GdkSettingAction" />
       <field name="Name" cname="name" type="char*" />
+    </struct>
+    <struct name="EventTouch" cname="GdkEventTouch">
+      <field name="Type" cname="type" type="GdkEventType" />
+      <field name="Window" cname="window" type="GdkWindow*" />
+      <field name="SendEvent" cname="send_event" type="gint8" />
+      <field name="Time" cname="time" type="guint32" />
+      <field name="X" cname="x" type="gdouble" />
+      <field name="Y" cname="y" type="gdouble" />
+      <field name="Axes" cname="axes" type="gdouble*" />
+      <field name="State" cname="state" type="guint" />
+      <field name="Sequence" cname="sequence" type="GdkEventSequence*" />
+      <field name="EmulatingPointer" cname="emulating_pointer" type="gboolean" />
+      <field name="Device" cname="device" type="GdkDevice*" />
+      <field name="XRoot" cname="x_root" type="gdouble" />
+      <field name="YRoot" cname="y_root" type="gdouble" />
     </struct>
     <struct name="EventVisibility" cname="GdkEventVisibility">
       <field name="Type" cname="type" type="GdkEventType" />
@@ -3094,6 +3401,35 @@
       <field name="ChangedMask" cname="changed_mask" type="GdkWindowState" />
       <field name="NewWindowState" cname="new_window_state" type="GdkWindowState" />
     </struct>
+    <boxed name="FrameTimings" cname="GdkFrameTimings" opaque="true">
+      <method name="GetComplete" cname="gdk_frame_timings_get_complete">
+        <return-type type="gboolean" />
+      </method>
+      <method name="GetFrameCounter" cname="gdk_frame_timings_get_frame_counter">
+        <return-type type="gint64" />
+      </method>
+      <method name="GetFrameTime" cname="gdk_frame_timings_get_frame_time">
+        <return-type type="gint64" />
+      </method>
+      <method name="GetPredictedPresentationTime" cname="gdk_frame_timings_get_predicted_presentation_time">
+        <return-type type="gint64" />
+      </method>
+      <method name="GetPresentationTime" cname="gdk_frame_timings_get_presentation_time">
+        <return-type type="gint64" />
+      </method>
+      <method name="GetRefreshInterval" cname="gdk_frame_timings_get_refresh_interval">
+        <return-type type="gint64" />
+      </method>
+      <method name="GetType" cname="gdk_frame_timings_get_type" shared="true">
+        <return-type type="GType" />
+      </method>
+      <method name="Ref" cname="gdk_frame_timings_ref">
+        <return-type type="GdkFrameTimings*" />
+      </method>
+      <method name="Unref" cname="gdk_frame_timings_unref">
+        <return-type type="void" />
+      </method>
+    </boxed>
     <struct name="Geometry" cname="GdkGeometry">
       <field name="MinWidth" cname="min_width" type="gint" />
       <field name="MinHeight" cname="min_height" type="gint" />
@@ -3136,8 +3472,6 @@
       </method>
     </struct>
     <struct name="OffscreenWindowClass" cname="GdkOffscreenWindowClass" opaque="true" />
-    <struct name="Paintable" cname="GdkPaintable" opaque="true" />
-    <struct name="PaintableIface" cname="GdkPaintableIface" opaque="true" />
     <struct name="Point" cname="GdkPoint">
       <field name="X" cname="x" type="gint" />
       <field name="Y" cname="y" type="gint" />
@@ -3236,9 +3570,6 @@
       <method name="GetDefaultRootWindow" cname="gdk_get_default_root_window" shared="true">
         <return-type type="GdkWindow*" />
       </method>
-      <method name="GetDisplay" cname="gdk_get_display" shared="true">
-        <return-type type="gchar*" />
-      </method>
       <method name="GetDisplayArgName" cname="gdk_get_display_arg_name" shared="true">
         <return-type type="const-gchar*" />
       </method>
@@ -3267,6 +3598,12 @@
       </method>
       <method name="PreParseLibgtkOnly" cname="gdk_pre_parse_libgtk_only" shared="true">
         <return-type type="void" />
+      </method>
+      <method name="SetAllowedBackends" cname="gdk_set_allowed_backends" shared="true">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="const-gchar*" name="backends" />
+        </parameters>
       </method>
       <method name="SetDoubleClickTime" cname="gdk_set_double_click_time" shared="true">
         <return-type type="void" />
@@ -3345,7 +3682,7 @@
           <parameter type="cairo_surface_t*" name="surface" />
         </parameters>
       </method>
-      <method name="SetSourceColor" cname="gdk_cairo_set_source_color" shared="true">
+      <method name="SetSourceColor" cname="gdk_cairo_set_source_color" deprecated="1" shared="true">
         <return-type type="void" />
         <parameters>
           <parameter type="cairo_t*" name="cr" />
@@ -3375,6 +3712,14 @@
           <parameter type="GdkWindow*" name="window" />
           <parameter type="gdouble" name="x" />
           <parameter type="gdouble" name="y" />
+        </parameters>
+      </method>
+      <method name="SurfaceCreateFromPixbuf" cname="gdk_cairo_surface_create_from_pixbuf" shared="true">
+        <return-type type="cairo_surface_t*" />
+        <parameters>
+          <parameter type="const-GdkPixbuf*" name="pixbuf" />
+          <parameter type="int" name="scale" />
+          <parameter type="GdkWindow*" name="for_window" />
         </parameters>
       </method>
     </class>
@@ -3504,6 +3849,20 @@
           <parameter type="gdouble*" name="value" />
         </parameters>
       </method>
+      <method name="GetButton" cname="gdk_event_get_button" shared="true">
+        <return-type type="gboolean" />
+        <parameters>
+          <parameter type="const-GdkEvent*" name="event" />
+          <parameter type="guint*" name="button" />
+        </parameters>
+      </method>
+      <method name="GetClickCount" cname="gdk_event_get_click_count" shared="true">
+        <return-type type="gboolean" />
+        <parameters>
+          <parameter type="const-GdkEvent*" name="event" />
+          <parameter type="guint*" name="click_count" />
+        </parameters>
+      </method>
       <method name="GetCoords" cname="gdk_event_get_coords" shared="true">
         <return-type type="gboolean" />
         <parameters>
@@ -3518,6 +3877,32 @@
           <parameter type="const-GdkEvent*" name="event" />
         </parameters>
       </method>
+      <method name="GetEventSequence" cname="gdk_event_get_event_sequence" shared="true">
+        <return-type type="GdkEventSequence*" />
+        <parameters>
+          <parameter type="const-GdkEvent*" name="event" />
+        </parameters>
+      </method>
+      <method name="GetEventType" cname="gdk_event_get_event_type" shared="true">
+        <return-type type="GdkEventType" />
+        <parameters>
+          <parameter type="const-GdkEvent*" name="event" />
+        </parameters>
+      </method>
+      <method name="GetKeycode" cname="gdk_event_get_keycode" shared="true">
+        <return-type type="gboolean" />
+        <parameters>
+          <parameter type="const-GdkEvent*" name="event" />
+          <parameter type="guint16*" name="keycode" />
+        </parameters>
+      </method>
+      <method name="GetKeyval" cname="gdk_event_get_keyval" shared="true">
+        <return-type type="gboolean" />
+        <parameters>
+          <parameter type="const-GdkEvent*" name="event" />
+          <parameter type="guint*" name="keyval" />
+        </parameters>
+      </method>
       <method name="GetRootCoords" cname="gdk_event_get_root_coords" shared="true">
         <return-type type="gboolean" />
         <parameters>
@@ -3530,6 +3915,21 @@
         <return-type type="GdkScreen*" />
         <parameters>
           <parameter type="const-GdkEvent*" name="event" />
+        </parameters>
+      </method>
+      <method name="GetScrollDeltas" cname="gdk_event_get_scroll_deltas" shared="true">
+        <return-type type="gboolean" />
+        <parameters>
+          <parameter type="const-GdkEvent*" name="event" />
+          <parameter type="gdouble*" name="delta_x" />
+          <parameter type="gdouble*" name="delta_y" />
+        </parameters>
+      </method>
+      <method name="GetScrollDirection" cname="gdk_event_get_scroll_direction" shared="true">
+        <return-type type="gboolean" />
+        <parameters>
+          <parameter type="const-GdkEvent*" name="event" />
+          <parameter type="GdkScrollDirection*" name="direction" />
         </parameters>
       </method>
       <method name="GetSourceDevice" cname="gdk_event_get_source_device" shared="true">
@@ -3553,6 +3953,12 @@
       </method>
       <method name="GetType" cname="gdk_event_get_type" shared="true">
         <return-type type="GType" />
+      </method>
+      <method name="GetWindow" cname="gdk_event_get_window" shared="true">
+        <return-type type="GdkWindow*" />
+        <parameters>
+          <parameter type="const-GdkEvent*" name="event" />
+        </parameters>
       </method>
       <method name="HandlerSet" cname="gdk_event_handler_set" shared="true">
         <return-type type="void" />
@@ -3602,6 +4008,12 @@
         <parameters>
           <parameter type="GdkEvent*" name="event" />
           <parameter type="GdkDevice*" name="device" />
+        </parameters>
+      </method>
+      <method name="TriggersContextMenu" cname="gdk_event_triggers_context_menu" shared="true">
+        <return-type type="gboolean" />
+        <parameters>
+          <parameter type="const-GdkEvent*" name="event" />
         </parameters>
       </method>
     </class>
@@ -3988,16 +4400,16 @@
           <parameter type="GDestroyNotify" name="notify" />
         </parameters>
       </method>
-      <method name="Enter" cname="gdk_threads_enter" shared="true">
+      <method name="Enter" cname="gdk_threads_enter" deprecated="1" shared="true">
         <return-type type="void" />
       </method>
-      <method name="Init" cname="gdk_threads_init" shared="true">
+      <method name="Init" cname="gdk_threads_init" deprecated="1" shared="true">
         <return-type type="void" />
       </method>
-      <method name="Leave" cname="gdk_threads_leave" shared="true">
+      <method name="Leave" cname="gdk_threads_leave" deprecated="1" shared="true">
         <return-type type="void" />
       </method>
-      <method name="SetLockFunctions" cname="gdk_threads_set_lock_functions" shared="true">
+      <method name="SetLockFunctions" cname="gdk_threads_set_lock_functions" deprecated="1" shared="true">
         <return-type type="void" />
         <parameters>
           <parameter type="GCallback" name="enter_fn" />

--- a/generator/ObjectBase.cs
+++ b/generator/ObjectBase.cs
@@ -183,7 +183,7 @@ namespace GtkSharp.Generation {
 				* as they may contain class fields which don't appear in the old (version 1) API files. There are also cases in which the order of the
 				* <signal> and <virtual_method> elements do not match the struct layout.
 				*/
-				return (is_interface || this.ParserVersion >= 2) && class_fields_valid;
+				return (is_interface || this.ParserVersion >= 2) && (class_fields_valid || class_struct_name == "GtkWidgetClass");
 			}
 		}
 

--- a/gtk/Gtk.metadata
+++ b/gtk/Gtk.metadata
@@ -8,6 +8,9 @@
   <attr path="/api/namespace/struct[@cname='GtkRadioActionEntry']" name="hidden">1</attr>
   <attr path="/api/namespace/struct[@cname='GtkToggleActionEntry']" name="hidden">1</attr>
   <attr path="/api/namespace/boxed[@cname='GtkBorder']" name="opaque">false</attr>
+  <attr path="/api/namespace/boxed[@cname='GtkGradient']/method[@cname='gtk_gradient_add_color_stop']" name="hidden">1</attr>
+  <attr path="/api/namespace/boxed[@cname='GtkGradient']/method[@cname='gtk_gradient_resolve']" name="hidden">1</attr>
+  <attr path="/api/namespace/boxed[@cname='GtkGradient']/method[@cname='gtk_gradient_resolve_for_context']" name="hidden">1</attr>
   <attr path="/api/namespace/boxed[@cname='GtkIconInfo']/method[@name='Free']" name="deprecated">1</attr>
   <attr path="/api/namespace/boxed[@cname='GtkIconInfo']/method[@name='GetFilename']" name="win32_utf8_variant">true</attr>
   <attr path="/api/namespace/boxed[@cname='GtkIconSet']/method[@name='GetSizes']" name="hidden">1</attr>
@@ -32,6 +35,7 @@
   <attr path="/api/namespace/boxed[@cname='GtkSelectionData']/method[@name='SetText']" name="hidden">1</attr>
   <attr path="/api/namespace/boxed[@cname='GtkSelectionData']/method[@name='Set']/*/*[@name='data']" name="type">guchar</attr>
   <attr path="/api/namespace/boxed[@cname='GtkSelectionData']/method[@name='Set']/*/*[@name='data']" name="array">1</attr>
+  <attr path="/api/namespace/boxed[@cname='GtkSymbolicColor']/method[@cname='gtk_symbolic_color_resolve']" name="hidden">1</attr>
   <attr path="/api/namespace/boxed[@cname='GtkTargetEntry']" name="opaque">false</attr>
   <attr path="/api/namespace/boxed[@cname='GtkTargetEntry']/field[@cname='flags']" name="type">GtkTargetFlags</attr>
   <attr path="/api/namespace/boxed[@cname='GtkTextAttributes']/field[@cname='appearance']" name="hidden">1</attr>
@@ -73,6 +77,7 @@
   <attr path="/api/namespace/class[@cname='GtkGlobal']/method[@name='EventsPending']" name="name">GetEventsPending</attr>
   <attr path="/api/namespace/class[@cname='GtkGlobal']/method[@name='CheckVersion']/return-type" name="type">const-gchar*</attr>
   <attr path="/api/namespace/class[@cname='GtkGlobal']/method[@name='EnumeratePrinters']" name="hidden">1</attr>
+  <attr path="/api/namespace/class[@cname='GtkIcon_']/method[@cname='gtk_icon_size_lookup_for_settings']" name="hidden">1</attr>
   <attr path="/api/namespace/class[@cname='GtkInit_']/method[@name='Check']" name="hidden">1</attr>
   <attr path="/api/namespace/class[@cname='GtkInit_']/method[@name='CheckAbiCheck']" name="hidden">1</attr>
   <attr path="/api/namespace/class[@cname='GtkInit_']/method[@name='AbiCheck']" name="hidden">1</attr>
@@ -83,6 +88,9 @@
   <attr path="/api/namespace/class[@cname='GtkRc_']/method[@name='Parse']" name="win32_utf8_variant">true</attr>
   <attr path="/api/namespace/class[@cname='GtkRc_']/method[@name='SetDefaultFiles']" name="win32_utf8_variant">true</attr>
   <attr path="/api/namespace/class[@cname='GtkRc_']/method[@name='SetDefaultFiles']/*/*[@name='filenames']" name="null_term_array">1</attr>
+  <attr path="/api/namespace/class[@cname='GtkRc_']/method[@cname='gtk_rc_get_style_by_paths']" name="hidden">1</attr>
+  <attr path="/api/namespace/class[@cname='GtkRc_']/method[@cname='gtk_rc_reparse_all_for_settings']" name="hidden">1</attr>
+  <attr path="/api/namespace/class[@cname='GtkRc_']/method[@cname='gtk_rc_reset_styles']" name="hidden">1</attr>
   <attr path="/api/namespace/class[@cname='GtkRender_']" name="internal">1</attr>
   <attr path="/api/namespace/class[@cname='GtkRender_']/method[@name='IconPixbuf']/return-type" name="owned">true</attr>
   <attr path="/api/namespace/class[@cname='GtkStock_']" name="hidden">1</attr>
@@ -113,6 +121,7 @@
   <attr path="/api/namespace/enum[@cname='GtkTextBufferTargetInfo']/member[@name='Text']" name="value">UInt32.MaxValue-2U</attr>
   <attr path="/api/namespace/enum[@cname='GtkToolbarSpaceStyle']" name="hidden">1</attr>
   <attr path="/api/namespace/enum[@cname='GtkWin32EmbedMessageType']" name="hidden">1</attr>
+  <attr path="/api/namespace/interface[@cname='GtkActionable']/property[@name='ActionName']" name="hidden">1</attr> 
   <attr path="/api/namespace/interface[@cname='GtkBuildable']" name="hidden">1</attr> 
   <attr path="/api/namespace/interface[@cname='GtkCellEditable']/method[@name='EditingDone']" name="name">FinishEditing</attr>
   <attr path="/api/namespace/interface[@cname='GtkCellEditable']/signal[@name='RemoveWidget']" name="name">WidgetRemoved</attr>
@@ -191,6 +200,8 @@
   <attr path="/api/namespace/interface[@cname='GtkRecentChooser']/virtual_method[@cname='list_filters']/return-type" name="element_type">GtkRecentFilter*</attr>
   <attr path="/api/namespace/interface[@cname='GtkRecentChooser']/virtual_method[@cname='list_filters']/return-type" name="elements_owned">false</attr>
   <attr path="/api/namespace/interface[@cname='GtkRecentChooser']/virtual_method[@cname='list_filters']/return-type" name="owned">true</attr>
+  <attr path="/api/namespace/interface[@cname='GtkStyleProvider']/method[@cname='gtk_style_provider_get_icon_factory']" name="hidden">1</attr>
+  <attr path="/api/namespace/interface[@cname='GtkStyleProvider']/method[@cname='gtk_style_provider_get_style']" name="hidden">1</attr>
   <attr path="/api/namespace/interface[@cname='GtkTreeModel']/method[@name='Foreach']/*/*[@name='func']" name="scope">call</attr>
   <attr path="/api/namespace/interface[@cname='GtkTreeModel']/*[@name='GetIterFirst']/*/*[@name='iter']" name="pass_as">out</attr>
   <attr path="/api/namespace/interface[@cname='GtkTreeModel']/method[@name='Get']" name="hidden">1</attr>
@@ -257,6 +268,9 @@
   <attr path="/api/namespace/object[@cname='GtkApplication']/method[@name='GetWindows']/return-type" name="element_type">GtkWindow*</attr>
   <attr path="/api/namespace/object[@cname='GtkArrow']/method[@name='Set']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GtkBin']/method[@name='GetChild']" name="hidden">1</attr>
+  <attr path="/api/namespace/object[@cname='GtkBuilder']/constructor[@cname='gtk_builder_new_from_file']" name="hidden">1</attr>
+  <attr path="/api/namespace/object[@cname='GtkBuilder']/constructor[@cname='gtk_builder_new_from_resource']" name="hidden">1</attr>
+  <attr path="/api/namespace/object[@cname='GtkBuilder']/constructor[@cname='gtk_builder_new_from_string']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GtkBuilder']/method[@name='AddFromFile']/*/*[@name='filename']" name="type">const-gfilename*</attr>
   <attr path="/api/namespace/object[@cname='GtkBuilder']/method[@cname='gtk_builder_connect_signals']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GtkBuilder']/method[@cname='gtk_builder_connect_signals_full']" name="hidden">1</attr>
@@ -306,6 +320,7 @@
   <attr path="/api/namespace/object[@cname='GtkClipboard']/signal" name="block_glue">1</attr>
   <attr path="/api/namespace/object[@cname='GtkColorButton']/method[@name='GetColor']/*/*[@name='color']" name="pass_as">out</attr>
   <attr path="/api/namespace/object[@cname='GtkColorButton']/property[@name='Rgba']" name="type">GdkRGBA</attr>
+  <attr path="/api/namespace/object[@cname='GtkColorButton']/property[@cname='use-alpha']" name="name">HasAlpha</attr>
   <attr path="/api/namespace/object[@cname='GtkColorSelection']/method[@name='GetCurrentColor']/*/*[@name='color']" name="pass_as">out</attr>
   <attr path="/api/namespace/object[@cname='GtkColorSelection']/method[@name='GetPreviousColor']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GtkColorSelection']/method[@name='PaletteFromString']" name="hidden">1</attr>
@@ -362,11 +377,15 @@
   <attr path="/api/namespace/object[@cname='GtkExpander']/constructor[@cname='gtk_expander_new_with_mnemonic']" name="preferred">1</attr>
   <attr path="/api/namespace/object[@cname='GtkExpander']/signal[@name='Activate']" name="name">Activated</attr>
   <attr path="/api/namespace/object[@cname='GtkFileChooserDialog']/constructor[@cname='gtk_file_chooser_dialog_new']" name="hidden">1</attr>
+  <attr path="/api/namespace/object[@cname='GtkFileChooserWidget']/signal[@cname='show-hidden']" name="name">ShowedHidden</attr>
   <remove-node path="/api/namespace/object[@cname='GtkFileChooserWidget']/implements/interface[@cname='GtkFileChooserEmbed']" />
+  <attr path="/api/namespace/object[@cname='GtkFlowBox']/signal[@cname='select-all']" name="name">SelectedAll</attr>
+  <attr path="/api/namespace/object[@cname='GtkFlowBox']/signal[@cname='unselect-all']" name="name">UnselectedAll</attr>
   <attr path="/api/namespace/object[@cname='GtkFontSelectionDialog']/method[@name='GetCancelButton']/return-type" name="type">GtkButton*</attr>
   <attr path="/api/namespace/object[@cname='GtkFontSelectionDialog']/method[@name='GetOkButton']/return-type" name="type">GtkButton*</attr>
   <attr path="/api/namespace/object[@cname='GtkFrame']/method[@name='GetLabelAlign']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GtkFrame']/method[@name='SetLabelAlign']" name="hidden">1</attr>
+  <attr path="/api/namespace/object[@cname='GtkGesture']/method[@cname='gtk_gesture_get_group']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GtkHandleBox']/property[@name='ChildDetached']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GtkHandleBox']/property[@name='ShadowType']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GtkHandleBox']/method[@name='GetChildDetached']" name="name">IsChildDetached</attr>
@@ -442,6 +461,8 @@
   <attr path="/api/namespace/object[@cname='GtkLayout']/method[@name='GetVadjustment']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GtkLayout']/method[@name='SetHadjustment']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GtkLayout']/method[@name='SetVadjustment']" name="hidden">1</attr>
+  <attr path="/api/namespace/object[@cname='GtkListBox']/signal[@cname='select-all']" name="name">SelectedAll</attr>
+  <attr path="/api/namespace/object[@cname='GtkListBox']/signal[@cname='unselect-all']" name="name">UnselectedAll</attr>
   <attr path="/api/namespace/object[@cname='GtkListStore']/constructor[@cname='gtk_list_store_new']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GtkListStore']/constructor[@cname='gtk_list_store_newv']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GtkListStore']/method[@name='Append']/*/*[@name='iter']" name="pass_as">out</attr>
@@ -471,6 +492,7 @@
   <attr path="/api/namespace/object[@cname='GtkMenu']/method[@name='SetScreen']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GtkMenuShell']/signal[@name='Cancel']" name="name">Canceled</attr>
   <attr path="/api/namespace/object[@cname='GtkMenuShell']/signal[@name='Deactivate']" name="name">Deactivated</attr>
+  <attr path="/api/namespace/object[@cname='GtkMenuShell']/signal[@name='Insert']" name="name">Inserted</attr>
   <attr path="/api/namespace/object[@cname='GtkMessageDialog']/constructor[@cname='gtk_message_dialog_new']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GtkMessageDialog']/constructor[@cname='gtk_message_dialog_new_with_markup']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GtkMountOperation']/method[@name='IsShowing']" name="name">GetIsShowing</attr>
@@ -478,6 +500,8 @@
   <attr path="/api/namespace/object[@cname='GtkNotebook']/signal[@name='ReorderTab']/return-type" name="type">void</attr>
   <attr path="/api/namespace/object[@cname='GtkPageSetup']/constructor[@cname='gtk_page_setup_new_from_file']/*/*[@name='file_name']" name="type">const-gfilename*</attr>
   <attr path="/api/namespace/object[@cname='GtkPageSetup']/method[@name='ToFile']/*/*[@name='file_name']" name="type">const-gfilename*</attr>
+  <attr path="/api/namespace/object[@cname='GtkPlacesSidebar']/signal[@cname='show-connect-to-server']" name="name">ShowedConnectToServer</attr>
+  <attr path="/api/namespace/object[@cname='GtkPlacesSidebar']/signal[@cname='show-enter-location']" name="name">ShowEnteredLocation</attr>
   <attr path="/api/namespace/object[@cname='GtkPlug']/constructor[@cname='gtk_plug_new']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GtkPlug']/constructor[@cname='gtk_plug_new_for_display']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GtkPlug']/property[@name='Embedded']" name="name">IsEmbedded</attr>
@@ -816,9 +840,10 @@
   <attr path="/api/namespace/object[@cname='GtkTreeView']/method[@name='SetHadjustment']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GtkTreeView']/method[@name='SetVadjustment']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GtkUIManager']/constructor[@cname='gtk_ui_manager_new_merge_id']" name="hidden">1</attr>
-   <attr path="/api/namespace/object[@cname='GtkUIManager']/method[@name='AddUiFromFile']" name="win32_utf8_variant">true</attr>
-   <attr path="/api/namespace/object[@cname='GtkUIManager']/method[@cname='gtk_ui_manager_get_action_groups']" name="hidden">1</attr>
-   <attr path="/api/namespace/object[@cname='GtkUIManager']/method[@name='GetToplevels']" name="hidden">1</attr>
+  <attr path="/api/namespace/object[@cname='GtkUIManager']/method[@name='AddUiFromFile']" name="win32_utf8_variant">true</attr>
+  <attr path="/api/namespace/object[@cname='GtkUIManager']/method[@name='AddUiFromResource']" name="hidden">1</attr>
+  <attr path="/api/namespace/object[@cname='GtkUIManager']/method[@cname='gtk_ui_manager_get_action_groups']" name="hidden">1</attr>
+  <attr path="/api/namespace/object[@cname='GtkUIManager']/method[@name='GetToplevels']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GtkViewport']/method[@name='GetHadjustment']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GtkViewport']/method[@name='GetVadjustment']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GtkViewport']/method[@name='SetHadjustment']" name="hidden">1</attr>
@@ -843,6 +868,7 @@
   <attr path="/api/namespace/object[@cname='GtkWidget']/method[@name='GetPreferredSize']/*/*[@type='GtkRequisition*']" name="pass_as">out</attr>
   <attr path="/api/namespace/object[@cname='GtkWidget']/method[@name='GetRealized']" name="name">GetIsRealized</attr>
   <attr path="/api/namespace/object[@cname='GtkWidget']/method[@name='GetRequisition']/*/parameter[@name='requisition']" name="pass_as">out</attr>
+  <attr path="/api/namespace/object[@cname='GtkWidget']/method[@name='GetSettings']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GtkWidget']/method[@name='HasDefault']" name="name">GetHasDefault</attr>
   <attr path="/api/namespace/object[@cname='GtkWidget']/method[@name='HasFocus']" name="name">GetHasFocus</attr>
   <attr path="/api/namespace/object[@cname='GtkWidget']/method[@name='Intersect']/*/*[@name='intersection']" name="pass_as">out</attr>
@@ -894,6 +920,7 @@
   <attr path="/api/namespace/object[@cname='GtkWindow']/method[@name='SetIconFromFile']" name="win32_utf8_variant">true</attr>
   <attr path="/api/namespace/object[@cname='GtkWindow']/method[@name='SetIconList']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GtkWindow']/property[@name='Screen']" name="new_flag">1</attr>
+  <attr path="/api/namespace/object[@cname='GtkWindow']/property[@cname='is-maximized']" name="name">Maximized</attr>
   <attr path="/api/namespace/object[@cname='GtkWindow']/signal[@name='ActivateDefault']" name="name">DefaultActivated</attr>
   <attr path="/api/namespace/object[@cname='GtkWindow']/signal[@name='ActivateFocus']" name="name">FocusActivated</attr>
   <attr path="/api/namespace/struct[@cname='GtkBindingArg']" name="hidden">1</attr>

--- a/gtk/gtk-api.raw
+++ b/gtk/gtk-api.raw
@@ -17,6 +17,13 @@
       <member cname="GTK_ALIGN_START" name="Start" />
       <member cname="GTK_ALIGN_END" name="End" />
       <member cname="GTK_ALIGN_CENTER" name="Center" />
+      <member cname="GTK_ALIGN_BASELINE" name="Baseline" />
+    </enum>
+    <enum name="ApplicationInhibitFlags" cname="GtkApplicationInhibitFlags" gtype="gtk_application_inhibit_flags_get_type" type="flags">
+      <member cname="GTK_APPLICATION_INHIBIT_LOGOUT" name="Logout" value="1 &lt;&lt; 0" />
+      <member cname="GTK_APPLICATION_INHIBIT_SWITCH" name="Switch" value="1 &lt;&lt; 1" />
+      <member cname="GTK_APPLICATION_INHIBIT_SUSPEND" name="Suspend" value="1 &lt;&lt; 2" />
+      <member cname="GTK_APPLICATION_INHIBIT_IDLE" name="Idle" value="1 &lt;&lt; 3" />
     </enum>
     <enum name="ArrowPlacement" cname="GtkArrowPlacement" gtype="gtk_arrow_placement_get_type" type="enum">
       <member cname="GTK_ARROWS_BOTH" name="Both" />
@@ -43,11 +50,22 @@
       <member cname="GTK_SHRINK" name="Shrink" value="1 &lt;&lt; 1" />
       <member cname="GTK_FILL" name="Fill" value="1 &lt;&lt; 2" />
     </enum>
+    <enum name="BaselinePosition" cname="GtkBaselinePosition" gtype="gtk_baseline_position_get_type" type="enum">
+      <member cname="GTK_BASELINE_POSITION_TOP" name="Top" />
+      <member cname="GTK_BASELINE_POSITION_CENTER" name="Center" />
+      <member cname="GTK_BASELINE_POSITION_BOTTOM" name="Bottom" />
+    </enum>
     <enum name="BorderStyle" cname="GtkBorderStyle" gtype="gtk_border_style_get_type" type="enum">
       <member cname="GTK_BORDER_STYLE_NONE" name="None" />
       <member cname="GTK_BORDER_STYLE_SOLID" name="Solid" />
       <member cname="GTK_BORDER_STYLE_INSET" name="Inset" />
       <member cname="GTK_BORDER_STYLE_OUTSET" name="Outset" />
+      <member cname="GTK_BORDER_STYLE_HIDDEN" name="Hidden" />
+      <member cname="GTK_BORDER_STYLE_DOTTED" name="Dotted" />
+      <member cname="GTK_BORDER_STYLE_DASHED" name="Dashed" />
+      <member cname="GTK_BORDER_STYLE_DOUBLE" name="Double" />
+      <member cname="GTK_BORDER_STYLE_GROOVE" name="Groove" />
+      <member cname="GTK_BORDER_STYLE_RIDGE" name="Ridge" />
     </enum>
     <enum name="BuilderError" cname="GtkBuilderError" gtype="gtk_builder_error_get_type" type="enum">
       <member cname="GTK_BUILDER_ERROR_INVALID_TYPE_FUNCTION" name="InvalidTypeFunction" />
@@ -59,6 +77,10 @@
       <member cname="GTK_BUILDER_ERROR_INVALID_VALUE" name="InvalidValue" />
       <member cname="GTK_BUILDER_ERROR_VERSION_MISMATCH" name="VersionMismatch" />
       <member cname="GTK_BUILDER_ERROR_DUPLICATE_ID" name="DuplicateId" />
+      <member cname="GTK_BUILDER_ERROR_OBJECT_TYPE_REFUSED" name="ObjectTypeRefused" />
+      <member cname="GTK_BUILDER_ERROR_TEMPLATE_MISMATCH" name="TemplateMismatch" />
+      <member cname="GTK_BUILDER_ERROR_INVALID_PROPERTY" name="InvalidProperty" />
+      <member cname="GTK_BUILDER_ERROR_INVALID_SIGNAL" name="InvalidSignal" />
     </enum>
     <enum name="ButtonBoxStyle" cname="GtkButtonBoxStyle" gtype="gtk_button_box_style_get_type" type="enum">
       <member cname="GTK_BUTTONBOX_SPREAD" name="Spread" value="1" />
@@ -66,6 +88,7 @@
       <member cname="GTK_BUTTONBOX_START" name="Start" />
       <member cname="GTK_BUTTONBOX_END" name="End" />
       <member cname="GTK_BUTTONBOX_CENTER" name="Center" />
+      <member cname="GTK_BUTTONBOX_EXPAND" name="Expand" />
     </enum>
     <enum name="ButtonsType" cname="GtkButtonsType" gtype="gtk_buttons_type_get_type" type="enum">
       <member cname="GTK_BUTTONS_NONE" name="None" />
@@ -97,6 +120,8 @@
       <member cname="GTK_CELL_RENDERER_INSENSITIVE" name="Insensitive" value="1 &lt;&lt; 2" />
       <member cname="GTK_CELL_RENDERER_SORTED" name="Sorted" value="1 &lt;&lt; 3" />
       <member cname="GTK_CELL_RENDERER_FOCUSED" name="Focused" value="1 &lt;&lt; 4" />
+      <member cname="GTK_CELL_RENDERER_EXPANDABLE" name="Expandable" value="1 &lt;&lt; 5" />
+      <member cname="GTK_CELL_RENDERER_EXPANDED" name="Expanded" value="1 &lt;&lt; 6" />
     </enum>
     <enum name="CornerType" cname="GtkCornerType" gtype="gtk_corner_type_get_type" type="enum">
       <member cname="GTK_CORNER_TOP_LEFT" name="TopLeft" />
@@ -106,6 +131,22 @@
     </enum>
     <enum name="CssProviderError" cname="GtkCssProviderError" gtype="gtk_css_provider_error_get_type" type="enum">
       <member cname="GTK_CSS_PROVIDER_ERROR_FAILED" name="Failed" />
+      <member cname="GTK_CSS_PROVIDER_ERROR_SYNTAX" name="Syntax" />
+      <member cname="GTK_CSS_PROVIDER_ERROR_IMPORT" name="Import" />
+      <member cname="GTK_CSS_PROVIDER_ERROR_NAME" name="Name" />
+      <member cname="GTK_CSS_PROVIDER_ERROR_DEPRECATED" name="Deprecated" />
+      <member cname="GTK_CSS_PROVIDER_ERROR_UNKNOWN_VALUE" name="UnknownValue" />
+    </enum>
+    <enum name="CssSectionType" cname="GtkCssSectionType" gtype="gtk_css_section_type_get_type" type="enum">
+      <member cname="GTK_CSS_SECTION_DOCUMENT" name="Document" />
+      <member cname="GTK_CSS_SECTION_IMPORT" name="Import" />
+      <member cname="GTK_CSS_SECTION_COLOR_DEFINITION" name="ColorDefinition" />
+      <member cname="GTK_CSS_SECTION_BINDING_SET" name="BindingSet" />
+      <member cname="GTK_CSS_SECTION_RULESET" name="Ruleset" />
+      <member cname="GTK_CSS_SECTION_SELECTOR" name="Selector" />
+      <member cname="GTK_CSS_SECTION_DECLARATION" name="Declaration" />
+      <member cname="GTK_CSS_SECTION_VALUE" name="Value" />
+      <member cname="GTK_CSS_SECTION_KEYFRAMES" name="Keyframes" />
     </enum>
     <enum name="DebugFlag" cname="GtkDebugFlag" gtype="gtk_debug_flag_get_type" type="flags">
       <member cname="GTK_DEBUG_MISC" name="Misc" value="1 &lt;&lt; 0" />
@@ -121,6 +162,13 @@
       <member cname="GTK_DEBUG_PRINTING" name="Printing" value="1 &lt;&lt; 10" />
       <member cname="GTK_DEBUG_BUILDER" name="Builder" value="1 &lt;&lt; 11" />
       <member cname="GTK_DEBUG_SIZE_REQUEST" name="SizeRequest" value="1 &lt;&lt; 12" />
+      <member cname="GTK_DEBUG_NO_CSS_CACHE" name="NoCssCache" value="1 &lt;&lt; 13" />
+      <member cname="GTK_DEBUG_BASELINES" name="Baselines" value="1 &lt;&lt; 14" />
+      <member cname="GTK_DEBUG_PIXEL_CACHE" name="PixelCache" value="1 &lt;&lt; 15" />
+      <member cname="GTK_DEBUG_NO_PIXEL_CACHE" name="NoPixelCache" value="1 &lt;&lt; 16" />
+      <member cname="GTK_DEBUG_INTERACTIVE" name="Interactive" value="1 &lt;&lt; 17" />
+      <member cname="GTK_DEBUG_TOUCHSCREEN" name="Touchscreen" value="1 &lt;&lt; 18" />
+      <member cname="GTK_DEBUG_ACTIONS" name="Actions" value="1 &lt;&lt; 19" />
     </enum>
     <enum name="DeleteType" cname="GtkDeleteType" gtype="gtk_delete_type_get_type" type="enum">
       <member cname="GTK_DELETE_CHARS" name="Chars" />
@@ -141,6 +189,7 @@
     <enum name="DialogFlags" cname="GtkDialogFlags" gtype="gtk_dialog_flags_get_type" type="flags">
       <member cname="GTK_DIALOG_MODAL" name="Modal" value="1 &lt;&lt; 0" />
       <member cname="GTK_DIALOG_DESTROY_WITH_PARENT" name="DestroyWithParent" value="1 &lt;&lt; 1" />
+      <member cname="GTK_DIALOG_USE_HEADER_BAR" name="UseHeaderBar" value="1 &lt;&lt; 2" />
     </enum>
     <enum name="DirectionType" cname="GtkDirectionType" gtype="gtk_direction_type_get_type" type="enum">
       <member cname="GTK_DIR_TAB_FORWARD" name="TabForward" />
@@ -161,6 +210,11 @@
     <enum name="EntryIconPosition" cname="GtkEntryIconPosition" gtype="gtk_entry_icon_position_get_type" type="enum">
       <member cname="GTK_ENTRY_ICON_PRIMARY" name="Primary" />
       <member cname="GTK_ENTRY_ICON_SECONDARY" name="Secondary" />
+    </enum>
+    <enum name="EventSequenceState" cname="GtkEventSequenceState" gtype="gtk_event_sequence_state_get_type" type="enum">
+      <member cname="GTK_EVENT_SEQUENCE_NONE" name="None" />
+      <member cname="GTK_EVENT_SEQUENCE_CLAIMED" name="Claimed" />
+      <member cname="GTK_EVENT_SEQUENCE_DENIED" name="Denied" />
     </enum>
     <enum name="ExpanderStyle" cname="GtkExpanderStyle" gtype="gtk_expander_style_get_type" type="enum">
       <member cname="GTK_EXPANDER_COLLAPSED" name="Collapsed" />
@@ -191,6 +245,14 @@
       <member cname="GTK_FILE_FILTER_DISPLAY_NAME" name="DisplayName" value="1 &lt;&lt; 2" />
       <member cname="GTK_FILE_FILTER_MIME_TYPE" name="MimeType" value="1 &lt;&lt; 3" />
     </enum>
+    <enum name="FontChooserProp" cname="GtkFontChooserProp" type="enum">
+      <member cname="GTK_FONT_CHOOSER_PROP_FIRST" name="First" value="0x4000" />
+      <member cname="GTK_FONT_CHOOSER_PROP_FONT" name="Font" />
+      <member cname="GTK_FONT_CHOOSER_PROP_FONT_DESC" name="FontDesc" />
+      <member cname="GTK_FONT_CHOOSER_PROP_PREVIEW_TEXT" name="PreviewText" />
+      <member cname="GTK_FONT_CHOOSER_PROP_SHOW_PREVIEW_ENTRY" name="ShowPreviewEntry" />
+      <member cname="GTK_FONT_CHOOSER_PROP_LAST" name="Last" />
+    </enum>
     <enum name="IMPreeditStyle" cname="GtkIMPreeditStyle" type="enum">
       <member cname="GTK_IM_PREEDIT_NOTHING" name="Nothing" />
       <member cname="GTK_IM_PREEDIT_CALLBACK" name="Callback" />
@@ -207,6 +269,10 @@
       <member cname="GTK_ICON_LOOKUP_USE_BUILTIN" name="UseBuiltin" value="1 &lt;&lt; 2" />
       <member cname="GTK_ICON_LOOKUP_GENERIC_FALLBACK" name="GenericFallback" value="1 &lt;&lt; 3" />
       <member cname="GTK_ICON_LOOKUP_FORCE_SIZE" name="ForceSize" value="1 &lt;&lt; 4" />
+      <member cname="GTK_ICON_LOOKUP_FORCE_REGULAR" name="ForceRegular" value="1 &lt;&lt; 5" />
+      <member cname="GTK_ICON_LOOKUP_FORCE_SYMBOLIC" name="ForceSymbolic" value="1 &lt;&lt; 6" />
+      <member cname="GTK_ICON_LOOKUP_DIR_LTR" name="DirLtr" value="1 &lt;&lt; 7" />
+      <member cname="GTK_ICON_LOOKUP_DIR_RTL" name="DirRtl" value="1 &lt;&lt; 8" />
     </enum>
     <enum name="IconSize" cname="GtkIconSize" gtype="gtk_icon_size_get_type" type="enum">
       <member cname="GTK_ICON_SIZE_INVALID" name="Invalid" />
@@ -237,6 +303,30 @@
       <member cname="GTK_IMAGE_ANIMATION" name="Animation" />
       <member cname="GTK_IMAGE_ICON_NAME" name="IconName" />
       <member cname="GTK_IMAGE_GICON" name="Gicon" />
+      <member cname="GTK_IMAGE_SURFACE" name="Surface" />
+    </enum>
+    <enum name="InputHints" cname="GtkInputHints" gtype="gtk_input_hints_get_type" type="flags">
+      <member cname="GTK_INPUT_HINT_NONE" name="None" />
+      <member cname="GTK_INPUT_HINT_SPELLCHECK" name="Spellcheck" value="1 &lt;&lt; 0" />
+      <member cname="GTK_INPUT_HINT_NO_SPELLCHECK" name="NoSpellcheck" value="1 &lt;&lt; 1" />
+      <member cname="GTK_INPUT_HINT_WORD_COMPLETION" name="WordCompletion" value="1 &lt;&lt; 2" />
+      <member cname="GTK_INPUT_HINT_LOWERCASE" name="Lowercase" value="1 &lt;&lt; 3" />
+      <member cname="GTK_INPUT_HINT_UPPERCASE_CHARS" name="UppercaseChars" value="1 &lt;&lt; 4" />
+      <member cname="GTK_INPUT_HINT_UPPERCASE_WORDS" name="UppercaseWords" value="1 &lt;&lt; 5" />
+      <member cname="GTK_INPUT_HINT_UPPERCASE_SENTENCES" name="UppercaseSentences" value="1 &lt;&lt; 6" />
+      <member cname="GTK_INPUT_HINT_INHIBIT_OSK" name="InhibitOsk" value="1 &lt;&lt; 7" />
+    </enum>
+    <enum name="InputPurpose" cname="GtkInputPurpose" gtype="gtk_input_purpose_get_type" type="enum">
+      <member cname="GTK_INPUT_PURPOSE_FREE_FORM" name="FreeForm" />
+      <member cname="GTK_INPUT_PURPOSE_ALPHA" name="Alpha" />
+      <member cname="GTK_INPUT_PURPOSE_DIGITS" name="Digits" />
+      <member cname="GTK_INPUT_PURPOSE_NUMBER" name="Number" />
+      <member cname="GTK_INPUT_PURPOSE_PHONE" name="Phone" />
+      <member cname="GTK_INPUT_PURPOSE_URL" name="Url" />
+      <member cname="GTK_INPUT_PURPOSE_EMAIL" name="Email" />
+      <member cname="GTK_INPUT_PURPOSE_NAME" name="Name" />
+      <member cname="GTK_INPUT_PURPOSE_PASSWORD" name="Password" />
+      <member cname="GTK_INPUT_PURPOSE_PIN" name="Pin" />
     </enum>
     <enum name="JunctionSides" cname="GtkJunctionSides" gtype="gtk_junction_sides_get_type" type="flags">
       <member cname="GTK_JUNCTION_NONE" name="None" />
@@ -255,6 +345,10 @@
       <member cname="GTK_JUSTIFY_CENTER" name="Center" />
       <member cname="GTK_JUSTIFY_FILL" name="Fill" />
     </enum>
+    <enum name="LevelBarMode" cname="GtkLevelBarMode" gtype="gtk_level_bar_mode_get_type" type="enum">
+      <member cname="GTK_LEVEL_BAR_MODE_CONTINUOUS" name="Continuous" />
+      <member cname="GTK_LEVEL_BAR_MODE_DISCRETE" name="Discrete" />
+    </enum>
     <enum name="License" cname="GtkLicense" gtype="gtk_license_get_type" type="enum">
       <member cname="GTK_LICENSE_UNKNOWN" name="Unknown" />
       <member cname="GTK_LICENSE_CUSTOM" name="Custom" />
@@ -265,12 +359,21 @@
       <member cname="GTK_LICENSE_BSD" name="Bsd" />
       <member cname="GTK_LICENSE_MIT_X11" name="MitX11" />
       <member cname="GTK_LICENSE_ARTISTIC" name="Artistic" />
+      <member cname="GTK_LICENSE_GPL_2_0_ONLY" name="Gpl20Only" />
+      <member cname="GTK_LICENSE_GPL_3_0_ONLY" name="Gpl30Only" />
+      <member cname="GTK_LICENSE_LGPL_2_1_ONLY" name="Lgpl21Only" />
+      <member cname="GTK_LICENSE_LGPL_3_0_ONLY" name="Lgpl30Only" />
     </enum>
     <enum name="MenuDirectionType" cname="GtkMenuDirectionType" gtype="gtk_menu_direction_type_get_type" type="enum">
       <member cname="GTK_MENU_DIR_PARENT" name="Parent" />
       <member cname="GTK_MENU_DIR_CHILD" name="Child" />
       <member cname="GTK_MENU_DIR_NEXT" name="Next" />
       <member cname="GTK_MENU_DIR_PREV" name="Prev" />
+    </enum>
+    <enum name="MenuTrackerItemRole" cname="GtkMenuTrackerItemRole" gtype="gtk_menu_tracker_item_role_get_type" type="enum">
+      <member cname="GTK_MENU_TRACKER_ITEM_ROLE_NORMAL" name="Normal" />
+      <member cname="GTK_MENU_TRACKER_ITEM_ROLE_CHECK" name="Check" />
+      <member cname="GTK_MENU_TRACKER_ITEM_ROLE_RADIO" name="Radio" />
     </enum>
     <enum name="MessageType" cname="GtkMessageType" gtype="gtk_message_type_get_type" type="enum">
       <member cname="GTK_MESSAGE_INFO" name="Info" />
@@ -330,6 +433,12 @@
       <member cname="GTK_PAGE_SET_EVEN" name="Even" />
       <member cname="GTK_PAGE_SET_ODD" name="Odd" />
     </enum>
+    <enum name="PanDirection" cname="GtkPanDirection" gtype="gtk_pan_direction_get_type" type="enum">
+      <member cname="GTK_PAN_DIRECTION_LEFT" name="Left" />
+      <member cname="GTK_PAN_DIRECTION_RIGHT" name="Right" />
+      <member cname="GTK_PAN_DIRECTION_UP" name="Up" />
+      <member cname="GTK_PAN_DIRECTION_DOWN" name="Down" />
+    </enum>
     <enum name="PathPriorityType" cname="GtkPathPriorityType" gtype="gtk_path_priority_type_get_type" type="enum">
       <member cname="GTK_PATH_PRIO_LOWEST" name="Lowest" />
       <member cname="GTK_PATH_PRIO_GTK" name="Gtk" value="4" />
@@ -342,6 +451,11 @@
       <member cname="GTK_PATH_WIDGET" name="Widget" />
       <member cname="GTK_PATH_WIDGET_CLASS" name="WidgetClass" />
       <member cname="GTK_PATH_CLASS" name="Class" />
+    </enum>
+    <enum name="PlacesOpenFlags" cname="GtkPlacesOpenFlags" gtype="gtk_places_open_flags_get_type" type="flags">
+      <member cname="GTK_PLACES_OPEN_NORMAL" name="Normal" value="1 &lt;&lt; 0" />
+      <member cname="GTK_PLACES_OPEN_NEW_TAB" name="NewTab" value="1 &lt;&lt; 1" />
+      <member cname="GTK_PLACES_OPEN_NEW_WINDOW" name="NewWindow" value="1 &lt;&lt; 2" />
     </enum>
     <enum name="PolicyType" cname="GtkPolicyType" gtype="gtk_policy_type_get_type" type="enum">
       <member cname="GTK_POLICY_ALWAYS" name="Always" />
@@ -412,13 +526,19 @@
       <member cname="GTK_PRINT_STATUS_FINISHED" name="Finished" />
       <member cname="GTK_PRINT_STATUS_FINISHED_ABORTED" name="FinishedAborted" />
     </enum>
+    <enum name="PropagationPhase" cname="GtkPropagationPhase" gtype="gtk_propagation_phase_get_type" type="enum">
+      <member cname="GTK_PHASE_NONE" name="None" />
+      <member cname="GTK_PHASE_CAPTURE" name="Capture" />
+      <member cname="GTK_PHASE_BUBBLE" name="Bubble" />
+      <member cname="GTK_PHASE_TARGET" name="Target" />
+    </enum>
     <enum name="RcFlags" cname="GtkRcFlags" gtype="gtk_rc_flags_get_type" type="flags">
       <member cname="GTK_RC_FG" name="Fg" value="1 &lt;&lt; 0" />
       <member cname="GTK_RC_BG" name="Bg" value="1 &lt;&lt; 1" />
       <member cname="GTK_RC_TEXT" name="Text" value="1 &lt;&lt; 2" />
       <member cname="GTK_RC_BASE" name="Base" value="1 &lt;&lt; 3" />
     </enum>
-    <enum name="RcTokenType" cname="GtkRcTokenType" deprecated="1" gtype="gtk_rc_token_type_get_type" type="enum">
+    <enum name="RcTokenType" cname="GtkRcTokenType" gtype="gtk_rc_token_type_get_type" type="enum">
       <member cname="GTK_RC_TOKEN_INVALID" name="Invalid" value="G_TOKEN_LAST" />
       <member cname="GTK_RC_TOKEN_INCLUDE" name="Include" />
       <member cname="GTK_RC_TOKEN_NORMAL" name="Normal" />
@@ -506,6 +626,7 @@
       <member cname="GTK_REGION_ODD" name="Odd" value="1 &lt;&lt; 1" />
       <member cname="GTK_REGION_FIRST" name="First" value="1 &lt;&lt; 2" />
       <member cname="GTK_REGION_LAST" name="Last" value="1 &lt;&lt; 3" />
+      <member cname="GTK_REGION_ONLY" name="Only" value="1 &lt;&lt; 4" />
       <member cname="GTK_REGION_SORTED" name="Sorted" value="1 &lt;&lt; 5" />
     </enum>
     <enum name="ReliefStyle" cname="GtkReliefStyle" gtype="gtk_relief_style_get_type" type="enum">
@@ -530,6 +651,14 @@
       <member cname="GTK_RESPONSE_NO" name="No" value="-9" />
       <member cname="GTK_RESPONSE_APPLY" name="Apply" value="-10" />
       <member cname="GTK_RESPONSE_HELP" name="Help" value="-11" />
+    </enum>
+    <enum name="RevealerTransitionType" cname="GtkRevealerTransitionType" gtype="gtk_revealer_transition_type_get_type" type="enum">
+      <member cname="GTK_REVEALER_TRANSITION_TYPE_NONE" name="None" />
+      <member cname="GTK_REVEALER_TRANSITION_TYPE_CROSSFADE" name="Crossfade" />
+      <member cname="GTK_REVEALER_TRANSITION_TYPE_SLIDE_RIGHT" name="SlideRight" />
+      <member cname="GTK_REVEALER_TRANSITION_TYPE_SLIDE_LEFT" name="SlideLeft" />
+      <member cname="GTK_REVEALER_TRANSITION_TYPE_SLIDE_UP" name="SlideUp" />
+      <member cname="GTK_REVEALER_TRANSITION_TYPE_SLIDE_DOWN" name="SlideDown" />
     </enum>
     <enum name="ScrollStep" cname="GtkScrollStep" gtype="gtk_scroll_step_get_type" type="enum">
       <member cname="GTK_SCROLL_STEPS" name="Steps" />
@@ -588,10 +717,7 @@
     <enum name="SizeRequestMode" cname="GtkSizeRequestMode" gtype="gtk_size_request_mode_get_type" type="enum">
       <member cname="GTK_SIZE_REQUEST_HEIGHT_FOR_WIDTH" name="HeightForWidth" />
       <member cname="GTK_SIZE_REQUEST_WIDTH_FOR_HEIGHT" name="WidthForHeight" />
-    </enum>
-    <enum name="SliceSideModifier" cname="GtkSliceSideModifier" type="enum">
-      <member cname="GTK_SLICE_REPEAT" name="Repeat" />
-      <member cname="GTK_SLICE_STRETCH" name="Stretch" />
+      <member cname="GTK_SIZE_REQUEST_CONSTANT_SIZE" name="ConstantSize" />
     </enum>
     <enum name="SortType" cname="GtkSortType" gtype="gtk_sort_type_get_type" type="enum">
       <member cname="GTK_SORT_ASCENDING" name="Ascending" />
@@ -610,6 +736,28 @@
       <member cname="GTK_SPIN_END" name="End" />
       <member cname="GTK_SPIN_USER_DEFINED" name="UserDefined" />
     </enum>
+    <enum name="StackTransitionType" cname="GtkStackTransitionType" gtype="gtk_stack_transition_type_get_type" type="enum">
+      <member cname="GTK_STACK_TRANSITION_TYPE_NONE" name="None" />
+      <member cname="GTK_STACK_TRANSITION_TYPE_CROSSFADE" name="Crossfade" />
+      <member cname="GTK_STACK_TRANSITION_TYPE_SLIDE_RIGHT" name="SlideRight" />
+      <member cname="GTK_STACK_TRANSITION_TYPE_SLIDE_LEFT" name="SlideLeft" />
+      <member cname="GTK_STACK_TRANSITION_TYPE_SLIDE_UP" name="SlideUp" />
+      <member cname="GTK_STACK_TRANSITION_TYPE_SLIDE_DOWN" name="SlideDown" />
+      <member cname="GTK_STACK_TRANSITION_TYPE_SLIDE_LEFT_RIGHT" name="SlideLeftRight" />
+      <member cname="GTK_STACK_TRANSITION_TYPE_SLIDE_UP_DOWN" name="SlideUpDown" />
+      <member cname="GTK_STACK_TRANSITION_TYPE_OVER_UP" name="OverUp" />
+      <member cname="GTK_STACK_TRANSITION_TYPE_OVER_DOWN" name="OverDown" />
+      <member cname="GTK_STACK_TRANSITION_TYPE_OVER_LEFT" name="OverLeft" />
+      <member cname="GTK_STACK_TRANSITION_TYPE_OVER_RIGHT" name="OverRight" />
+      <member cname="GTK_STACK_TRANSITION_TYPE_UNDER_UP" name="UnderUp" />
+      <member cname="GTK_STACK_TRANSITION_TYPE_UNDER_DOWN" name="UnderDown" />
+      <member cname="GTK_STACK_TRANSITION_TYPE_UNDER_LEFT" name="UnderLeft" />
+      <member cname="GTK_STACK_TRANSITION_TYPE_UNDER_RIGHT" name="UnderRight" />
+      <member cname="GTK_STACK_TRANSITION_TYPE_OVER_UP_DOWN" name="OverUpDown" />
+      <member cname="GTK_STACK_TRANSITION_TYPE_OVER_DOWN_UP" name="OverDownUp" />
+      <member cname="GTK_STACK_TRANSITION_TYPE_OVER_LEFT_RIGHT" name="OverLeftRight" />
+      <member cname="GTK_STACK_TRANSITION_TYPE_OVER_RIGHT_LEFT" name="OverRightLeft" />
+    </enum>
     <enum name="StateFlags" cname="GtkStateFlags" gtype="gtk_state_flags_get_type" type="flags">
       <member cname="GTK_STATE_FLAG_NORMAL" name="Normal" />
       <member cname="GTK_STATE_FLAG_ACTIVE" name="Active" value="1 &lt;&lt; 0" />
@@ -618,6 +766,12 @@
       <member cname="GTK_STATE_FLAG_INSENSITIVE" name="Insensitive" value="1 &lt;&lt; 3" />
       <member cname="GTK_STATE_FLAG_INCONSISTENT" name="Inconsistent" value="1 &lt;&lt; 4" />
       <member cname="GTK_STATE_FLAG_FOCUSED" name="Focused" value="1 &lt;&lt; 5" />
+      <member cname="GTK_STATE_FLAG_BACKDROP" name="Backdrop" value="1 &lt;&lt; 6" />
+      <member cname="GTK_STATE_FLAG_DIR_LTR" name="DirLtr" value="1 &lt;&lt; 7" />
+      <member cname="GTK_STATE_FLAG_DIR_RTL" name="DirRtl" value="1 &lt;&lt; 8" />
+      <member cname="GTK_STATE_FLAG_LINK" name="Link" value="1 &lt;&lt; 9" />
+      <member cname="GTK_STATE_FLAG_VISITED" name="Visited" value="1 &lt;&lt; 10" />
+      <member cname="GTK_STATE_FLAG_CHECKED" name="Checked" value="1 &lt;&lt; 11" />
     </enum>
     <enum name="StateType" cname="GtkStateType" gtype="gtk_state_type_get_type" type="enum">
       <member cname="GTK_STATE_NORMAL" name="Normal" />
@@ -649,6 +803,10 @@
       <member cname="GTK_TEXT_SEARCH_TEXT_ONLY" name="TextOnly" value="1 &lt;&lt; 1" />
       <member cname="GTK_TEXT_SEARCH_CASE_INSENSITIVE" name="CaseInsensitive" value="1 &lt;&lt; 2" />
     </enum>
+    <enum name="TextViewLayer" cname="GtkTextViewLayer" gtype="gtk_text_view_layer_get_type" type="enum">
+      <member cname="GTK_TEXT_VIEW_LAYER_BELOW" name="Below" />
+      <member cname="GTK_TEXT_VIEW_LAYER_ABOVE" name="Above" />
+    </enum>
     <enum name="TextWindowType" cname="GtkTextWindowType" gtype="gtk_text_window_type_get_type" type="enum">
       <member cname="GTK_TEXT_WINDOW_PRIVATE" name="Private" />
       <member cname="GTK_TEXT_WINDOW_WIDGET" name="Widget" />
@@ -657,17 +815,6 @@
       <member cname="GTK_TEXT_WINDOW_RIGHT" name="Right" />
       <member cname="GTK_TEXT_WINDOW_TOP" name="Top" />
       <member cname="GTK_TEXT_WINDOW_BOTTOM" name="Bottom" />
-    </enum>
-    <enum name="TimelineDirection" cname="GtkTimelineDirection" type="enum">
-      <member cname="GTK_TIMELINE_DIRECTION_FORWARD" name="Forward" />
-      <member cname="GTK_TIMELINE_DIRECTION_BACKWARD" name="Backward" />
-    </enum>
-    <enum name="TimelineProgressType" cname="GtkTimelineProgressType" type="enum">
-      <member cname="GTK_TIMELINE_PROGRESS_LINEAR" name="Linear" />
-      <member cname="GTK_TIMELINE_PROGRESS_EASE" name="Ease" />
-      <member cname="GTK_TIMELINE_PROGRESS_EASE_IN" name="EaseIn" />
-      <member cname="GTK_TIMELINE_PROGRESS_EASE_OUT" name="EaseOut" />
-      <member cname="GTK_TIMELINE_PROGRESS_EASE_IN_OUT" name="EaseInOut" />
     </enum>
     <enum name="ToolPaletteDragTargets" cname="GtkToolPaletteDragTargets" gtype="gtk_tool_palette_drag_targets_get_type" type="flags">
       <member cname="GTK_TOOL_PALETTE_DRAG_ITEMS" name="Items" value="1 &lt;&lt; 0" />
@@ -718,7 +865,7 @@
       <member cname="GTK_UI_MANAGER_POPUP_WITH_ACCELS" name="PopupWithAccels" value="1 &lt;&lt; 9" />
     </enum>
     <enum name="Unit" cname="GtkUnit" gtype="gtk_unit_get_type" type="enum">
-      <member cname="GTK_UNIT_PIXEL" name="Pixel" />
+      <member cname="GTK_UNIT_NONE" name="None" />
       <member cname="GTK_UNIT_POINTS" name="Points" />
       <member cname="GTK_UNIT_INCH" name="Inch" />
       <member cname="GTK_UNIT_MM" name="Mm" />
@@ -761,25 +908,6 @@
       <member cname="GTK_WRAP_WORD" name="Word" />
       <member cname="GTK_WRAP_WORD_CHAR" name="WordChar" />
     </enum>
-    <enum name="LoadState" cname="LoadState" type="enum">
-      <member cname="LOAD_EMPTY" name="Empty" />
-      <member cname="LOAD_PRELOAD" name="Preload" />
-      <member cname="LOAD_LOADING" name="Loading" />
-      <member cname="LOAD_FINISHED" name="Finished" />
-    </enum>
-    <enum name="LocationMode" cname="LocationMode" type="enum">
-      <member cname="LOCATION_MODE_PATH_BAR" name="PathBar" />
-      <member cname="LOCATION_MODE_FILENAME_ENTRY" name="FilenameEntry" />
-    </enum>
-    <enum name="OperationMode" cname="OperationMode" type="enum">
-      <member cname="OPERATION_MODE_BROWSE" name="Browse" />
-      <member cname="OPERATION_MODE_SEARCH" name="Search" />
-      <member cname="OPERATION_MODE_RECENT" name="Recent" />
-    </enum>
-    <enum name="ReloadState" cname="ReloadState" type="enum">
-      <member cname="RELOAD_EMPTY" name="Empty" />
-      <member cname="RELOAD_HAS_FOLDER" name="HasFolder" />
-    </enum>
     <callback name="AccelGroupActivate" cname="GtkAccelGroupActivate">
       <return-type type="gboolean" />
       <parameters>
@@ -811,6 +939,12 @@
       <return-type type="gint" />
       <parameters>
         <parameter type="gint" name="current_page" />
+        <parameter type="gpointer" name="data" />
+      </parameters>
+    </callback>
+    <callback name="BookmarksChangedFunc" cname="GtkBookmarksChangedFunc">
+      <return-type type="void" />
+      <parameters>
         <parameter type="gpointer" name="data" />
       </parameters>
     </callback>
@@ -967,6 +1101,37 @@
         <parameter type="gpointer" name="data" />
       </parameters>
     </callback>
+    <callback name="FlowBoxFilterFunc" cname="GtkFlowBoxFilterFunc">
+      <return-type type="gboolean" />
+      <parameters>
+        <parameter type="GtkFlowBoxChild*" name="child" />
+        <parameter type="gpointer" name="user_data" />
+      </parameters>
+    </callback>
+    <callback name="FlowBoxForeachFunc" cname="GtkFlowBoxForeachFunc">
+      <return-type type="void" />
+      <parameters>
+        <parameter type="GtkFlowBox*" name="box" />
+        <parameter type="GtkFlowBoxChild*" name="child" />
+        <parameter type="gpointer" name="user_data" />
+      </parameters>
+    </callback>
+    <callback name="FlowBoxSortFunc" cname="GtkFlowBoxSortFunc">
+      <return-type type="gint" />
+      <parameters>
+        <parameter type="GtkFlowBoxChild*" name="child1" />
+        <parameter type="GtkFlowBoxChild*" name="child2" />
+        <parameter type="gpointer" name="user_data" />
+      </parameters>
+    </callback>
+    <callback name="FontFilterFunc" cname="GtkFontFilterFunc">
+      <return-type type="gboolean" />
+      <parameters>
+        <parameter type="const-PangoFontFamily*" name="family" />
+        <parameter type="const-PangoFontFace*" name="face" />
+        <parameter type="gpointer" name="data" />
+      </parameters>
+    </callback>
     <callback name="IconViewForeachFunc" cname="GtkIconViewForeachFunc">
       <return-type type="void" />
       <parameters>
@@ -983,6 +1148,37 @@
         <parameter type="gpointer" name="func_data" />
       </parameters>
     </callback>
+    <callback name="ListBoxFilterFunc" cname="GtkListBoxFilterFunc">
+      <return-type type="gboolean" />
+      <parameters>
+        <parameter type="GtkListBoxRow*" name="row" />
+        <parameter type="gpointer" name="user_data" />
+      </parameters>
+    </callback>
+    <callback name="ListBoxForeachFunc" cname="GtkListBoxForeachFunc">
+      <return-type type="void" />
+      <parameters>
+        <parameter type="GtkListBox*" name="box" />
+        <parameter type="GtkListBoxRow*" name="row" />
+        <parameter type="gpointer" name="user_data" />
+      </parameters>
+    </callback>
+    <callback name="ListBoxSortFunc" cname="GtkListBoxSortFunc">
+      <return-type type="gint" />
+      <parameters>
+        <parameter type="GtkListBoxRow*" name="row1" />
+        <parameter type="GtkListBoxRow*" name="row2" />
+        <parameter type="gpointer" name="user_data" />
+      </parameters>
+    </callback>
+    <callback name="ListBoxUpdateHeaderFunc" cname="GtkListBoxUpdateHeaderFunc">
+      <return-type type="void" />
+      <parameters>
+        <parameter type="GtkListBoxRow*" name="row" />
+        <parameter type="GtkListBoxRow*" name="before" />
+        <parameter type="gpointer" name="user_data" />
+      </parameters>
+    </callback>
     <callback name="MenuDetachFunc" cname="GtkMenuDetachFunc">
       <return-type type="void" />
       <parameters>
@@ -997,6 +1193,21 @@
         <parameter type="gint*" name="x" />
         <parameter type="gint*" name="y" />
         <parameter type="gboolean*" name="push_in" />
+        <parameter type="gpointer" name="user_data" />
+      </parameters>
+    </callback>
+    <callback name="MenuTrackerInsertFunc" cname="GtkMenuTrackerInsertFunc">
+      <return-type type="void" />
+      <parameters>
+        <parameter type="GtkMenuTrackerItem*" name="item" />
+        <parameter type="gint" name="position" />
+        <parameter type="gpointer" name="user_data" />
+      </parameters>
+    </callback>
+    <callback name="MenuTrackerRemoveFunc" cname="GtkMenuTrackerRemoveFunc">
+      <return-type type="void" />
+      <parameters>
+        <parameter type="gint" name="position" />
         <parameter type="gpointer" name="user_data" />
       </parameters>
     </callback>
@@ -1118,6 +1329,14 @@
       <parameters>
         <parameter type="GtkTextTag*" name="tag" />
         <parameter type="gpointer" name="data" />
+      </parameters>
+    </callback>
+    <callback name="TickCallback" cname="GtkTickCallback">
+      <return-type type="gboolean" />
+      <parameters>
+        <parameter type="GtkWidget*" name="widget" />
+        <parameter type="GdkFrameClock*" name="frame_clock" />
+        <parameter type="gpointer" name="user_data" />
       </parameters>
     </callback>
     <callback name="TranslateFunc" cname="GtkTranslateFunc">
@@ -1253,6 +1472,204 @@
         <parameter type="gpointer" name="user_data" />
       </parameters>
     </callback>
+    <interface name="Actionable" cname="GtkActionable">
+      <class_struct cname="GtkActionableInterface">
+        <field name="GIface" cname="g_iface" type="GTypeInterface" />
+        <method vm="get_action_name" />
+        <method vm="set_action_name" />
+        <method vm="get_action_target_value" />
+        <method vm="set_action_target_value" />
+      </class_struct>
+      <property name="ActionName" cname="action-name" type="gchar*" readable="true" writeable="true" />
+      <property name="ActionTarget" cname="action-target" type="variant" readable="true" writeable="true" />
+      <virtual_method name="GetActionName" cname="get_action_name">
+        <return-type type="gchar*" />
+        <parameters />
+      </virtual_method>
+      <virtual_method name="SetActionName" cname="set_action_name">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="const-gchar*" name="action_name" />
+        </parameters>
+      </virtual_method>
+      <virtual_method name="GetActionTargetValue" cname="get_action_target_value">
+        <return-type type="GVariant*" />
+        <parameters />
+      </virtual_method>
+      <virtual_method name="SetActionTargetValue" cname="set_action_target_value">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GVariant*" name="target_value" />
+        </parameters>
+      </virtual_method>
+      <method name="GetActionName" cname="gtk_actionable_get_action_name">
+        <return-type type="const-gchar*" />
+      </method>
+      <method name="GetActionTargetValue" cname="gtk_actionable_get_action_target_value">
+        <return-type type="GVariant*" />
+      </method>
+      <method name="GetType" cname="gtk_actionable_get_type" shared="true">
+        <return-type type="GType" />
+      </method>
+      <method name="SetActionName" cname="gtk_actionable_set_action_name">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="const-gchar*" name="action_name" />
+        </parameters>
+      </method>
+      <method name="SetActionTarget" cname="gtk_actionable_set_action_target">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="const-gchar*" name="format_string" />
+          <parameter ellipsis="true" />
+        </parameters>
+      </method>
+      <method name="SetActionTargetValue" cname="gtk_actionable_set_action_target_value">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GVariant*" name="target_value" />
+        </parameters>
+      </method>
+      <method name="SetDetailedActionName" cname="gtk_actionable_set_detailed_action_name">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="const-gchar*" name="detailed_action_name" />
+        </parameters>
+      </method>
+    </interface>
+    <interface name="ActionObservable" cname="GtkActionObservable">
+      <class_struct cname="GtkActionObservableInterface">
+        <field name="GIface" cname="g_iface" type="GTypeInterface" />
+        <method vm="register_observer" />
+        <method vm="unregister_observer" />
+      </class_struct>
+      <virtual_method name="RegisterObserver" cname="register_observer">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="const-gchar*" name="action_name" />
+          <parameter type="GtkActionObserver*" name="observer" />
+        </parameters>
+      </virtual_method>
+      <virtual_method name="UnregisterObserver" cname="unregister_observer">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="const-gchar*" name="action_name" />
+          <parameter type="GtkActionObserver*" name="observer" />
+        </parameters>
+      </virtual_method>
+      <method name="GetType" cname="gtk_action_observable_get_type" shared="true">
+        <return-type type="GType" />
+      </method>
+      <method name="RegisterObserver" cname="gtk_action_observable_register_observer">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="const-gchar*" name="action_name" />
+          <parameter type="GtkActionObserver*" name="observer" />
+        </parameters>
+      </method>
+      <method name="UnregisterObserver" cname="gtk_action_observable_unregister_observer">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="const-gchar*" name="action_name" />
+          <parameter type="GtkActionObserver*" name="observer" />
+        </parameters>
+      </method>
+    </interface>
+    <interface name="ActionObserver" cname="GtkActionObserver">
+      <class_struct cname="GtkActionObserverInterface">
+        <field name="GIface" cname="g_iface" type="GTypeInterface" />
+        <method vm="action_added" />
+        <method vm="action_enabled_changed" />
+        <method vm="action_state_changed" />
+        <method vm="action_removed" />
+        <method vm="primary_accel_changed" />
+      </class_struct>
+      <virtual_method name="ActionAdded" cname="action_added">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkActionObservable*" name="observable" />
+          <parameter type="const-gchar*" name="action_name" />
+          <parameter type="const-GVariantType*" name="parameter_type" />
+          <parameter type="gboolean" name="enabled" />
+          <parameter type="GVariant*" name="state" />
+        </parameters>
+      </virtual_method>
+      <virtual_method name="ActionEnabledChanged" cname="action_enabled_changed">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkActionObservable*" name="observable" />
+          <parameter type="const-gchar*" name="action_name" />
+          <parameter type="gboolean" name="enabled" />
+        </parameters>
+      </virtual_method>
+      <virtual_method name="ActionStateChanged" cname="action_state_changed">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkActionObservable*" name="observable" />
+          <parameter type="const-gchar*" name="action_name" />
+          <parameter type="GVariant*" name="state" />
+        </parameters>
+      </virtual_method>
+      <virtual_method name="ActionRemoved" cname="action_removed">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkActionObservable*" name="observable" />
+          <parameter type="const-gchar*" name="action_name" />
+        </parameters>
+      </virtual_method>
+      <virtual_method name="PrimaryAccelChanged" cname="primary_accel_changed">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkActionObservable*" name="observable" />
+          <parameter type="const-gchar*" name="action_name" />
+          <parameter type="const-gchar*" name="action_and_target" />
+        </parameters>
+      </virtual_method>
+      <method name="ActionAdded" cname="gtk_action_observer_action_added">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkActionObservable*" name="observable" />
+          <parameter type="const-gchar*" name="action_name" />
+          <parameter type="const-GVariantType*" name="parameter_type" />
+          <parameter type="gboolean" name="enabled" />
+          <parameter type="GVariant*" name="state" />
+        </parameters>
+      </method>
+      <method name="ActionEnabledChanged" cname="gtk_action_observer_action_enabled_changed">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkActionObservable*" name="observable" />
+          <parameter type="const-gchar*" name="action_name" />
+          <parameter type="gboolean" name="enabled" />
+        </parameters>
+      </method>
+      <method name="ActionRemoved" cname="gtk_action_observer_action_removed">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkActionObservable*" name="observable" />
+          <parameter type="const-gchar*" name="action_name" />
+        </parameters>
+      </method>
+      <method name="ActionStateChanged" cname="gtk_action_observer_action_state_changed">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkActionObservable*" name="observable" />
+          <parameter type="const-gchar*" name="action_name" />
+          <parameter type="GVariant*" name="state" />
+        </parameters>
+      </method>
+      <method name="GetType" cname="gtk_action_observer_get_type" shared="true">
+        <return-type type="GType" />
+      </method>
+      <method name="PrimaryAccelChanged" cname="gtk_action_observer_primary_accel_changed">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkActionObservable*" name="observable" />
+          <parameter type="const-gchar*" name="action_name" />
+          <parameter type="const-gchar*" name="action_and_target" />
+        </parameters>
+      </method>
+    </interface>
     <interface name="Activatable" cname="GtkActivatable">
       <class_struct cname="GtkActivatableIface">
         <field name="GIface" cname="g_iface" type="GTypeInterface" />
@@ -1274,34 +1691,34 @@
           <parameter type="GtkAction*" name="action" />
         </parameters>
       </virtual_method>
-      <method name="DoSetRelatedAction" cname="gtk_activatable_do_set_related_action">
+      <method name="DoSetRelatedAction" cname="gtk_activatable_do_set_related_action" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="GtkAction*" name="action" />
         </parameters>
       </method>
-      <method name="GetRelatedAction" cname="gtk_activatable_get_related_action">
+      <method name="GetRelatedAction" cname="gtk_activatable_get_related_action" deprecated="1">
         <return-type type="GtkAction*" />
       </method>
-      <method name="GetType" cname="gtk_activatable_get_type" shared="true">
+      <method name="GetType" cname="gtk_activatable_get_type" deprecated="1" shared="true">
         <return-type type="GType" />
       </method>
-      <method name="GetUseActionAppearance" cname="gtk_activatable_get_use_action_appearance">
+      <method name="GetUseActionAppearance" cname="gtk_activatable_get_use_action_appearance" deprecated="1">
         <return-type type="gboolean" />
       </method>
-      <method name="SetRelatedAction" cname="gtk_activatable_set_related_action">
+      <method name="SetRelatedAction" cname="gtk_activatable_set_related_action" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="GtkAction*" name="action" />
         </parameters>
       </method>
-      <method name="SetUseActionAppearance" cname="gtk_activatable_set_use_action_appearance">
+      <method name="SetUseActionAppearance" cname="gtk_activatable_set_use_action_appearance" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="gboolean" name="use_appearance" />
         </parameters>
       </method>
-      <method name="SyncActionProperties" cname="gtk_activatable_sync_action_properties">
+      <method name="SyncActionProperties" cname="gtk_activatable_sync_action_properties" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="GtkAction*" name="action" />
@@ -1658,6 +2075,78 @@
         </parameters>
       </method>
     </interface>
+    <interface name="ColorChooser" cname="GtkColorChooser">
+      <class_struct cname="GtkColorChooserInterface">
+        <field name="BaseInterface" cname="base_interface" type="GTypeInterface" />
+        <method vm="get_rgba" />
+        <method vm="set_rgba" />
+        <method vm="add_palette" />
+        <method signal_vm="color_activated" />
+        <field name="Padding" cname="padding" type="gpointer" array_len="12" />
+      </class_struct>
+      <property name="Rgba" cname="rgba" type="GdkRgba" readable="true" writeable="true" />
+      <property name="UseAlpha" cname="use-alpha" type="gboolean" readable="true" writeable="true" />
+      <signal name="ColorActivated" cname="color-activated" when="FIRST" field_name="color_activated">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="const-GdkRGBA*" name="color" />
+        </parameters>
+      </signal>
+      <virtual_method name="GetRgba" cname="get_rgba">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GdkRGBA*" name="color" />
+        </parameters>
+      </virtual_method>
+      <virtual_method name="SetRgba" cname="set_rgba">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="const-GdkRGBA*" name="color" />
+        </parameters>
+      </virtual_method>
+      <virtual_method name="AddPalette" cname="add_palette">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkOrientation" name="orientation" />
+          <parameter type="gint" name="colors_per_line" />
+          <parameter type="gint" name="n_colors" />
+          <parameter type="GdkRGBA*" name="colors" />
+        </parameters>
+      </virtual_method>
+      <method name="AddPalette" cname="gtk_color_chooser_add_palette">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkOrientation" name="orientation" />
+          <parameter type="gint" name="colors_per_line" />
+          <parameter type="gint" name="n_colors" />
+          <parameter type="GdkRGBA*" name="colors" />
+        </parameters>
+      </method>
+      <method name="GetRgba" cname="gtk_color_chooser_get_rgba">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GdkRGBA*" name="color" />
+        </parameters>
+      </method>
+      <method name="GetType" cname="gtk_color_chooser_get_type" shared="true">
+        <return-type type="GType" />
+      </method>
+      <method name="GetUseAlpha" cname="gtk_color_chooser_get_use_alpha">
+        <return-type type="gboolean" />
+      </method>
+      <method name="SetRgba" cname="gtk_color_chooser_set_rgba">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="const-GdkRGBA*" name="color" />
+        </parameters>
+      </method>
+      <method name="SetUseAlpha" cname="gtk_color_chooser_set_use_alpha">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gboolean" name="use_alpha" />
+        </parameters>
+      </method>
+    </interface>
     <interface name="Editable" cname="GtkEditable">
       <class_struct cname="GtkEditableInterface">
         <field name="BaseIface" cname="base_iface" type="GTypeInterface" />
@@ -1813,6 +2302,7 @@
         <method vm="set_current_folder" />
         <method vm="get_current_folder" />
         <method vm="set_current_name" />
+        <method vm="get_current_name" />
         <method vm="select_file" />
         <method vm="unselect_file" />
         <method vm="select_all" />
@@ -1879,6 +2369,10 @@
         <parameters>
           <parameter type="const-gchar*" name="name" />
         </parameters>
+      </virtual_method>
+      <virtual_method name="GetCurrentName" cname="get_current_name">
+        <return-type type="gchar*" />
+        <parameters />
       </virtual_method>
       <virtual_method name="SelectFile" cname="select_file">
         <return-type type="gboolean" />
@@ -1983,6 +2477,9 @@
         <return-type type="GFile*" />
       </method>
       <method name="GetCurrentFolderUri" cname="gtk_file_chooser_get_current_folder_uri">
+        <return-type type="gchar*" />
+      </method>
+      <method name="GetCurrentName" cname="gtk_file_chooser_get_current_name">
         <return-type type="gchar*" />
       </method>
       <method name="GetDoOverwriteConfirmation" cname="gtk_file_chooser_get_do_overwrite_confirmation">
@@ -2222,6 +2719,103 @@
         <return-type type="void" />
         <parameters>
           <parameter type="const-char*" name="uri" />
+        </parameters>
+      </method>
+    </interface>
+    <interface name="FontChooser" cname="GtkFontChooser">
+      <class_struct cname="GtkFontChooserIface">
+        <field name="BaseIface" cname="base_iface" type="GTypeInterface" />
+        <method vm="get_font_family" />
+        <method vm="get_font_face" />
+        <method vm="get_font_size" />
+        <method vm="set_filter_func" />
+        <method signal_vm="font_activated" />
+        <field name="Padding" cname="padding" type="gpointer" array_len="12" />
+      </class_struct>
+      <property name="Font" cname="font" type="gchar*" readable="true" writeable="true" />
+      <property name="FontDesc" cname="font-desc" type="PangoFontDescription" readable="true" writeable="true" />
+      <property name="PreviewText" cname="preview-text" type="gchar*" readable="true" writeable="true" />
+      <property name="ShowPreviewEntry" cname="show-preview-entry" type="gboolean" readable="true" writeable="true" />
+      <signal name="FontActivated" cname="font-activated" when="FIRST" field_name="font_activated">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="const-gchar*" name="fontname" />
+        </parameters>
+      </signal>
+      <virtual_method name="GetFontFamily" cname="get_font_family">
+        <return-type type="PangoFontFamily*" />
+        <parameters />
+      </virtual_method>
+      <virtual_method name="GetFontFace" cname="get_font_face">
+        <return-type type="PangoFontFace*" />
+        <parameters />
+      </virtual_method>
+      <virtual_method name="GetFontSize" cname="get_font_size">
+        <return-type type="gint" />
+        <parameters />
+      </virtual_method>
+      <virtual_method name="SetFilterFunc" cname="set_filter_func">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkFontFilterFunc" name="filter" />
+          <parameter type="gpointer" name="user_data" />
+          <parameter type="GDestroyNotify" name="destroy" />
+        </parameters>
+      </virtual_method>
+      <method name="GetFont" cname="gtk_font_chooser_get_font">
+        <return-type type="gchar*" />
+      </method>
+      <method name="GetFontDesc" cname="gtk_font_chooser_get_font_desc">
+        <return-type type="PangoFontDescription*" />
+      </method>
+      <method name="GetFontFace" cname="gtk_font_chooser_get_font_face">
+        <return-type type="PangoFontFace*" />
+      </method>
+      <method name="GetFontFamily" cname="gtk_font_chooser_get_font_family">
+        <return-type type="PangoFontFamily*" />
+      </method>
+      <method name="GetFontSize" cname="gtk_font_chooser_get_font_size">
+        <return-type type="gint" />
+      </method>
+      <method name="GetPreviewText" cname="gtk_font_chooser_get_preview_text">
+        <return-type type="gchar*" />
+      </method>
+      <method name="GetShowPreviewEntry" cname="gtk_font_chooser_get_show_preview_entry">
+        <return-type type="gboolean" />
+      </method>
+      <method name="GetType" cname="gtk_font_chooser_get_type" shared="true">
+        <return-type type="GType" />
+      </method>
+      <method name="SetFilterFunc" cname="gtk_font_chooser_set_filter_func">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkFontFilterFunc" name="filter" />
+          <parameter type="gpointer" name="user_data" />
+          <parameter type="GDestroyNotify" name="destroy" />
+        </parameters>
+      </method>
+      <method name="SetFont" cname="gtk_font_chooser_set_font">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="const-gchar*" name="fontname" />
+        </parameters>
+      </method>
+      <method name="SetFontDesc" cname="gtk_font_chooser_set_font_desc">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="const-PangoFontDescription*" name="font_desc" />
+        </parameters>
+      </method>
+      <method name="SetPreviewText" cname="gtk_font_chooser_set_preview_text">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="const-gchar*" name="text" />
+        </parameters>
+      </method>
+      <method name="SetShowPreviewEntry" cname="gtk_font_chooser_set_show_preview_entry">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gboolean" name="show_preview_entry" />
         </parameters>
       </method>
     </interface>
@@ -2650,13 +3244,13 @@
           <parameter type="GtkWidgetPath*" name="path" />
         </parameters>
       </virtual_method>
-      <method name="GetIconFactory" cname="gtk_style_provider_get_icon_factory">
+      <method name="GetIconFactory" cname="gtk_style_provider_get_icon_factory" deprecated="1">
         <return-type type="GtkIconFactory*" />
         <parameters>
           <parameter type="GtkWidgetPath*" name="path" />
         </parameters>
       </method>
-      <method name="GetStyle" cname="gtk_style_provider_get_style">
+      <method name="GetStyle" cname="gtk_style_provider_get_style" deprecated="1">
         <return-type type="GtkStyleProperties*" />
         <parameters>
           <parameter type="GtkWidgetPath*" name="path" />
@@ -3157,6 +3751,15 @@
           <parameter type="gint*" name="new_order" />
         </parameters>
       </method>
+      <method name="RowsReorderedWithLength" cname="gtk_tree_model_rows_reordered_with_length">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkTreePath*" name="path" />
+          <parameter type="GtkTreeIter*" name="iter" />
+          <parameter type="gint*" name="new_order" />
+          <parameter type="gint" name="length" />
+        </parameters>
+      </method>
       <method name="UnrefNode" cname="gtk_tree_model_unref_node">
         <return-type type="void" />
         <parameters>
@@ -3270,20 +3873,6 @@
           <parameter type="const-gchar*" name="uri" />
         </parameters>
       </signal>
-      <property name="ProgramName" cname="program-name" type="gchar*" readable="true" writeable="true" />
-      <property name="Version" cname="version" type="gchar*" readable="true" writeable="true" />
-      <property name="Copyright" cname="copyright" type="gchar*" readable="true" writeable="true" />
-      <property name="Comments" cname="comments" type="gchar*" readable="true" writeable="true" />
-      <property name="License" cname="license" type="gchar*" readable="true" writeable="true" />
-      <property name="LicenseType" cname="license-type" type="GtkLicense" readable="true" writeable="true" />
-      <property name="Website" cname="website" type="gchar*" readable="true" writeable="true" />
-      <property name="WebsiteLabel" cname="website-label" type="gchar*" readable="true" writeable="true" />
-      <property name="Authors" cname="authors" type="GStrv" readable="true" writeable="true" />
-      <property name="Documenters" cname="documenters" type="GStrv" readable="true" writeable="true" />
-      <property name="Artists" cname="artists" type="GStrv" readable="true" writeable="true" />
-      <property name="TranslatorCredits" cname="translator-credits" type="gchar*" readable="true" writeable="true" />
-      <property name="Logo" cname="logo" type="GdkPixbuf" readable="true" writeable="true" />
-      <property name="LogoIconName" cname="logo-icon-name" type="gchar*" readable="true" writeable="true" />
       <property name="WrapLicense" cname="wrap-license" type="gboolean" readable="true" writeable="true" />
       <virtual_method name="GtkReserved1" cname="_gtk_reserved1" shared="true" padding="true">
         <return-type type="void" />
@@ -3297,6 +3886,13 @@
       <virtual_method name="GtkReserved4" cname="_gtk_reserved4" shared="true" padding="true">
         <return-type type="void" />
       </virtual_method>
+      <method name="AddCreditSection" cname="gtk_about_dialog_add_credit_section">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="const-gchar*" name="section_name" />
+          <parameter type="const-gchar**" name="people" />
+        </parameters>
+      </method>
       <method name="GetArtists" cname="gtk_about_dialog_get_artists">
         <return-type type="const-gchar**" />
       </method>
@@ -3447,7 +4043,6 @@
         <method vm="_gtk_reserved4" />
       </class_struct>
       <field name="Priv" cname="priv" type="GtkAccelGroupPrivate*" />
-      <property name="IsLocked" cname="is-locked" type="gboolean" readable="true" />
       <property name="ModifierMask" cname="modifier-mask" type="GdkModifierType" readable="true" />
       <signal name="AccelActivate" cname="accel-activate">
         <return-type type="gboolean" />
@@ -3568,7 +4163,6 @@
         <method vm="_gtk_reserved4" />
       </class_struct>
       <field name="Priv" cname="priv" type="GtkAccelLabelPrivate*" />
-      <property name="AccelClosure" cname="accel-closure" type="GClosure" readable="true" writeable="true" />
       <property name="AccelWidget" cname="accel-widget" type="GtkWidget" readable="true" writeable="true" />
       <virtual_method name="GtkReserved1" cname="_gtk_reserved1" shared="true" padding="true">
         <return-type type="void" />
@@ -3582,6 +4176,13 @@
       <virtual_method name="GtkReserved4" cname="_gtk_reserved4" shared="true" padding="true">
         <return-type type="void" />
       </virtual_method>
+      <method name="GetAccel" cname="gtk_accel_label_get_accel">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="guint*" name="accelerator_key" />
+          <parameter type="GdkModifierType*" name="accelerator_mods" />
+        </parameters>
+      </method>
       <method name="GetAccelWidget" cname="gtk_accel_label_get_accel_widget">
         <return-type type="GtkWidget*" />
       </method>
@@ -3598,6 +4199,13 @@
       </constructor>
       <method name="Refetch" cname="gtk_accel_label_refetch">
         <return-type type="gboolean" />
+      </method>
+      <method name="SetAccel" cname="gtk_accel_label_set_accel">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="guint" name="accelerator_key" />
+          <parameter type="GdkModifierType" name="accelerator_mods" />
+        </parameters>
       </method>
       <method name="SetAccelClosure" cname="gtk_accel_label_set_accel_closure">
         <return-type type="void" />
@@ -3721,21 +4329,24 @@
       <class_struct cname="GtkAccessibleClass">
         <field name="ParentClass" cname="parent_class" type="AtkObjectClass" />
         <method vm="connect_widget_destroyed" />
-        <method vm="_gtk_reserved1" />
-        <method vm="_gtk_reserved2" />
+        <method vm="widget_set" />
+        <method vm="widget_unset" />
         <method vm="_gtk_reserved3" />
         <method vm="_gtk_reserved4" />
       </class_struct>
       <field name="Priv" cname="priv" type="GtkAccessiblePrivate*" />
+      <property name="Widget" cname="widget" type="GtkWidget" readable="true" writeable="true" />
       <virtual_method name="ConnectWidgetDestroyed" cname="connect_widget_destroyed">
         <return-type type="void" />
         <parameters />
       </virtual_method>
-      <virtual_method name="GtkReserved1" cname="_gtk_reserved1" shared="true" padding="true">
+      <virtual_method name="WidgetSet" cname="widget_set">
         <return-type type="void" />
+        <parameters />
       </virtual_method>
-      <virtual_method name="GtkReserved2" cname="_gtk_reserved2" shared="true" padding="true">
+      <virtual_method name="WidgetUnset" cname="widget_unset">
         <return-type type="void" />
+        <parameters />
       </virtual_method>
       <virtual_method name="GtkReserved3" cname="_gtk_reserved3" shared="true" padding="true">
         <return-type type="void" />
@@ -3743,7 +4354,7 @@
       <virtual_method name="GtkReserved4" cname="_gtk_reserved4" shared="true" padding="true">
         <return-type type="void" />
       </virtual_method>
-      <method name="ConnectWidgetDestroyed" cname="gtk_accessible_connect_widget_destroyed">
+      <method name="ConnectWidgetDestroyed" cname="gtk_accessible_connect_widget_destroyed" deprecated="1">
         <return-type type="void" />
       </method>
       <method name="GetType" cname="gtk_accessible_get_type" shared="true">
@@ -3835,91 +4446,91 @@
       <implements>
         <interface cname="GtkBuildable" />
       </implements>
-      <method name="Activate" cname="gtk_action_activate">
+      <method name="Activate" cname="gtk_action_activate" deprecated="1">
         <return-type type="void" />
       </method>
-      <method name="BlockActivate" cname="gtk_action_block_activate">
+      <method name="BlockActivate" cname="gtk_action_block_activate" deprecated="1">
         <return-type type="void" />
       </method>
-      <method name="ConnectAccelerator" cname="gtk_action_connect_accelerator">
+      <method name="ConnectAccelerator" cname="gtk_action_connect_accelerator" deprecated="1">
         <return-type type="void" />
       </method>
-      <method name="CreateIcon" cname="gtk_action_create_icon">
+      <method name="CreateIcon" cname="gtk_action_create_icon" deprecated="1">
         <return-type type="GtkWidget*" />
         <parameters>
           <parameter type="GtkIconSize" name="icon_size" />
         </parameters>
       </method>
-      <method name="CreateMenu" cname="gtk_action_create_menu">
+      <method name="CreateMenu" cname="gtk_action_create_menu" deprecated="1">
         <return-type type="GtkWidget*" />
       </method>
-      <method name="CreateMenuItem" cname="gtk_action_create_menu_item">
+      <method name="CreateMenuItem" cname="gtk_action_create_menu_item" deprecated="1">
         <return-type type="GtkWidget*" />
       </method>
-      <method name="CreateToolItem" cname="gtk_action_create_tool_item">
+      <method name="CreateToolItem" cname="gtk_action_create_tool_item" deprecated="1">
         <return-type type="GtkWidget*" />
       </method>
-      <method name="DisconnectAccelerator" cname="gtk_action_disconnect_accelerator">
+      <method name="DisconnectAccelerator" cname="gtk_action_disconnect_accelerator" deprecated="1">
         <return-type type="void" />
       </method>
-      <method name="GetAccelClosure" cname="gtk_action_get_accel_closure">
+      <method name="GetAccelClosure" cname="gtk_action_get_accel_closure" deprecated="1">
         <return-type type="GClosure*" />
       </method>
-      <method name="GetAccelPath" cname="gtk_action_get_accel_path">
+      <method name="GetAccelPath" cname="gtk_action_get_accel_path" deprecated="1">
         <return-type type="const-gchar*" />
       </method>
-      <method name="GetAlwaysShowImage" cname="gtk_action_get_always_show_image">
+      <method name="GetAlwaysShowImage" cname="gtk_action_get_always_show_image" deprecated="1">
         <return-type type="gboolean" />
       </method>
-      <method name="GetGicon" cname="gtk_action_get_gicon">
+      <method name="GetGicon" cname="gtk_action_get_gicon" deprecated="1">
         <return-type type="GIcon*" />
       </method>
-      <method name="GetIconName" cname="gtk_action_get_icon_name">
+      <method name="GetIconName" cname="gtk_action_get_icon_name" deprecated="1">
         <return-type type="const-gchar*" />
       </method>
-      <method name="GetIsImportant" cname="gtk_action_get_is_important">
+      <method name="GetIsImportant" cname="gtk_action_get_is_important" deprecated="1">
         <return-type type="gboolean" />
       </method>
-      <method name="GetLabel" cname="gtk_action_get_label">
+      <method name="GetLabel" cname="gtk_action_get_label" deprecated="1">
         <return-type type="const-gchar*" />
       </method>
-      <method name="GetName" cname="gtk_action_get_name">
+      <method name="GetName" cname="gtk_action_get_name" deprecated="1">
         <return-type type="const-gchar*" />
       </method>
-      <method name="GetProxies" cname="gtk_action_get_proxies">
+      <method name="GetProxies" cname="gtk_action_get_proxies" deprecated="1">
         <return-type type="GSList*" />
       </method>
-      <method name="GetSensitive" cname="gtk_action_get_sensitive">
+      <method name="GetSensitive" cname="gtk_action_get_sensitive" deprecated="1">
         <return-type type="gboolean" />
       </method>
-      <method name="GetShortLabel" cname="gtk_action_get_short_label">
+      <method name="GetShortLabel" cname="gtk_action_get_short_label" deprecated="1">
         <return-type type="const-gchar*" />
       </method>
-      <method name="GetStockId" cname="gtk_action_get_stock_id">
+      <method name="GetStockId" cname="gtk_action_get_stock_id" deprecated="1">
         <return-type type="const-gchar*" />
       </method>
-      <method name="GetTooltip" cname="gtk_action_get_tooltip">
+      <method name="GetTooltip" cname="gtk_action_get_tooltip" deprecated="1">
         <return-type type="const-gchar*" />
       </method>
-      <method name="GetType" cname="gtk_action_get_type" shared="true">
+      <method name="GetType" cname="gtk_action_get_type" deprecated="1" shared="true">
         <return-type type="GType" />
       </method>
-      <method name="GetVisible" cname="gtk_action_get_visible">
+      <method name="GetVisible" cname="gtk_action_get_visible" deprecated="1">
         <return-type type="gboolean" />
       </method>
-      <method name="GetVisibleHorizontal" cname="gtk_action_get_visible_horizontal">
+      <method name="GetVisibleHorizontal" cname="gtk_action_get_visible_horizontal" deprecated="1">
         <return-type type="gboolean" />
       </method>
-      <method name="GetVisibleVertical" cname="gtk_action_get_visible_vertical">
+      <method name="GetVisibleVertical" cname="gtk_action_get_visible_vertical" deprecated="1">
         <return-type type="gboolean" />
       </method>
-      <method name="IsSensitive" cname="gtk_action_is_sensitive">
+      <method name="IsSensitive" cname="gtk_action_is_sensitive" deprecated="1">
         <return-type type="gboolean" />
       </method>
-      <method name="IsVisible" cname="gtk_action_is_visible">
+      <method name="IsVisible" cname="gtk_action_is_visible" deprecated="1">
         <return-type type="gboolean" />
       </method>
-      <constructor cname="gtk_action_new">
+      <constructor cname="gtk_action_new" deprecated="1">
         <parameters>
           <parameter type="const-gchar*" name="name" />
           <parameter type="const-gchar*" name="label" />
@@ -3927,92 +4538,143 @@
           <parameter type="const-gchar*" name="stock_id" />
         </parameters>
       </constructor>
-      <method name="SetAccelGroup" cname="gtk_action_set_accel_group">
+      <method name="SetAccelGroup" cname="gtk_action_set_accel_group" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="GtkAccelGroup*" name="accel_group" />
         </parameters>
       </method>
-      <method name="SetAccelPath" cname="gtk_action_set_accel_path">
+      <method name="SetAccelPath" cname="gtk_action_set_accel_path" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="const-gchar*" name="accel_path" />
         </parameters>
       </method>
-      <method name="SetAlwaysShowImage" cname="gtk_action_set_always_show_image">
+      <method name="SetAlwaysShowImage" cname="gtk_action_set_always_show_image" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="gboolean" name="always_show" />
         </parameters>
       </method>
-      <method name="SetGicon" cname="gtk_action_set_gicon">
+      <method name="SetGicon" cname="gtk_action_set_gicon" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="GIcon*" name="icon" />
         </parameters>
       </method>
-      <method name="SetIconName" cname="gtk_action_set_icon_name">
+      <method name="SetIconName" cname="gtk_action_set_icon_name" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="const-gchar*" name="icon_name" />
         </parameters>
       </method>
-      <method name="SetIsImportant" cname="gtk_action_set_is_important">
+      <method name="SetIsImportant" cname="gtk_action_set_is_important" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="gboolean" name="is_important" />
         </parameters>
       </method>
-      <method name="SetLabel" cname="gtk_action_set_label">
+      <method name="SetLabel" cname="gtk_action_set_label" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="const-gchar*" name="label" />
         </parameters>
       </method>
-      <method name="SetSensitive" cname="gtk_action_set_sensitive">
+      <method name="SetSensitive" cname="gtk_action_set_sensitive" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="gboolean" name="sensitive" />
         </parameters>
       </method>
-      <method name="SetShortLabel" cname="gtk_action_set_short_label">
+      <method name="SetShortLabel" cname="gtk_action_set_short_label" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="const-gchar*" name="short_label" />
         </parameters>
       </method>
-      <method name="SetStockId" cname="gtk_action_set_stock_id">
+      <method name="SetStockId" cname="gtk_action_set_stock_id" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="const-gchar*" name="stock_id" />
         </parameters>
       </method>
-      <method name="SetTooltip" cname="gtk_action_set_tooltip">
+      <method name="SetTooltip" cname="gtk_action_set_tooltip" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="const-gchar*" name="tooltip" />
         </parameters>
       </method>
-      <method name="SetVisible" cname="gtk_action_set_visible">
+      <method name="SetVisible" cname="gtk_action_set_visible" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="gboolean" name="visible" />
         </parameters>
       </method>
-      <method name="SetVisibleHorizontal" cname="gtk_action_set_visible_horizontal">
+      <method name="SetVisibleHorizontal" cname="gtk_action_set_visible_horizontal" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="gboolean" name="visible_horizontal" />
         </parameters>
       </method>
-      <method name="SetVisibleVertical" cname="gtk_action_set_visible_vertical">
+      <method name="SetVisibleVertical" cname="gtk_action_set_visible_vertical" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="gboolean" name="visible_vertical" />
         </parameters>
       </method>
-      <method name="UnblockActivate" cname="gtk_action_unblock_activate">
+      <method name="UnblockActivate" cname="gtk_action_unblock_activate" deprecated="1">
         <return-type type="void" />
+      </method>
+    </object>
+    <object name="ActionBar" cname="GtkActionBar" parent="GtkBin">
+      <class_struct cname="GtkActionBarClass">
+        <field name="ParentClass" cname="parent_class" type="GtkBinClass" />
+        <method vm="_gtk_reserved1" />
+        <method vm="_gtk_reserved2" />
+        <method vm="_gtk_reserved3" />
+        <method vm="_gtk_reserved4" />
+      </class_struct>
+      <childprop name="PackType" cname="pack-type" type="GtkPackType" readable="true" writeable="true" />
+      <childprop name="Position" cname="position" type="gint" readable="true" />
+      <virtual_method name="GtkReserved1" cname="_gtk_reserved1" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <virtual_method name="GtkReserved2" cname="_gtk_reserved2" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <virtual_method name="GtkReserved3" cname="_gtk_reserved3" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <virtual_method name="GtkReserved4" cname="_gtk_reserved4" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <implements>
+        <interface cname="GtkBuildable" />
+      </implements>
+      <method name="GetCenterWidget" cname="gtk_action_bar_get_center_widget">
+        <return-type type="GtkWidget*" />
+      </method>
+      <method name="GetType" cname="gtk_action_bar_get_type" shared="true">
+        <return-type type="GType" />
+      </method>
+      <constructor cname="gtk_action_bar_new" />
+      <method name="PackEnd" cname="gtk_action_bar_pack_end">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkWidget*" name="child" />
+        </parameters>
+      </method>
+      <method name="PackStart" cname="gtk_action_bar_pack_start">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkWidget*" name="child" />
+        </parameters>
+      </method>
+      <method name="SetCenterWidget" cname="gtk_action_bar_set_center_widget">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkWidget*" name="center_widget" />
+        </parameters>
       </method>
     </object>
     <object name="ActionGroup" cname="GtkActionGroup" parent="GObject">
@@ -4028,6 +4690,7 @@
       <property name="Name" cname="name" type="gchar*" readable="true" writeable="true" construct-only="true" />
       <property name="Sensitive" cname="sensitive" type="gboolean" readable="true" writeable="true" />
       <property name="Visible" cname="visible" type="gboolean" readable="true" writeable="true" />
+      <property name="AccelGroup" cname="accel-group" type="GtkAccelGroup" readable="true" writeable="true" />
       <signal name="ConnectProxy" cname="connect-proxy">
         <return-type type="void" />
         <parameters>
@@ -4075,20 +4738,20 @@
       <implements>
         <interface cname="GtkBuildable" />
       </implements>
-      <method name="AddAction" cname="gtk_action_group_add_action">
+      <method name="AddAction" cname="gtk_action_group_add_action" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="GtkAction*" name="action" />
         </parameters>
       </method>
-      <method name="AddActionWithAccel" cname="gtk_action_group_add_action_with_accel">
+      <method name="AddActionWithAccel" cname="gtk_action_group_add_action_with_accel" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="GtkAction*" name="action" />
           <parameter type="const-gchar*" name="accelerator" />
         </parameters>
       </method>
-      <method name="AddActions" cname="gtk_action_group_add_actions">
+      <method name="AddActions" cname="gtk_action_group_add_actions" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="const-GtkActionEntry*" name="entries" />
@@ -4096,7 +4759,7 @@
           <parameter type="gpointer" name="user_data" />
         </parameters>
       </method>
-      <method name="AddActionsFull" cname="gtk_action_group_add_actions_full">
+      <method name="AddActionsFull" cname="gtk_action_group_add_actions_full" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="const-GtkActionEntry*" name="entries" />
@@ -4105,7 +4768,7 @@
           <parameter type="GDestroyNotify" name="destroy" />
         </parameters>
       </method>
-      <method name="AddRadioActions" cname="gtk_action_group_add_radio_actions">
+      <method name="AddRadioActions" cname="gtk_action_group_add_radio_actions" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="const-GtkRadioActionEntry*" name="entries" />
@@ -4115,7 +4778,7 @@
           <parameter type="gpointer" name="user_data" />
         </parameters>
       </method>
-      <method name="AddRadioActionsFull" cname="gtk_action_group_add_radio_actions_full">
+      <method name="AddRadioActionsFull" cname="gtk_action_group_add_radio_actions_full" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="const-GtkRadioActionEntry*" name="entries" />
@@ -4126,7 +4789,7 @@
           <parameter type="GDestroyNotify" name="destroy" />
         </parameters>
       </method>
-      <method name="AddToggleActions" cname="gtk_action_group_add_toggle_actions">
+      <method name="AddToggleActions" cname="gtk_action_group_add_toggle_actions" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="const-GtkToggleActionEntry*" name="entries" />
@@ -4134,7 +4797,7 @@
           <parameter type="gpointer" name="user_data" />
         </parameters>
       </method>
-      <method name="AddToggleActionsFull" cname="gtk_action_group_add_toggle_actions_full">
+      <method name="AddToggleActionsFull" cname="gtk_action_group_add_toggle_actions_full" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="const-GtkToggleActionEntry*" name="entries" />
@@ -4143,45 +4806,54 @@
           <parameter type="GDestroyNotify" name="destroy" />
         </parameters>
       </method>
-      <method name="GetAction" cname="gtk_action_group_get_action">
+      <method name="GetAccelGroup" cname="gtk_action_group_get_accel_group" deprecated="1">
+        <return-type type="GtkAccelGroup*" />
+      </method>
+      <method name="GetAction" cname="gtk_action_group_get_action" deprecated="1">
         <return-type type="GtkAction*" />
         <parameters>
           <parameter type="const-gchar*" name="action_name" />
         </parameters>
       </method>
-      <method name="GetName" cname="gtk_action_group_get_name">
+      <method name="GetName" cname="gtk_action_group_get_name" deprecated="1">
         <return-type type="const-gchar*" />
       </method>
-      <method name="GetSensitive" cname="gtk_action_group_get_sensitive">
+      <method name="GetSensitive" cname="gtk_action_group_get_sensitive" deprecated="1">
         <return-type type="gboolean" />
       </method>
-      <method name="GetType" cname="gtk_action_group_get_type" shared="true">
+      <method name="GetType" cname="gtk_action_group_get_type" deprecated="1" shared="true">
         <return-type type="GType" />
       </method>
-      <method name="GetVisible" cname="gtk_action_group_get_visible">
+      <method name="GetVisible" cname="gtk_action_group_get_visible" deprecated="1">
         <return-type type="gboolean" />
       </method>
-      <method name="ListActions" cname="gtk_action_group_list_actions">
+      <method name="ListActions" cname="gtk_action_group_list_actions" deprecated="1">
         <return-type type="GList*" />
       </method>
-      <constructor cname="gtk_action_group_new">
+      <constructor cname="gtk_action_group_new" deprecated="1">
         <parameters>
           <parameter type="const-gchar*" name="name" />
         </parameters>
       </constructor>
-      <method name="RemoveAction" cname="gtk_action_group_remove_action">
+      <method name="RemoveAction" cname="gtk_action_group_remove_action" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="GtkAction*" name="action" />
         </parameters>
       </method>
-      <method name="SetSensitive" cname="gtk_action_group_set_sensitive">
+      <method name="SetAccelGroup" cname="gtk_action_group_set_accel_group" deprecated="1">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkAccelGroup*" name="accel_group" />
+        </parameters>
+      </method>
+      <method name="SetSensitive" cname="gtk_action_group_set_sensitive" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="gboolean" name="sensitive" />
         </parameters>
       </method>
-      <method name="SetTranslateFunc" cname="gtk_action_group_set_translate_func">
+      <method name="SetTranslateFunc" cname="gtk_action_group_set_translate_func" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="GtkTranslateFunc" name="func" />
@@ -4189,22 +4861,125 @@
           <parameter type="GDestroyNotify" name="notify" />
         </parameters>
       </method>
-      <method name="SetTranslationDomain" cname="gtk_action_group_set_translation_domain">
+      <method name="SetTranslationDomain" cname="gtk_action_group_set_translation_domain" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="const-gchar*" name="domain" />
         </parameters>
       </method>
-      <method name="SetVisible" cname="gtk_action_group_set_visible">
+      <method name="SetVisible" cname="gtk_action_group_set_visible" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="gboolean" name="visible" />
         </parameters>
       </method>
-      <method name="TranslateString" cname="gtk_action_group_translate_string">
+      <method name="TranslateString" cname="gtk_action_group_translate_string" deprecated="1">
         <return-type type="const-gchar*" />
         <parameters>
           <parameter type="const-gchar*" name="string" />
+        </parameters>
+      </method>
+    </object>
+    <object name="ActionHelper" cname="GtkActionHelper" parent="GObject">
+      <property name="Active" cname="active" type="gboolean" readable="true" />
+      <implements>
+        <interface cname="GtkActionObserver" />
+      </implements>
+      <method name="Activate" cname="gtk_action_helper_activate">
+        <return-type type="void" />
+      </method>
+      <method name="GetActionName" cname="gtk_action_helper_get_action_name">
+        <return-type type="const-gchar*" />
+      </method>
+      <method name="GetActionTargetValue" cname="gtk_action_helper_get_action_target_value">
+        <return-type type="GVariant*" />
+      </method>
+      <method name="GetActive" cname="gtk_action_helper_get_active">
+        <return-type type="gboolean" />
+      </method>
+      <method name="GetEnabled" cname="gtk_action_helper_get_enabled">
+        <return-type type="gboolean" />
+      </method>
+      <method name="GetType" cname="gtk_action_helper_get_type" shared="true">
+        <return-type type="GType" />
+      </method>
+      <constructor cname="gtk_action_helper_new">
+        <parameters>
+          <parameter type="GtkActionable*" name="widget" />
+        </parameters>
+      </constructor>
+      <method name="SetActionName" cname="gtk_action_helper_set_action_name">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="const-gchar*" name="action_name" />
+        </parameters>
+      </method>
+      <method name="SetActionTargetValue" cname="gtk_action_helper_set_action_target_value">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GVariant*" name="action_target" />
+        </parameters>
+      </method>
+    </object>
+    <object name="ActionMuxer" cname="GtkActionMuxer" parent="GObject">
+      <signal name="PrimaryAccelChanged" cname="primary-accel-changed" when="LAST">
+        <return-type type="void" />
+        <parameters>
+          <parameter name="p0" type="gchar*" />
+          <parameter name="p1" type="gchar*" />
+        </parameters>
+      </signal>
+      <property name="Parent" cname="parent" type="GtkActionMuxer" readable="true" writeable="true" />
+      <implements>
+        <interface cname="GActionGroup" />
+        <interface cname="GtkActionObservable" />
+      </implements>
+      <method name="GetParent" cname="gtk_action_muxer_get_parent">
+        <return-type type="GtkActionMuxer*" />
+      </method>
+      <method name="GetPrimaryAccel" cname="gtk_action_muxer_get_primary_accel">
+        <return-type type="const-gchar*" />
+        <parameters>
+          <parameter type="const-gchar*" name="action_and_target" />
+        </parameters>
+      </method>
+      <method name="GetType" cname="gtk_action_muxer_get_type" shared="true">
+        <return-type type="GType" />
+      </method>
+      <method name="Insert" cname="gtk_action_muxer_insert">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="const-gchar*" name="prefix" />
+          <parameter type="GActionGroup*" name="action_group" />
+        </parameters>
+      </method>
+      <method name="ListPrefixes" cname="gtk_action_muxer_list_prefixes">
+        <return-type type="gchar**" />
+      </method>
+      <method name="Lookup" cname="gtk_action_muxer_lookup">
+        <return-type type="GActionGroup*" />
+        <parameters>
+          <parameter type="const-gchar*" name="prefix" />
+        </parameters>
+      </method>
+      <constructor cname="gtk_action_muxer_new" />
+      <method name="Remove" cname="gtk_action_muxer_remove">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="const-gchar*" name="prefix" />
+        </parameters>
+      </method>
+      <method name="SetParent" cname="gtk_action_muxer_set_parent">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkActionMuxer*" name="parent" />
+        </parameters>
+      </method>
+      <method name="SetPrimaryAccel" cname="gtk_action_muxer_set_primary_accel">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="const-gchar*" name="action_and_target" />
+          <parameter type="const-gchar*" name="primary_accel" />
         </parameters>
       </method>
     </object>
@@ -4267,6 +5042,9 @@
         </parameters>
       </method>
       <method name="GetLower" cname="gtk_adjustment_get_lower">
+        <return-type type="gdouble" />
+      </method>
+      <method name="GetMinimumIncrement" cname="gtk_adjustment_get_minimum_increment">
         <return-type type="gdouble" />
       </method>
       <method name="GetPageIncrement" cname="gtk_adjustment_get_page_increment">
@@ -4366,7 +5144,7 @@
       <virtual_method name="GtkReserved4" cname="_gtk_reserved4" shared="true" padding="true">
         <return-type type="void" />
       </virtual_method>
-      <method name="GetPadding" cname="gtk_alignment_get_padding">
+      <method name="GetPadding" cname="gtk_alignment_get_padding" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="guint*" name="padding_top" />
@@ -4375,10 +5153,10 @@
           <parameter type="guint*" name="padding_right" />
         </parameters>
       </method>
-      <method name="GetType" cname="gtk_alignment_get_type" shared="true">
+      <method name="GetType" cname="gtk_alignment_get_type" deprecated="1" shared="true">
         <return-type type="GType" />
       </method>
-      <constructor cname="gtk_alignment_new">
+      <constructor cname="gtk_alignment_new" deprecated="1">
         <parameters>
           <parameter type="gfloat" name="xalign" />
           <parameter type="gfloat" name="yalign" />
@@ -4386,7 +5164,7 @@
           <parameter type="gfloat" name="yscale" />
         </parameters>
       </constructor>
-      <method name="Set" cname="gtk_alignment_set">
+      <method name="Set" cname="gtk_alignment_set" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="gfloat" name="xalign" />
@@ -4395,7 +5173,7 @@
           <parameter type="gfloat" name="yscale" />
         </parameters>
       </method>
-      <method name="SetPadding" cname="gtk_alignment_set_padding">
+      <method name="SetPadding" cname="gtk_alignment_set_padding" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="guint" name="padding_top" />
@@ -4408,20 +5186,96 @@
     <object name="Application" cname="GtkApplication" parent="GApplication">
       <class_struct cname="GtkApplicationClass">
         <field name="ParentClass" cname="parent_class" type="GApplicationClass" />
-        <field name="Padding" cname="padding" type="gpointer" array_len="16" />
+        <method signal_vm="window_added" />
+        <method signal_vm="window_removed" />
+        <field name="Padding" cname="padding" type="gpointer" array_len="12" />
       </class_struct>
       <field name="Priv" cname="priv" type="GtkApplicationPrivate*" />
+      <signal name="WindowAdded" cname="window-added" when="FIRST" field_name="window_added">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkWindow*" name="window" />
+        </parameters>
+      </signal>
+      <signal name="WindowRemoved" cname="window-removed" when="FIRST" field_name="window_removed">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkWindow*" name="window" />
+        </parameters>
+      </signal>
+      <property name="RegisterSession" cname="register-session" type="gboolean" readable="true" writeable="true" />
+      <property name="AppMenu" cname="app-menu" type="GMenuModel" readable="true" writeable="true" />
+      <property name="Menubar" cname="menubar" type="GMenuModel" readable="true" writeable="true" />
+      <property name="ActiveWindow" cname="active-window" type="GtkWindow" readable="true" />
+      <method name="AddAccelerator" cname="gtk_application_add_accelerator" deprecated="1">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="const-gchar*" name="accelerator" />
+          <parameter type="const-gchar*" name="action_name" />
+          <parameter type="GVariant*" name="parameter" />
+        </parameters>
+      </method>
       <method name="AddWindow" cname="gtk_application_add_window">
         <return-type type="void" />
         <parameters>
           <parameter type="GtkWindow*" name="window" />
         </parameters>
       </method>
+      <method name="GetAccelsForAction" cname="gtk_application_get_accels_for_action">
+        <return-type type="gchar**" />
+        <parameters>
+          <parameter type="const-gchar*" name="detailed_action_name" />
+        </parameters>
+      </method>
+      <method name="GetActionsForAccel" cname="gtk_application_get_actions_for_accel">
+        <return-type type="gchar**" />
+        <parameters>
+          <parameter type="const-gchar*" name="accel" />
+        </parameters>
+      </method>
+      <method name="GetActiveWindow" cname="gtk_application_get_active_window">
+        <return-type type="GtkWindow*" />
+      </method>
+      <method name="GetAppMenu" cname="gtk_application_get_app_menu">
+        <return-type type="GMenuModel*" />
+      </method>
+      <method name="GetMenuById" cname="gtk_application_get_menu_by_id">
+        <return-type type="GMenu*" />
+        <parameters>
+          <parameter type="const-gchar*" name="id" />
+        </parameters>
+      </method>
+      <method name="GetMenubar" cname="gtk_application_get_menubar">
+        <return-type type="GMenuModel*" />
+      </method>
       <method name="GetType" cname="gtk_application_get_type" shared="true">
         <return-type type="GType" />
       </method>
+      <method name="GetWindowById" cname="gtk_application_get_window_by_id">
+        <return-type type="GtkWindow*" />
+        <parameters>
+          <parameter type="guint" name="id" />
+        </parameters>
+      </method>
       <method name="GetWindows" cname="gtk_application_get_windows">
         <return-type type="GList*" />
+      </method>
+      <method name="Inhibit" cname="gtk_application_inhibit">
+        <return-type type="guint" />
+        <parameters>
+          <parameter type="GtkWindow*" name="window" />
+          <parameter type="GtkApplicationInhibitFlags" name="flags" />
+          <parameter type="const-gchar*" name="reason" />
+        </parameters>
+      </method>
+      <method name="IsInhibited" cname="gtk_application_is_inhibited">
+        <return-type type="gboolean" />
+        <parameters>
+          <parameter type="GtkApplicationInhibitFlags" name="flags" />
+        </parameters>
+      </method>
+      <method name="ListActionDescriptions" cname="gtk_application_list_action_descriptions">
+        <return-type type="gchar**" />
       </method>
       <constructor cname="gtk_application_new">
         <parameters>
@@ -4429,10 +5283,77 @@
           <parameter type="GApplicationFlags" name="flags" />
         </parameters>
       </constructor>
+      <method name="PrefersAppMenu" cname="gtk_application_prefers_app_menu">
+        <return-type type="gboolean" />
+      </method>
+      <method name="RemoveAccelerator" cname="gtk_application_remove_accelerator" deprecated="1">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="const-gchar*" name="action_name" />
+          <parameter type="GVariant*" name="parameter" />
+        </parameters>
+      </method>
       <method name="RemoveWindow" cname="gtk_application_remove_window">
         <return-type type="void" />
         <parameters>
           <parameter type="GtkWindow*" name="window" />
+        </parameters>
+      </method>
+      <method name="SetAccelsForAction" cname="gtk_application_set_accels_for_action">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="const-gchar*" name="detailed_action_name" />
+          <parameter type="const-gchar*" name="accels" />
+        </parameters>
+      </method>
+      <method name="SetAppMenu" cname="gtk_application_set_app_menu">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GMenuModel*" name="app_menu" />
+        </parameters>
+      </method>
+      <method name="SetMenubar" cname="gtk_application_set_menubar">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GMenuModel*" name="menubar" />
+        </parameters>
+      </method>
+      <method name="Uninhibit" cname="gtk_application_uninhibit">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="guint" name="cookie" />
+        </parameters>
+      </method>
+    </object>
+    <object name="ApplicationWindow" cname="GtkApplicationWindow" parent="GtkWindow">
+      <class_struct cname="GtkApplicationWindowClass">
+        <field name="ParentClass" cname="parent_class" type="GtkWindowClass" />
+        <field name="Padding" cname="padding" type="gpointer" array_len="14" />
+      </class_struct>
+      <field name="Priv" cname="priv" type="GtkApplicationWindowPrivate*" />
+      <property name="ShowMenubar" cname="show-menubar" type="gboolean" readable="true" writeable="true" construct="true" />
+      <implements>
+        <interface cname="GActionGroup" />
+        <interface cname="GActionMap" />
+      </implements>
+      <method name="GetId" cname="gtk_application_window_get_id">
+        <return-type type="guint" />
+      </method>
+      <method name="GetShowMenubar" cname="gtk_application_window_get_show_menubar">
+        <return-type type="gboolean" />
+      </method>
+      <method name="GetType" cname="gtk_application_window_get_type" shared="true">
+        <return-type type="GType" />
+      </method>
+      <constructor cname="gtk_application_window_new">
+        <parameters>
+          <parameter type="GtkApplication*" name="application" />
+        </parameters>
+      </constructor>
+      <method name="SetShowMenubar" cname="gtk_application_window_set_show_menubar">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gboolean" name="show_menubar" />
         </parameters>
       </method>
     </object>
@@ -4444,6 +5365,7 @@
       </class_struct>
       <field name="Priv" cname="priv" type="GtkAppChooserButtonPrivate*" />
       <property name="ShowDialogItem" cname="show-dialog-item" type="gboolean" readable="true" writeable="true" construct="true" />
+      <property name="ShowDefaultItem" cname="show-default-item" type="gboolean" readable="true" writeable="true" construct="true" />
       <property name="Heading" cname="heading" type="gchar*" readable="true" writeable="true" />
       <signal name="CustomItemActivated" cname="custom-item-activated" when="FIRST" field_name="custom_item_activated">
         <return-type type="void" />
@@ -4468,6 +5390,9 @@
       <method name="GetHeading" cname="gtk_app_chooser_button_get_heading">
         <return-type type="const-gchar*" />
       </method>
+      <method name="GetShowDefaultItem" cname="gtk_app_chooser_button_get_show_default_item">
+        <return-type type="gboolean" />
+      </method>
       <method name="GetShowDialogItem" cname="gtk_app_chooser_button_get_show_dialog_item">
         <return-type type="gboolean" />
       </method>
@@ -4489,6 +5414,12 @@
         <return-type type="void" />
         <parameters>
           <parameter type="const-gchar*" name="heading" />
+        </parameters>
+      </method>
+      <method name="SetShowDefaultItem" cname="gtk_app_chooser_button_set_show_default_item">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gboolean" name="setting" />
         </parameters>
       </method>
       <method name="SetShowDialogItem" cname="gtk_app_chooser_button_set_show_dialog_item">
@@ -4538,16 +5469,6 @@
           <parameter type="const-gchar*" name="heading" />
         </parameters>
       </method>
-    </object>
-    <object name="AppChooserOnlinePk" cname="GtkAppChooserOnlinePk" parent="GObject">
-      <class_struct cname="GtkAppChooserOnlinePkClass">
-        <field name="ParentClass" cname="parent_class" type="GObjectClass" />
-      </class_struct>
-      <field name="Priv" cname="priv" type="GtkAppChooserOnlinePkPrivate*" />
-      <implements>
-        <interface cname="GAsyncInitable" />
-        <interface cname="GtkAppChooserOnline" />
-      </implements>
     </object>
     <object name="AppChooserWidget" cname="GtkAppChooserWidget" parent="GtkBox">
       <class_struct cname="GtkAppChooserWidgetClass">
@@ -4672,16 +5593,16 @@
       <virtual_method name="GtkReserved4" cname="_gtk_reserved4" shared="true" padding="true">
         <return-type type="void" />
       </virtual_method>
-      <method name="GetType" cname="gtk_arrow_get_type" shared="true">
+      <method name="GetType" cname="gtk_arrow_get_type" deprecated="1" shared="true">
         <return-type type="GType" />
       </method>
-      <constructor cname="gtk_arrow_new">
+      <constructor cname="gtk_arrow_new" deprecated="1">
         <parameters>
           <parameter type="GtkArrowType" name="arrow_type" />
           <parameter type="GtkShadowType" name="shadow_type" />
         </parameters>
       </constructor>
-      <method name="Set" cname="gtk_arrow_set">
+      <method name="Set" cname="gtk_arrow_set" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="GtkArrowType" name="arrow_type" />
@@ -4768,6 +5689,11 @@
         <return-type type="void" />
         <parameters />
       </signal>
+      <signal name="Escape" cname="escape" when="FIRST">
+        <return-type type="void" />
+        <parameters />
+      </signal>
+      <property name="UseHeaderBar" cname="use-header-bar" type="gint" readable="true" writeable="true" construct-only="true" />
       <childprop name="PageType" cname="page-type" type="GtkAssistantPageType" readable="true" writeable="true" />
       <childprop name="Title" cname="title" type="gchar*" readable="true" writeable="true" />
       <childprop name="HeaderImage" cname="header-image" type="GdkPixbuf" readable="true" writeable="true" />
@@ -4824,13 +5750,13 @@
           <parameter type="GtkWidget*" name="page" />
         </parameters>
       </method>
-      <method name="GetPageHeaderImage" cname="gtk_assistant_get_page_header_image">
+      <method name="GetPageHeaderImage" cname="gtk_assistant_get_page_header_image" deprecated="1">
         <return-type type="GdkPixbuf*" />
         <parameters>
           <parameter type="GtkWidget*" name="page" />
         </parameters>
       </method>
-      <method name="GetPageSideImage" cname="gtk_assistant_get_page_side_image">
+      <method name="GetPageSideImage" cname="gtk_assistant_get_page_side_image" deprecated="1">
         <return-type type="GdkPixbuf*" />
         <parameters>
           <parameter type="GtkWidget*" name="page" />
@@ -4877,6 +5803,12 @@
           <parameter type="GtkWidget*" name="child" />
         </parameters>
       </method>
+      <method name="RemovePage" cname="gtk_assistant_remove_page">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gint" name="page_num" />
+        </parameters>
+      </method>
       <method name="SetCurrentPage" cname="gtk_assistant_set_current_page">
         <return-type type="void" />
         <parameters>
@@ -4898,14 +5830,14 @@
           <parameter type="gboolean" name="complete" />
         </parameters>
       </method>
-      <method name="SetPageHeaderImage" cname="gtk_assistant_set_page_header_image">
+      <method name="SetPageHeaderImage" cname="gtk_assistant_set_page_header_image" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="GtkWidget*" name="page" />
           <parameter type="GdkPixbuf*" name="pixbuf" />
         </parameters>
       </method>
-      <method name="SetPageSideImage" cname="gtk_assistant_set_page_side_image">
+      <method name="SetPageSideImage" cname="gtk_assistant_set_page_side_image" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="GtkWidget*" name="page" />
@@ -4967,8 +5899,7 @@
         <method vm="_gtk_reserved4" />
       </class_struct>
       <field name="Priv" cname="priv" type="GtkBoxPrivate*" />
-      <property name="Spacing" cname="spacing" type="gint" readable="true" writeable="true" />
-      <property name="Homogeneous" cname="homogeneous" type="gboolean" readable="true" writeable="true" />
+      <property name="BaselinePosition" cname="baseline-position" type="GtkBaselinePosition" readable="true" writeable="true" />
       <childprop name="Expand" cname="expand" type="gboolean" readable="true" writeable="true" />
       <childprop name="Fill" cname="fill" type="gboolean" readable="true" writeable="true" />
       <childprop name="Padding" cname="padding" type="guint" readable="true" writeable="true" />
@@ -4988,7 +5919,14 @@
       </virtual_method>
       <implements>
         <interface cname="GtkOrientable" />
+        <interface cname="GtkBuildable" />
       </implements>
+      <method name="GetBaselinePosition" cname="gtk_box_get_baseline_position">
+        <return-type type="GtkBaselinePosition" />
+      </method>
+      <method name="GetCenterWidget" cname="gtk_box_get_center_widget">
+        <return-type type="GtkWidget*" />
+      </method>
       <method name="GetHomogeneous" cname="gtk_box_get_homogeneous">
         <return-type type="gboolean" />
       </method>
@@ -5037,6 +5975,18 @@
         <parameters>
           <parameter type="GtkWidget*" name="child" />
           <parameter type="gint" name="position" />
+        </parameters>
+      </method>
+      <method name="SetBaselinePosition" cname="gtk_box_set_baseline_position">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkBaselinePosition" name="position" />
+        </parameters>
+      </method>
+      <method name="SetCenterWidget" cname="gtk_box_set_center_widget">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkWidget*" name="widget" />
         </parameters>
       </method>
       <method name="SetChildPacking" cname="gtk_box_set_child_packing">
@@ -5107,10 +6057,32 @@
       <virtual_method name="GtkReserved8" cname="_gtk_reserved8" shared="true" padding="true">
         <return-type type="void" />
       </virtual_method>
+      <method name="AddCallbackSymbol" cname="gtk_builder_add_callback_symbol">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="const-gchar*" name="callback_name" />
+          <parameter type="GCallback" name="callback_symbol" />
+        </parameters>
+      </method>
+      <method name="AddCallbackSymbols" cname="gtk_builder_add_callback_symbols">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="const-gchar*" name="first_callback_name" />
+          <parameter type="GCallback" name="first_callback_symbol" />
+          <parameter ellipsis="true" />
+        </parameters>
+      </method>
       <method name="AddFromFile" cname="gtk_builder_add_from_file">
         <return-type type="guint" />
         <parameters>
           <parameter type="const-gchar*" name="filename" />
+          <parameter type="GError**" name="error" />
+        </parameters>
+      </method>
+      <method name="AddFromResource" cname="gtk_builder_add_from_resource">
+        <return-type type="guint" />
+        <parameters>
+          <parameter type="const-gchar*" name="resource_path" />
           <parameter type="GError**" name="error" />
         </parameters>
       </method>
@@ -5126,6 +6098,14 @@
         <return-type type="guint" />
         <parameters>
           <parameter type="const-gchar*" name="filename" />
+          <parameter type="gchar**" name="object_ids" />
+          <parameter type="GError**" name="error" />
+        </parameters>
+      </method>
+      <method name="AddObjectsFromResource" cname="gtk_builder_add_objects_from_resource">
+        <return-type type="guint" />
+        <parameters>
+          <parameter type="const-gchar*" name="resource_path" />
           <parameter type="gchar**" name="object_ids" />
           <parameter type="GError**" name="error" />
         </parameters>
@@ -5155,6 +6135,16 @@
       <method name="ErrorQuark" cname="gtk_builder_error_quark" shared="true">
         <return-type type="GQuark" />
       </method>
+      <method name="ExposeObject" cname="gtk_builder_expose_object">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="const-gchar*" name="name" />
+          <parameter type="GObject*" name="object" />
+        </parameters>
+      </method>
+      <method name="GetApplication" cname="gtk_builder_get_application">
+        <return-type type="GtkApplication*" />
+      </method>
       <method name="GetObject" cname="gtk_builder_get_object">
         <return-type type="GObject*" />
         <parameters>
@@ -5176,7 +6166,35 @@
           <parameter type="const-char*" name="type_name" />
         </parameters>
       </method>
+      <method name="LookupCallbackSymbol" cname="gtk_builder_lookup_callback_symbol">
+        <return-type type="GCallback" />
+        <parameters>
+          <parameter type="const-gchar*" name="callback_name" />
+        </parameters>
+      </method>
       <constructor cname="gtk_builder_new" />
+      <constructor cname="gtk_builder_new_from_file">
+        <parameters>
+          <parameter type="const-gchar*" name="filename" />
+        </parameters>
+      </constructor>
+      <constructor cname="gtk_builder_new_from_resource">
+        <parameters>
+          <parameter type="const-gchar*" name="resource_path" />
+        </parameters>
+      </constructor>
+      <constructor cname="gtk_builder_new_from_string">
+        <parameters>
+          <parameter type="const-gchar*" name="string" />
+          <parameter type="gssize" name="length" />
+        </parameters>
+      </constructor>
+      <method name="SetApplication" cname="gtk_builder_set_application">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkApplication*" name="application" />
+        </parameters>
+      </method>
       <method name="SetTranslationDomain" cname="gtk_builder_set_translation_domain">
         <return-type type="void" />
         <parameters>
@@ -5217,15 +6235,7 @@
         <method vm="_gtk_reserved4" />
       </class_struct>
       <field name="Priv" cname="priv" type="GtkButtonPrivate*" />
-      <property name="Label" cname="label" type="gchar*" readable="true" writeable="true" construct="true" />
-      <property name="UseUnderline" cname="use-underline" type="gboolean" readable="true" writeable="true" construct="true" />
-      <property name="UseStock" cname="use-stock" type="gboolean" readable="true" writeable="true" construct="true" />
-      <property name="FocusOnClick" cname="focus-on-click" type="gboolean" readable="true" writeable="true" />
-      <property name="Relief" cname="relief" type="GtkReliefStyle" readable="true" writeable="true" />
-      <property name="Xalign" cname="xalign" type="gfloat" readable="true" writeable="true" />
-      <property name="Yalign" cname="yalign" type="gfloat" readable="true" writeable="true" />
-      <property name="Image" cname="image" type="GtkWidget" readable="true" writeable="true" />
-      <property name="ImagePosition" cname="image-position" type="GtkPositionType" readable="true" writeable="true" />
+      <property name="AlwaysShowImage" cname="always-show-image" type="gboolean" readable="true" writeable="true" construct="true" />
       <signal name="Pressed" cname="pressed" when="FIRST" field_name="pressed">
         <return-type type="void" />
         <parameters />
@@ -5263,6 +6273,7 @@
         <return-type type="void" />
       </virtual_method>
       <implements>
+        <interface cname="GtkActionable" />
         <interface cname="GtkActivatable" />
       </implements>
       <method name="Clicked" cname="gtk_button_clicked">
@@ -5271,12 +6282,15 @@
       <method name="Enter" cname="gtk_button_enter" deprecated="1">
         <return-type type="void" />
       </method>
-      <method name="GetAlignment" cname="gtk_button_get_alignment">
+      <method name="GetAlignment" cname="gtk_button_get_alignment" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="gfloat*" name="xalign" />
           <parameter type="gfloat*" name="yalign" />
         </parameters>
+      </method>
+      <method name="GetAlwaysShowImage" cname="gtk_button_get_always_show_image">
+        <return-type type="gboolean" />
       </method>
       <method name="GetEventWindow" cname="gtk_button_get_event_window">
         <return-type type="GdkWindow*" />
@@ -5299,7 +6313,7 @@
       <method name="GetType" cname="gtk_button_get_type" shared="true">
         <return-type type="GType" />
       </method>
-      <method name="GetUseStock" cname="gtk_button_get_use_stock">
+      <method name="GetUseStock" cname="gtk_button_get_use_stock" deprecated="1">
         <return-type type="gboolean" />
       </method>
       <method name="GetUseUnderline" cname="gtk_button_get_use_underline">
@@ -5309,7 +6323,13 @@
         <return-type type="void" />
       </method>
       <constructor cname="gtk_button_new" />
-      <constructor cname="gtk_button_new_from_stock">
+      <constructor cname="gtk_button_new_from_icon_name">
+        <parameters>
+          <parameter type="const-gchar*" name="icon_name" />
+          <parameter type="GtkIconSize" name="size" />
+        </parameters>
+      </constructor>
+      <constructor cname="gtk_button_new_from_stock" deprecated="1">
         <parameters>
           <parameter type="const-gchar*" name="stock_id" />
         </parameters>
@@ -5330,11 +6350,17 @@
       <method name="Released" cname="gtk_button_released" deprecated="1">
         <return-type type="void" />
       </method>
-      <method name="SetAlignment" cname="gtk_button_set_alignment">
+      <method name="SetAlignment" cname="gtk_button_set_alignment" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="gfloat" name="xalign" />
           <parameter type="gfloat" name="yalign" />
+        </parameters>
+      </method>
+      <method name="SetAlwaysShowImage" cname="gtk_button_set_always_show_image">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gboolean" name="always_show" />
         </parameters>
       </method>
       <method name="SetFocusOnClick" cname="gtk_button_set_focus_on_click">
@@ -5364,10 +6390,10 @@
       <method name="SetRelief" cname="gtk_button_set_relief">
         <return-type type="void" />
         <parameters>
-          <parameter type="GtkReliefStyle" name="newstyle" />
+          <parameter type="GtkReliefStyle" name="relief" />
         </parameters>
       </method>
-      <method name="SetUseStock" cname="gtk_button_set_use_stock">
+      <method name="SetUseStock" cname="gtk_button_set_use_stock" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="gboolean" name="use_stock" />
@@ -5391,6 +6417,7 @@
       <field name="Priv" cname="priv" type="GtkButtonBoxPrivate*" />
       <property name="LayoutStyle" cname="layout-style" type="GtkButtonBoxStyle" readable="true" writeable="true" />
       <childprop name="Secondary" cname="secondary" type="gboolean" readable="true" writeable="true" />
+      <childprop name="NonHomogeneous" cname="non-homogeneous" type="gboolean" readable="true" writeable="true" />
       <virtual_method name="GtkReserved1" cname="_gtk_reserved1" shared="true" padding="true">
         <return-type type="void" />
       </virtual_method>
@@ -5403,6 +6430,12 @@
       <virtual_method name="GtkReserved4" cname="_gtk_reserved4" shared="true" padding="true">
         <return-type type="void" />
       </virtual_method>
+      <method name="GetChildNonHomogeneous" cname="gtk_button_box_get_child_non_homogeneous">
+        <return-type type="gboolean" />
+        <parameters>
+          <parameter type="GtkWidget*" name="child" />
+        </parameters>
+      </method>
       <method name="GetChildSecondary" cname="gtk_button_box_get_child_secondary">
         <return-type type="gboolean" />
         <parameters>
@@ -5420,6 +6453,13 @@
           <parameter type="GtkOrientation" name="orientation" />
         </parameters>
       </constructor>
+      <method name="SetChildNonHomogeneous" cname="gtk_button_box_set_child_non_homogeneous">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkWidget*" name="child" />
+          <parameter type="gboolean" name="non_homogeneous" />
+        </parameters>
+      </method>
       <method name="SetChildSecondary" cname="gtk_button_box_set_child_secondary">
         <return-type type="void" />
         <parameters>
@@ -5591,7 +6631,7 @@
         <method vm="foreach_alloc" />
         <method vm="event" />
         <method vm="render" />
-        <method signal_vm="apply_attributes" />
+        <method vm="apply_attributes" />
         <method vm="create_context" />
         <method vm="copy_context" />
         <method vm="get_request_mode" />
@@ -5614,41 +6654,6 @@
         <method vm="_gtk_reserved8" />
       </class_struct>
       <field name="Priv" cname="priv" type="GtkCellAreaPrivate*" />
-      <signal name="ApplyAttributes" cname="apply-attributes" when="FIRST" field_name="apply_attributes">
-        <return-type type="void" />
-        <parameters>
-          <parameter type="GtkTreeModel*" name="tree_model" />
-          <parameter type="GtkTreeIter*" name="iter" />
-          <parameter type="gboolean" name="is_expander" />
-          <parameter type="gboolean" name="is_expanded" />
-        </parameters>
-      </signal>
-      <signal name="AddEditable" cname="add-editable" when="FIRST">
-        <return-type type="void" />
-        <parameters>
-          <parameter name="p0" type="GtkCellRenderer" />
-          <parameter name="p1" type="GtkCellEditable" />
-          <parameter name="p2" type="GdkRectangle" />
-          <parameter name="p3" type="gchar*" />
-        </parameters>
-      </signal>
-      <signal name="RemoveEditable" cname="remove-editable" when="FIRST">
-        <return-type type="void" />
-        <parameters>
-          <parameter name="p0" type="GtkCellRenderer" />
-          <parameter name="p1" type="GtkCellEditable" />
-        </parameters>
-      </signal>
-      <signal name="FocusChanged" cname="focus-changed" when="FIRST">
-        <return-type type="void" />
-        <parameters>
-          <parameter name="p0" type="GtkCellRenderer" />
-          <parameter name="p1" type="gchar*" />
-        </parameters>
-      </signal>
-      <property name="FocusCell" cname="focus-cell" type="GtkCellRenderer" readable="true" writeable="true" />
-      <property name="EditedCell" cname="edited-cell" type="GtkCellRenderer" readable="true" />
-      <property name="EditWidget" cname="edit-widget" type="GtkCellEditable" readable="true" />
       <virtual_method name="Add" cname="add">
         <return-type type="void" />
         <parameters>
@@ -5699,6 +6704,15 @@
           <parameter type="const-GdkRectangle*" name="cell_area" />
           <parameter type="GtkCellRendererState" name="flags" />
           <parameter type="gboolean" name="paint_focus" />
+        </parameters>
+      </virtual_method>
+      <virtual_method name="ApplyAttributes" cname="apply_attributes">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkTreeModel*" name="tree_model" />
+          <parameter type="GtkTreeIter*" name="iter" />
+          <parameter type="gboolean" name="is_expander" />
+          <parameter type="gboolean" name="is_expanded" />
         </parameters>
       </virtual_method>
       <virtual_method name="CreateContext" cname="create_context">
@@ -5875,6 +6889,13 @@
       </method>
       <method name="AttributeDisconnect" cname="gtk_cell_area_attribute_disconnect">
         <return-type type="void" />
+        <parameters>
+          <parameter type="GtkCellRenderer*" name="renderer" />
+          <parameter type="const-gchar*" name="attribute" />
+        </parameters>
+      </method>
+      <method name="AttributeGetColumn" cname="gtk_cell_area_attribute_get_column">
+        <return-type type="gint" />
         <parameters>
           <parameter type="GtkCellRenderer*" name="renderer" />
           <parameter type="const-gchar*" name="attribute" />
@@ -6361,7 +7382,7 @@
         <method vm="start_editing" />
         <method signal_vm="editing_canceled" />
         <method signal_vm="editing_started" />
-        <method vm="_gtk_reserved1" />
+        <field name="Priv" cname="priv" type="GtkCellRendererClassPrivate*" />
         <method vm="_gtk_reserved2" />
         <method vm="_gtk_reserved3" />
         <method vm="_gtk_reserved4" />
@@ -6483,9 +7504,6 @@
           <parameter type="GtkCellRendererState" name="flags" />
         </parameters>
       </virtual_method>
-      <virtual_method name="GtkReserved1" cname="_gtk_reserved1" shared="true" padding="true">
-        <return-type type="void" />
-      </virtual_method>
       <virtual_method name="GtkReserved2" cname="_gtk_reserved2" shared="true" padding="true">
         <return-type type="void" />
       </virtual_method>
@@ -6504,6 +7522,13 @@
           <parameter type="const-GdkRectangle*" name="background_area" />
           <parameter type="const-GdkRectangle*" name="cell_area" />
           <parameter type="GtkCellRendererState" name="flags" />
+        </parameters>
+      </method>
+      <method name="ClassSetAccessibleType" cname="gtk_cell_renderer_class_set_accessible_type" shared="true">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkCellRendererClass*" name="renderer_class" />
+          <parameter type="GType" name="type" />
         </parameters>
       </method>
       <method name="GetAlignedArea" cname="gtk_cell_renderer_get_aligned_area">
@@ -6771,6 +7796,7 @@
       <property name="Pixbuf" cname="pixbuf" type="GdkPixbuf" readable="true" writeable="true" />
       <property name="PixbufExpanderOpen" cname="pixbuf-expander-open" type="GdkPixbuf" readable="true" writeable="true" />
       <property name="PixbufExpanderClosed" cname="pixbuf-expander-closed" type="GdkPixbuf" readable="true" writeable="true" />
+      <property name="Surface" cname="surface" type="CairoGobjectSurface" readable="true" writeable="true" />
       <property name="StockId" cname="stock-id" type="gchar*" readable="true" writeable="true" />
       <property name="StockSize" cname="stock-size" type="guint" readable="true" writeable="true" />
       <property name="StockDetail" cname="stock-detail" type="gchar*" readable="true" writeable="true" />
@@ -6928,6 +7954,7 @@
       <property name="WrapMode" cname="wrap-mode" type="PangoWrapMode" readable="true" writeable="true" />
       <property name="WrapWidth" cname="wrap-width" type="gint" readable="true" writeable="true" />
       <property name="Alignment" cname="alignment" type="PangoAlignment" readable="true" writeable="true" />
+      <property name="PlaceholderText" cname="placeholder-text" type="gchar*" readable="true" writeable="true" />
       <signal name="Edited" cname="edited" when="LAST" field_name="edited">
         <return-type type="void" />
         <parameters>
@@ -7101,7 +8128,7 @@
           <parameter type="const-gchar*" name="text" />
         </parameters>
       </constructor>
-      <method name="SetBackgroundColor" cname="gtk_cell_view_set_background_color">
+      <method name="SetBackgroundColor" cname="gtk_cell_view_set_background_color" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="const-GdkColor*" name="color" />
@@ -7470,16 +8497,19 @@
       <virtual_method name="GtkReserved4" cname="_gtk_reserved4" shared="true" padding="true">
         <return-type type="void" />
       </virtual_method>
-      <method name="GetAlpha" cname="gtk_color_button_get_alpha">
+      <implements>
+        <interface cname="GtkColorChooser" />
+      </implements>
+      <method name="GetAlpha" cname="gtk_color_button_get_alpha" deprecated="1">
         <return-type type="guint16" />
       </method>
-      <method name="GetColor" cname="gtk_color_button_get_color">
+      <method name="GetColor" cname="gtk_color_button_get_color" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="GdkColor*" name="color" />
         </parameters>
       </method>
-      <method name="GetRgba" cname="gtk_color_button_get_rgba">
+      <method name="GetRgba" cname="gtk_color_button_get_rgba" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="GdkRGBA*" name="rgba" />
@@ -7491,11 +8521,11 @@
       <method name="GetType" cname="gtk_color_button_get_type" shared="true">
         <return-type type="GType" />
       </method>
-      <method name="GetUseAlpha" cname="gtk_color_button_get_use_alpha">
+      <method name="GetUseAlpha" cname="gtk_color_button_get_use_alpha" deprecated="1">
         <return-type type="gboolean" />
       </method>
       <constructor cname="gtk_color_button_new" />
-      <constructor cname="gtk_color_button_new_with_color">
+      <constructor cname="gtk_color_button_new_with_color" deprecated="1">
         <parameters>
           <parameter type="const-GdkColor*" name="color" />
         </parameters>
@@ -7505,19 +8535,19 @@
           <parameter type="const-GdkRGBA*" name="rgba" />
         </parameters>
       </constructor>
-      <method name="SetAlpha" cname="gtk_color_button_set_alpha">
+      <method name="SetAlpha" cname="gtk_color_button_set_alpha" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="guint16" name="alpha" />
         </parameters>
       </method>
-      <method name="SetColor" cname="gtk_color_button_set_color">
+      <method name="SetColor" cname="gtk_color_button_set_color" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="const-GdkColor*" name="color" />
         </parameters>
       </method>
-      <method name="SetRgba" cname="gtk_color_button_set_rgba">
+      <method name="SetRgba" cname="gtk_color_button_set_rgba" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="const-GdkRGBA*" name="rgba" />
@@ -7529,16 +8559,97 @@
           <parameter type="const-gchar*" name="title" />
         </parameters>
       </method>
-      <method name="SetUseAlpha" cname="gtk_color_button_set_use_alpha">
+      <method name="SetUseAlpha" cname="gtk_color_button_set_use_alpha" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="gboolean" name="use_alpha" />
         </parameters>
       </method>
     </object>
-    <object name="ColorSelection" cname="GtkColorSelection" parent="GtkVBox">
+    <object name="ColorChooserDialog" cname="GtkColorChooserDialog" parent="GtkDialog">
+      <class_struct cname="GtkColorChooserDialogClass">
+        <field name="ParentClass" cname="parent_class" type="GtkDialogClass" />
+        <method vm="_gtk_reserved1" />
+        <method vm="_gtk_reserved2" />
+        <method vm="_gtk_reserved3" />
+        <method vm="_gtk_reserved4" />
+      </class_struct>
+      <field name="Priv" cname="priv" type="GtkColorChooserDialogPrivate*" />
+      <property name="ShowEditor" cname="show-editor" type="gboolean" readable="true" writeable="true" />
+      <virtual_method name="GtkReserved1" cname="_gtk_reserved1" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <virtual_method name="GtkReserved2" cname="_gtk_reserved2" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <virtual_method name="GtkReserved3" cname="_gtk_reserved3" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <virtual_method name="GtkReserved4" cname="_gtk_reserved4" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <implements>
+        <interface cname="GtkColorChooser" />
+      </implements>
+      <method name="GetType" cname="gtk_color_chooser_dialog_get_type" shared="true">
+        <return-type type="GType" />
+      </method>
+      <constructor cname="gtk_color_chooser_dialog_new">
+        <parameters>
+          <parameter type="const-gchar*" name="title" />
+          <parameter type="GtkWindow*" name="parent" />
+        </parameters>
+      </constructor>
+    </object>
+    <object name="ColorChooserWidget" cname="GtkColorChooserWidget" parent="GtkBox">
+      <class_struct cname="GtkColorChooserWidgetClass">
+        <field name="ParentClass" cname="parent_class" type="GtkBoxClass" />
+        <method vm="_gtk_reserved1" />
+        <method vm="_gtk_reserved2" />
+        <method vm="_gtk_reserved3" />
+        <method vm="_gtk_reserved4" />
+        <method vm="_gtk_reserved5" />
+        <method vm="_gtk_reserved6" />
+        <method vm="_gtk_reserved7" />
+        <method vm="_gtk_reserved8" />
+      </class_struct>
+      <field name="Priv" cname="priv" type="GtkColorChooserWidgetPrivate*" />
+      <property name="ShowEditor" cname="show-editor" type="gboolean" readable="true" writeable="true" />
+      <virtual_method name="GtkReserved1" cname="_gtk_reserved1" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <virtual_method name="GtkReserved2" cname="_gtk_reserved2" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <virtual_method name="GtkReserved3" cname="_gtk_reserved3" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <virtual_method name="GtkReserved4" cname="_gtk_reserved4" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <virtual_method name="GtkReserved5" cname="_gtk_reserved5" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <virtual_method name="GtkReserved6" cname="_gtk_reserved6" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <virtual_method name="GtkReserved7" cname="_gtk_reserved7" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <virtual_method name="GtkReserved8" cname="_gtk_reserved8" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <implements>
+        <interface cname="GtkColorChooser" />
+      </implements>
+      <method name="GetType" cname="gtk_color_chooser_widget_get_type" shared="true">
+        <return-type type="GType" />
+      </method>
+      <constructor cname="gtk_color_chooser_widget_new" />
+    </object>
+    <object name="ColorSelection" cname="GtkColorSelection" parent="GtkBox">
       <class_struct cname="GtkColorSelectionClass">
-        <field name="ParentClass" cname="parent_class" type="GtkVBoxClass" />
+        <field name="ParentClass" cname="parent_class" type="GtkBoxClass" />
         <method signal_vm="color_changed" />
         <method vm="_gtk_reserved1" />
         <method vm="_gtk_reserved2" />
@@ -7567,50 +8678,50 @@
       <virtual_method name="GtkReserved4" cname="_gtk_reserved4" shared="true" padding="true">
         <return-type type="void" />
       </virtual_method>
-      <method name="GetCurrentAlpha" cname="gtk_color_selection_get_current_alpha">
+      <method name="GetCurrentAlpha" cname="gtk_color_selection_get_current_alpha" deprecated="1">
         <return-type type="guint16" />
       </method>
-      <method name="GetCurrentColor" cname="gtk_color_selection_get_current_color">
+      <method name="GetCurrentColor" cname="gtk_color_selection_get_current_color" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="GdkColor*" name="color" />
         </parameters>
       </method>
-      <method name="GetCurrentRgba" cname="gtk_color_selection_get_current_rgba">
+      <method name="GetCurrentRgba" cname="gtk_color_selection_get_current_rgba" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="GdkRGBA*" name="rgba" />
         </parameters>
       </method>
-      <method name="GetHasOpacityControl" cname="gtk_color_selection_get_has_opacity_control">
+      <method name="GetHasOpacityControl" cname="gtk_color_selection_get_has_opacity_control" deprecated="1">
         <return-type type="gboolean" />
       </method>
-      <method name="GetHasPalette" cname="gtk_color_selection_get_has_palette">
+      <method name="GetHasPalette" cname="gtk_color_selection_get_has_palette" deprecated="1">
         <return-type type="gboolean" />
       </method>
-      <method name="GetPreviousAlpha" cname="gtk_color_selection_get_previous_alpha">
+      <method name="GetPreviousAlpha" cname="gtk_color_selection_get_previous_alpha" deprecated="1">
         <return-type type="guint16" />
       </method>
-      <method name="GetPreviousColor" cname="gtk_color_selection_get_previous_color">
+      <method name="GetPreviousColor" cname="gtk_color_selection_get_previous_color" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="GdkColor*" name="color" />
         </parameters>
       </method>
-      <method name="GetPreviousRgba" cname="gtk_color_selection_get_previous_rgba">
+      <method name="GetPreviousRgba" cname="gtk_color_selection_get_previous_rgba" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="GdkRGBA*" name="rgba" />
         </parameters>
       </method>
-      <method name="GetType" cname="gtk_color_selection_get_type" shared="true">
+      <method name="GetType" cname="gtk_color_selection_get_type" deprecated="1" shared="true">
         <return-type type="GType" />
       </method>
-      <method name="IsAdjusting" cname="gtk_color_selection_is_adjusting">
+      <method name="IsAdjusting" cname="gtk_color_selection_is_adjusting" deprecated="1">
         <return-type type="gboolean" />
       </method>
-      <constructor cname="gtk_color_selection_new" />
-      <method name="PaletteFromString" cname="gtk_color_selection_palette_from_string" shared="true">
+      <constructor cname="gtk_color_selection_new" deprecated="1" />
+      <method name="PaletteFromString" cname="gtk_color_selection_palette_from_string" deprecated="1" shared="true">
         <return-type type="gboolean" />
         <parameters>
           <parameter type="const-gchar*" name="str" />
@@ -7618,62 +8729,62 @@
           <parameter type="gint*" name="n_colors" />
         </parameters>
       </method>
-      <method name="PaletteToString" cname="gtk_color_selection_palette_to_string" shared="true">
+      <method name="PaletteToString" cname="gtk_color_selection_palette_to_string" deprecated="1" shared="true">
         <return-type type="gchar*" />
         <parameters>
           <parameter type="const-GdkColor*" name="colors" />
           <parameter type="gint" name="n_colors" />
         </parameters>
       </method>
-      <method name="SetChangePaletteWithScreenHook" cname="gtk_color_selection_set_change_palette_with_screen_hook" shared="true">
+      <method name="SetChangePaletteWithScreenHook" cname="gtk_color_selection_set_change_palette_with_screen_hook" deprecated="1" shared="true">
         <return-type type="GtkColorSelectionChangePaletteWithScreenFunc" />
         <parameters>
           <parameter type="GtkColorSelectionChangePaletteWithScreenFunc" name="func" />
         </parameters>
       </method>
-      <method name="SetCurrentAlpha" cname="gtk_color_selection_set_current_alpha">
+      <method name="SetCurrentAlpha" cname="gtk_color_selection_set_current_alpha" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="guint16" name="alpha" />
         </parameters>
       </method>
-      <method name="SetCurrentColor" cname="gtk_color_selection_set_current_color">
+      <method name="SetCurrentColor" cname="gtk_color_selection_set_current_color" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="const-GdkColor*" name="color" />
         </parameters>
       </method>
-      <method name="SetCurrentRgba" cname="gtk_color_selection_set_current_rgba">
+      <method name="SetCurrentRgba" cname="gtk_color_selection_set_current_rgba" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="const-GdkRGBA*" name="rgba" />
         </parameters>
       </method>
-      <method name="SetHasOpacityControl" cname="gtk_color_selection_set_has_opacity_control">
+      <method name="SetHasOpacityControl" cname="gtk_color_selection_set_has_opacity_control" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="gboolean" name="has_opacity" />
         </parameters>
       </method>
-      <method name="SetHasPalette" cname="gtk_color_selection_set_has_palette">
+      <method name="SetHasPalette" cname="gtk_color_selection_set_has_palette" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="gboolean" name="has_palette" />
         </parameters>
       </method>
-      <method name="SetPreviousAlpha" cname="gtk_color_selection_set_previous_alpha">
+      <method name="SetPreviousAlpha" cname="gtk_color_selection_set_previous_alpha" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="guint16" name="alpha" />
         </parameters>
       </method>
-      <method name="SetPreviousColor" cname="gtk_color_selection_set_previous_color">
+      <method name="SetPreviousColor" cname="gtk_color_selection_set_previous_color" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="const-GdkColor*" name="color" />
         </parameters>
       </method>
-      <method name="SetPreviousRgba" cname="gtk_color_selection_set_previous_rgba">
+      <method name="SetPreviousRgba" cname="gtk_color_selection_set_previous_rgba" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="const-GdkRGBA*" name="rgba" />
@@ -7708,13 +8819,13 @@
       <implements>
         <interface cname="GtkBuildable" />
       </implements>
-      <method name="GetColorSelection" cname="gtk_color_selection_dialog_get_color_selection">
+      <method name="GetColorSelection" cname="gtk_color_selection_dialog_get_color_selection" deprecated="1">
         <return-type type="GtkWidget*" />
       </method>
-      <method name="GetType" cname="gtk_color_selection_dialog_get_type" shared="true">
+      <method name="GetType" cname="gtk_color_selection_dialog_get_type" deprecated="1" shared="true">
         <return-type type="GType" />
       </method>
-      <constructor cname="gtk_color_selection_dialog_new">
+      <constructor cname="gtk_color_selection_dialog_new" deprecated="1">
         <parameters>
           <parameter type="const-gchar*" name="title" />
         </parameters>
@@ -7724,10 +8835,10 @@
       <class_struct cname="GtkComboBoxClass">
         <field name="ParentClass" cname="parent_class" type="GtkBinClass" />
         <method signal_vm="changed" />
+        <method signal_vm="format_entry_text" />
         <method vm="_gtk_reserved1" />
         <method vm="_gtk_reserved2" />
         <method vm="_gtk_reserved3" />
-        <method vm="_gtk_reserved4" />
       </class_struct>
       <field name="Priv" cname="priv" type="GtkComboBoxPrivate*" />
       <signal name="Changed" cname="changed" when="LAST" field_name="changed">
@@ -7747,6 +8858,12 @@
       <signal name="Popdown" cname="popdown" when="LAST">
         <return-type type="gboolean" />
         <parameters />
+      </signal>
+      <signal name="FormatEntryText" cname="format-entry-text" when="LAST" field_name="format_entry_text">
+        <return-type type="gchar*" />
+        <parameters>
+          <parameter type="const-gchar*" name="path" />
+        </parameters>
       </signal>
       <property name="Model" cname="model" type="GtkTreeModel" readable="true" writeable="true" />
       <property name="WrapWidth" cname="wrap-width" type="gint" readable="true" writeable="true" />
@@ -7774,9 +8891,6 @@
       <virtual_method name="GtkReserved3" cname="_gtk_reserved3" shared="true" padding="true">
         <return-type type="void" />
       </virtual_method>
-      <virtual_method name="GtkReserved4" cname="_gtk_reserved4" shared="true" padding="true">
-        <return-type type="void" />
-      </virtual_method>
       <implements>
         <interface cname="GtkCellLayout" />
         <interface cname="GtkCellEditable" />
@@ -7794,7 +8908,7 @@
           <parameter type="GtkTreeIter*" name="iter" />
         </parameters>
       </method>
-      <method name="GetAddTearoffs" cname="gtk_combo_box_get_add_tearoffs">
+      <method name="GetAddTearoffs" cname="gtk_combo_box_get_add_tearoffs" deprecated="1">
         <return-type type="gboolean" />
       </method>
       <method name="GetButtonSensitivity" cname="gtk_combo_box_get_button_sensitivity">
@@ -7830,7 +8944,7 @@
       <method name="GetRowSpanColumn" cname="gtk_combo_box_get_row_span_column">
         <return-type type="gint" />
       </method>
-      <method name="GetTitle" cname="gtk_combo_box_get_title">
+      <method name="GetTitle" cname="gtk_combo_box_get_title" deprecated="1">
         <return-type type="const-gchar*" />
       </method>
       <method name="GetType" cname="gtk_combo_box_get_type" shared="true">
@@ -7880,7 +8994,7 @@
         </parameters>
       </method>
       <method name="SetActiveId" cname="gtk_combo_box_set_active_id">
-        <return-type type="void" />
+        <return-type type="gboolean" />
         <parameters>
           <parameter type="const-gchar*" name="active_id" />
         </parameters>
@@ -7891,7 +9005,7 @@
           <parameter type="GtkTreeIter*" name="iter" />
         </parameters>
       </method>
-      <method name="SetAddTearoffs" cname="gtk_combo_box_set_add_tearoffs">
+      <method name="SetAddTearoffs" cname="gtk_combo_box_set_add_tearoffs" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="gboolean" name="add_tearoffs" />
@@ -7953,7 +9067,7 @@
           <parameter type="gint" name="row_span" />
         </parameters>
       </method>
-      <method name="SetTitle" cname="gtk_combo_box_set_title">
+      <method name="SetTitle" cname="gtk_combo_box_set_title" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="const-gchar*" name="title" />
@@ -8208,6 +9322,13 @@
           <parameter type="va_list" name="var_args" />
         </parameters>
       </method>
+      <method name="ChildNotify" cname="gtk_container_child_notify">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkWidget*" name="child" />
+          <parameter type="const-gchar*" name="child_property" />
+        </parameters>
+      </method>
       <method name="ChildSet" cname="gtk_container_child_set">
         <return-type type="void" />
         <parameters>
@@ -8304,7 +9425,7 @@
           <parameter type="GtkWidget*" name="child" />
         </parameters>
       </method>
-      <method name="GetResizeMode" cname="gtk_container_get_resize_mode">
+      <method name="GetResizeMode" cname="gtk_container_get_resize_mode" deprecated="1">
         <return-type type="GtkResizeMode" />
       </method>
       <method name="GetType" cname="gtk_container_get_type" shared="true">
@@ -8323,7 +9444,7 @@
           <parameter type="GtkWidget*" name="widget" />
         </parameters>
       </method>
-      <method name="ResizeChildren" cname="gtk_container_resize_children">
+      <method name="ResizeChildren" cname="gtk_container_resize_children" deprecated="1">
         <return-type type="void" />
       </method>
       <method name="SetBorderWidth" cname="gtk_container_set_border_width">
@@ -8356,13 +9477,13 @@
           <parameter type="GtkAdjustment*" name="adjustment" />
         </parameters>
       </method>
-      <method name="SetReallocateRedraws" cname="gtk_container_set_reallocate_redraws">
+      <method name="SetReallocateRedraws" cname="gtk_container_set_reallocate_redraws" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="gboolean" name="needs_redraws" />
         </parameters>
       </method>
-      <method name="SetResizeMode" cname="gtk_container_set_resize_mode">
+      <method name="SetResizeMode" cname="gtk_container_set_resize_mode" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="GtkResizeMode" name="resize_mode" />
@@ -8375,15 +9496,19 @@
     <object name="CssProvider" cname="GtkCssProvider" parent="GObject">
       <class_struct cname="GtkCssProviderClass">
         <field name="ParentClass" cname="parent_class" type="GObjectClass" />
-        <method vm="_gtk_reserved1" />
+        <method signal_vm="parsing_error" />
         <method vm="_gtk_reserved2" />
         <method vm="_gtk_reserved3" />
         <method vm="_gtk_reserved4" />
       </class_struct>
-      <field name="Priv" cname="priv" type="gpointer" />
-      <virtual_method name="GtkReserved1" cname="_gtk_reserved1" shared="true" padding="true">
+      <field name="Priv" cname="priv" type="GtkCssProviderPrivate*" />
+      <signal name="ParsingError" cname="parsing-error" when="LAST" field_name="parsing_error">
         <return-type type="void" />
-      </virtual_method>
+        <parameters>
+          <parameter type="GtkCssSection*" name="section" />
+          <parameter type="const-GError*" name="error" />
+        </parameters>
+      </signal>
       <virtual_method name="GtkReserved2" cname="_gtk_reserved2" shared="true" padding="true">
         <return-type type="void" />
       </virtual_method>
@@ -8395,6 +9520,7 @@
       </virtual_method>
       <implements>
         <interface cname="GtkStyleProvider" />
+        <interface cname="GtkStyleProviderPrivate" />
       </implements>
       <method name="ErrorQuark" cname="gtk_css_provider_error_quark" shared="true">
         <return-type type="GQuark" />
@@ -8435,6 +9561,9 @@
         </parameters>
       </method>
       <constructor cname="gtk_css_provider_new" />
+      <method name="ToString" cname="gtk_css_provider_to_string">
+        <return-type type="char*" />
+      </method>
     </object>
     <object name="CustomPaperUnixDialog" cname="GtkCustomPaperUnixDialog" parent="GtkDialog">
       <class_struct cname="GtkCustomPaperUnixDialogClass">
@@ -8482,6 +9611,7 @@
         <return-type type="void" />
         <parameters />
       </signal>
+      <property name="UseHeaderBar" cname="use-header-bar" type="gint" readable="true" writeable="true" construct-only="true" />
       <virtual_method name="GtkReserved1" cname="_gtk_reserved1" shared="true" padding="true">
         <return-type type="void" />
       </virtual_method>
@@ -8518,10 +9648,13 @@
           <parameter ellipsis="true" />
         </parameters>
       </method>
-      <method name="GetActionArea" cname="gtk_dialog_get_action_area">
+      <method name="GetActionArea" cname="gtk_dialog_get_action_area" deprecated="1">
         <return-type type="GtkWidget*" />
       </method>
       <method name="GetContentArea" cname="gtk_dialog_get_content_area">
+        <return-type type="GtkWidget*" />
+      </method>
+      <method name="GetHeaderBar" cname="gtk_dialog_get_header_bar">
         <return-type type="GtkWidget*" />
       </method>
       <method name="GetResponseForWidget" cname="gtk_dialog_get_response_for_widget">
@@ -8558,14 +9691,14 @@
       <method name="Run" cname="gtk_dialog_run">
         <return-type type="gint" />
       </method>
-      <method name="SetAlternativeButtonOrder" cname="gtk_dialog_set_alternative_button_order">
+      <method name="SetAlternativeButtonOrder" cname="gtk_dialog_set_alternative_button_order" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="gint" name="first_response_id" />
           <parameter ellipsis="true" />
         </parameters>
       </method>
-      <method name="SetAlternativeButtonOrderFromArray" cname="gtk_dialog_set_alternative_button_order_from_array">
+      <method name="SetAlternativeButtonOrderFromArray" cname="gtk_dialog_set_alternative_button_order_from_array" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="gint" name="n_params" />
@@ -8626,6 +9759,7 @@
         <method signal_vm="paste_clipboard" />
         <method signal_vm="toggle_overwrite" />
         <method vm="get_text_area_size" />
+        <method vm="get_frame_size" />
         <method vm="_gtk_reserved1" />
         <method vm="_gtk_reserved2" />
         <method vm="_gtk_reserved3" />
@@ -8633,7 +9767,6 @@
         <method vm="_gtk_reserved5" />
         <method vm="_gtk_reserved6" />
         <method vm="_gtk_reserved7" />
-        <method vm="_gtk_reserved8" />
       </class_struct>
       <field name="Priv" cname="priv" type="GtkEntryPrivate*" />
       <property name="Buffer" cname="buffer" type="GtkEntryBuffer" readable="true" writeable="true" construct="true" />
@@ -8647,6 +9780,7 @@
       <property name="InvisibleChar" cname="invisible-char" type="gunichar" readable="true" writeable="true" />
       <property name="ActivatesDefault" cname="activates-default" type="gboolean" readable="true" writeable="true" />
       <property name="WidthChars" cname="width-chars" type="gint" readable="true" writeable="true" />
+      <property name="MaxWidthChars" cname="max-width-chars" type="gint" readable="true" writeable="true" />
       <property name="ScrollOffset" cname="scroll-offset" type="gint" readable="true" />
       <property name="Text" cname="text" type="gchar*" readable="true" writeable="true" />
       <property name="Xalign" cname="xalign" type="gfloat" readable="true" writeable="true" />
@@ -8658,6 +9792,7 @@
       <property name="CapsLockWarning" cname="caps-lock-warning" type="gboolean" readable="true" writeable="true" />
       <property name="ProgressFraction" cname="progress-fraction" type="gdouble" readable="true" writeable="true" />
       <property name="ProgressPulseStep" cname="progress-pulse-step" type="gdouble" readable="true" writeable="true" />
+      <property name="PlaceholderText" cname="placeholder-text" type="gchar*" readable="true" writeable="true" />
       <property name="PrimaryIconPixbuf" cname="primary-icon-pixbuf" type="GdkPixbuf" readable="true" writeable="true" />
       <property name="SecondaryIconPixbuf" cname="secondary-icon-pixbuf" type="GdkPixbuf" readable="true" writeable="true" />
       <property name="PrimaryIconStock" cname="primary-icon-stock" type="gchar*" readable="true" writeable="true" />
@@ -8677,10 +9812,16 @@
       <property name="PrimaryIconTooltipMarkup" cname="primary-icon-tooltip-markup" type="gchar*" readable="true" writeable="true" />
       <property name="SecondaryIconTooltipMarkup" cname="secondary-icon-tooltip-markup" type="gchar*" readable="true" writeable="true" />
       <property name="ImModule" cname="im-module" type="gchar*" readable="true" writeable="true" />
+      <property name="Completion" cname="completion" type="GtkEntryCompletion" readable="true" writeable="true" />
+      <property name="InputPurpose" cname="input-purpose" type="GtkInputPurpose" readable="true" writeable="true" />
+      <property name="InputHints" cname="input-hints" type="GtkInputHints" readable="true" writeable="true" />
+      <property name="Attributes" cname="attributes" type="PangoAttrList" readable="true" writeable="true" />
+      <property name="PopulateAll" cname="populate-all" type="gboolean" readable="true" writeable="true" />
+      <property name="Tabs" cname="tabs" type="PangoTabArray" readable="true" writeable="true" />
       <signal name="PopulatePopup" cname="populate-popup" when="LAST" field_name="populate_popup">
         <return-type type="void" />
         <parameters>
-          <parameter type="GtkMenu*" name="menu" />
+          <parameter type="GtkWidget*" name="popup" />
         </parameters>
       </signal>
       <signal name="Activate" cname="activate" when="LAST" field_name="activate">
@@ -8757,6 +9898,15 @@
           <parameter type="gint*" name="height" />
         </parameters>
       </virtual_method>
+      <virtual_method name="GetFrameSize" cname="get_frame_size">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gint*" name="x" />
+          <parameter type="gint*" name="y" />
+          <parameter type="gint*" name="width" />
+          <parameter type="gint*" name="height" />
+        </parameters>
+      </virtual_method>
       <virtual_method name="GtkReserved1" cname="_gtk_reserved1" shared="true" padding="true">
         <return-type type="void" />
       </virtual_method>
@@ -8778,9 +9928,6 @@
       <virtual_method name="GtkReserved7" cname="_gtk_reserved7" shared="true" padding="true">
         <return-type type="void" />
       </virtual_method>
-      <virtual_method name="GtkReserved8" cname="_gtk_reserved8" shared="true" padding="true">
-        <return-type type="void" />
-      </virtual_method>
       <implements>
         <interface cname="GtkEditable" />
         <interface cname="GtkCellEditable" />
@@ -8790,6 +9937,9 @@
       </method>
       <method name="GetAlignment" cname="gtk_entry_get_alignment">
         <return-type type="gfloat" />
+      </method>
+      <method name="GetAttributes" cname="gtk_entry_get_attributes">
+        <return-type type="PangoAttrList*" />
       </method>
       <method name="GetBuffer" cname="gtk_entry_get_buffer">
         <return-type type="GtkEntryBuffer*" />
@@ -8850,7 +10000,7 @@
           <parameter type="GtkEntryIconPosition" name="icon_pos" />
         </parameters>
       </method>
-      <method name="GetIconStock" cname="gtk_entry_get_icon_stock">
+      <method name="GetIconStock" cname="gtk_entry_get_icon_stock" deprecated="1">
         <return-type type="const-gchar*" />
         <parameters>
           <parameter type="GtkEntryIconPosition" name="icon_pos" />
@@ -8874,8 +10024,14 @@
           <parameter type="GtkEntryIconPosition" name="icon_pos" />
         </parameters>
       </method>
-      <method name="GetInnerBorder" cname="gtk_entry_get_inner_border">
+      <method name="GetInnerBorder" cname="gtk_entry_get_inner_border" deprecated="1">
         <return-type type="const-GtkBorder*" />
+      </method>
+      <method name="GetInputHints" cname="gtk_entry_get_input_hints">
+        <return-type type="GtkInputHints" />
+      </method>
+      <method name="GetInputPurpose" cname="gtk_entry_get_input_purpose">
+        <return-type type="GtkInputPurpose" />
       </method>
       <method name="GetInvisibleChar" cname="gtk_entry_get_invisible_char">
         <return-type type="gunichar" />
@@ -8893,14 +10049,23 @@
       <method name="GetMaxLength" cname="gtk_entry_get_max_length">
         <return-type type="gint" />
       </method>
+      <method name="GetMaxWidthChars" cname="gtk_entry_get_max_width_chars">
+        <return-type type="gint" />
+      </method>
       <method name="GetOverwriteMode" cname="gtk_entry_get_overwrite_mode">
         <return-type type="gboolean" />
+      </method>
+      <method name="GetPlaceholderText" cname="gtk_entry_get_placeholder_text">
+        <return-type type="const-gchar*" />
       </method>
       <method name="GetProgressFraction" cname="gtk_entry_get_progress_fraction">
         <return-type type="gdouble" />
       </method>
       <method name="GetProgressPulseStep" cname="gtk_entry_get_progress_pulse_step">
         <return-type type="gdouble" />
+      </method>
+      <method name="GetTabs" cname="gtk_entry_get_tabs">
+        <return-type type="PangoTabArray*" />
       </method>
       <method name="GetText" cname="gtk_entry_get_text">
         <return-type type="const-gchar*" />
@@ -8957,6 +10122,12 @@
         <return-type type="void" />
         <parameters>
           <parameter type="gfloat" name="xalign" />
+        </parameters>
+      </method>
+      <method name="SetAttributes" cname="gtk_entry_set_attributes">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="PangoAttrList*" name="attrs" />
         </parameters>
       </method>
       <method name="SetBuffer" cname="gtk_entry_set_buffer">
@@ -9019,7 +10190,7 @@
           <parameter type="GdkPixbuf*" name="pixbuf" />
         </parameters>
       </method>
-      <method name="SetIconFromStock" cname="gtk_entry_set_icon_from_stock">
+      <method name="SetIconFromStock" cname="gtk_entry_set_icon_from_stock" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="GtkEntryIconPosition" name="icon_pos" />
@@ -9047,10 +10218,22 @@
           <parameter type="const-gchar*" name="tooltip" />
         </parameters>
       </method>
-      <method name="SetInnerBorder" cname="gtk_entry_set_inner_border">
+      <method name="SetInnerBorder" cname="gtk_entry_set_inner_border" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="const-GtkBorder*" name="border" />
+        </parameters>
+      </method>
+      <method name="SetInputHints" cname="gtk_entry_set_input_hints">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkInputHints" name="hints" />
+        </parameters>
+      </method>
+      <method name="SetInputPurpose" cname="gtk_entry_set_input_purpose">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkInputPurpose" name="purpose" />
         </parameters>
       </method>
       <method name="SetInvisibleChar" cname="gtk_entry_set_invisible_char">
@@ -9065,10 +10248,22 @@
           <parameter type="gint" name="max" />
         </parameters>
       </method>
+      <method name="SetMaxWidthChars" cname="gtk_entry_set_max_width_chars">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gint" name="n_chars" />
+        </parameters>
+      </method>
       <method name="SetOverwriteMode" cname="gtk_entry_set_overwrite_mode">
         <return-type type="void" />
         <parameters>
           <parameter type="gboolean" name="overwrite" />
+        </parameters>
+      </method>
+      <method name="SetPlaceholderText" cname="gtk_entry_set_placeholder_text">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="const-gchar*" name="text" />
         </parameters>
       </method>
       <method name="SetProgressFraction" cname="gtk_entry_set_progress_fraction">
@@ -9081,6 +10276,12 @@
         <return-type type="void" />
         <parameters>
           <parameter type="gdouble" name="fraction" />
+        </parameters>
+      </method>
+      <method name="SetTabs" cname="gtk_entry_set_tabs">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="PangoTabArray*" name="tabs" />
         </parameters>
       </method>
       <method name="SetText" cname="gtk_entry_set_text">
@@ -9269,10 +10470,10 @@
         <method signal_vm="action_activated" />
         <method signal_vm="insert_prefix" />
         <method signal_vm="cursor_on_match" />
+        <method signal_vm="no_matches" />
         <method vm="_gtk_reserved0" />
         <method vm="_gtk_reserved1" />
         <method vm="_gtk_reserved2" />
-        <method vm="_gtk_reserved3" />
       </class_struct>
       <field name="Priv" cname="priv" type="GtkEntryCompletionPrivate*" />
       <signal name="InsertPrefix" cname="insert-prefix" when="LAST" field_name="insert_prefix">
@@ -9294,6 +10495,10 @@
           <parameter type="GtkTreeModel*" name="model" />
           <parameter type="GtkTreeIter*" name="iter" />
         </parameters>
+      </signal>
+      <signal name="NoMatches" cname="no-matches" when="LAST" field_name="no_matches">
+        <return-type type="void" />
+        <parameters />
       </signal>
       <signal name="ActionActivated" cname="action-activated" when="LAST" field_name="action_activated">
         <return-type type="void" />
@@ -9319,15 +10524,18 @@
       <virtual_method name="GtkReserved2" cname="_gtk_reserved2" shared="true" padding="true">
         <return-type type="void" />
       </virtual_method>
-      <virtual_method name="GtkReserved3" cname="_gtk_reserved3" shared="true" padding="true">
-        <return-type type="void" />
-      </virtual_method>
       <implements>
         <interface cname="GtkCellLayout" />
         <interface cname="GtkBuildable" />
       </implements>
       <method name="Complete" cname="gtk_entry_completion_complete">
         <return-type type="void" />
+      </method>
+      <method name="ComputePrefix" cname="gtk_entry_completion_compute_prefix">
+        <return-type type="gchar*" />
+        <parameters>
+          <parameter type="const-char*" name="key" />
+        </parameters>
       </method>
       <method name="DeleteAction" cname="gtk_entry_completion_delete_action">
         <return-type type="void" />
@@ -9494,6 +10702,50 @@
         </parameters>
       </method>
     </object>
+    <object name="EventController" cname="GtkEventController" parent="GObject">
+      <class_struct cname="GtkEventControllerClass">
+        <field name="ParentClass" cname="parent_class" type="GObjectClass" />
+        <method vm="handle_event" />
+        <method vm="reset" />
+        <field name="Padding" cname="padding" type="gpointer" array_len="10" />
+      </class_struct>
+      <property name="Widget" cname="widget" type="GtkWidget" readable="true" writeable="true" construct-only="true" />
+      <property name="PropagationPhase" cname="propagation-phase" type="GtkPropagationPhase" readable="true" writeable="true" />
+      <virtual_method name="HandleEvent" cname="handle_event">
+        <return-type type="gboolean" />
+        <parameters>
+          <parameter type="const-GdkEvent*" name="event" />
+        </parameters>
+      </virtual_method>
+      <virtual_method name="Reset" cname="reset">
+        <return-type type="void" />
+        <parameters />
+      </virtual_method>
+      <method name="GetPropagationPhase" cname="gtk_event_controller_get_propagation_phase">
+        <return-type type="GtkPropagationPhase" />
+      </method>
+      <method name="GetType" cname="gtk_event_controller_get_type" shared="true">
+        <return-type type="GType" />
+      </method>
+      <method name="GetWidget" cname="gtk_event_controller_get_widget">
+        <return-type type="GtkWidget*" />
+      </method>
+      <method name="HandleEvent" cname="gtk_event_controller_handle_event">
+        <return-type type="gboolean" />
+        <parameters>
+          <parameter type="const-GdkEvent*" name="event" />
+        </parameters>
+      </method>
+      <method name="Reset" cname="gtk_event_controller_reset">
+        <return-type type="void" />
+      </method>
+      <method name="SetPropagationPhase" cname="gtk_event_controller_set_propagation_phase">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkPropagationPhase" name="phase" />
+        </parameters>
+      </method>
+    </object>
     <object name="Expander" cname="GtkExpander" parent="GtkBin">
       <class_struct cname="GtkExpanderClass">
         <field name="ParentClass" cname="parent_class" type="GtkBinClass" />
@@ -9511,6 +10763,7 @@
       <property name="Spacing" cname="spacing" type="gint" readable="true" writeable="true" />
       <property name="LabelWidget" cname="label-widget" type="GtkWidget" readable="true" writeable="true" />
       <property name="LabelFill" cname="label-fill" type="gboolean" readable="true" writeable="true" construct="true" />
+      <property name="ResizeToplevel" cname="resize-toplevel" type="gboolean" readable="true" writeable="true" />
       <signal name="Activate" cname="activate" when="LAST" field_name="activate">
         <return-type type="void" />
         <parameters />
@@ -9541,6 +10794,9 @@
       </method>
       <method name="GetLabelWidget" cname="gtk_expander_get_label_widget">
         <return-type type="GtkWidget*" />
+      </method>
+      <method name="GetResizeToplevel" cname="gtk_expander_get_resize_toplevel">
+        <return-type type="gboolean" />
       </method>
       <method name="GetSpacing" cname="gtk_expander_get_spacing">
         <return-type type="gint" />
@@ -9588,6 +10844,12 @@
           <parameter type="GtkWidget*" name="label_widget" />
         </parameters>
       </method>
+      <method name="SetResizeToplevel" cname="gtk_expander_set_resize_toplevel">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gboolean" name="resize_toplevel" />
+        </parameters>
+      </method>
       <method name="SetSpacing" cname="gtk_expander_set_spacing">
         <return-type type="void" />
         <parameters>
@@ -9607,9 +10869,9 @@
         </parameters>
       </method>
     </object>
-    <object name="FileChooserButton" cname="GtkFileChooserButton" parent="GtkHBox">
+    <object name="FileChooserButton" cname="GtkFileChooserButton" parent="GtkBox">
       <class_struct cname="GtkFileChooserButtonClass">
-        <field name="ParentClass" cname="parent_class" type="GtkHBoxClass" />
+        <field name="ParentClass" cname="parent_class" type="GtkBoxClass" />
         <method signal_vm="file_set" />
         <method vm="__gtk_reserved1" />
         <method vm="__gtk_reserved2" />
@@ -9719,15 +10981,63 @@
         </parameters>
       </constructor>
     </object>
-    <object name="FileChooserWidget" cname="GtkFileChooserWidget" parent="GtkVBox">
+    <object name="FileChooserWidget" cname="GtkFileChooserWidget" parent="GtkBox">
       <class_struct cname="GtkFileChooserWidgetClass">
-        <field name="ParentClass" cname="parent_class" type="GtkVBoxClass" />
+        <field name="ParentClass" cname="parent_class" type="GtkBoxClass" />
         <method vm="_gtk_reserved1" />
         <method vm="_gtk_reserved2" />
         <method vm="_gtk_reserved3" />
         <method vm="_gtk_reserved4" />
       </class_struct>
       <field name="Priv" cname="priv" type="GtkFileChooserWidgetPrivate*" />
+      <signal name="LocationPopup" cname="location-popup" when="FIRST">
+        <return-type type="void" />
+        <parameters>
+          <parameter name="p0" type="gchar*" />
+        </parameters>
+      </signal>
+      <signal name="LocationPopupOnPaste" cname="location-popup-on-paste" when="FIRST">
+        <return-type type="void" />
+        <parameters />
+      </signal>
+      <signal name="LocationTogglePopup" cname="location-toggle-popup" when="FIRST">
+        <return-type type="void" />
+        <parameters />
+      </signal>
+      <signal name="UpFolder" cname="up-folder" when="FIRST">
+        <return-type type="void" />
+        <parameters />
+      </signal>
+      <signal name="DownFolder" cname="down-folder" when="FIRST">
+        <return-type type="void" />
+        <parameters />
+      </signal>
+      <signal name="HomeFolder" cname="home-folder" when="FIRST">
+        <return-type type="void" />
+        <parameters />
+      </signal>
+      <signal name="DesktopFolder" cname="desktop-folder" when="FIRST">
+        <return-type type="void" />
+        <parameters />
+      </signal>
+      <signal name="QuickBookmark" cname="quick-bookmark" when="FIRST">
+        <return-type type="void" />
+        <parameters>
+          <parameter name="p0" type="gint32" />
+        </parameters>
+      </signal>
+      <signal name="ShowHidden" cname="show-hidden" when="FIRST">
+        <return-type type="void" />
+        <parameters />
+      </signal>
+      <signal name="SearchShortcut" cname="search-shortcut" when="FIRST">
+        <return-type type="void" />
+        <parameters />
+      </signal>
+      <signal name="RecentShortcut" cname="recent-shortcut" when="FIRST">
+        <return-type type="void" />
+        <parameters />
+      </signal>
       <virtual_method name="GtkReserved1" cname="_gtk_reserved1" shared="true" padding="true">
         <return-type type="void" />
       </virtual_method>
@@ -9851,6 +11161,252 @@
         </parameters>
       </method>
     </object>
+    <object name="FlowBox" cname="GtkFlowBox" parent="GtkContainer">
+      <class_struct cname="GtkFlowBoxClass">
+        <field name="ParentClass" cname="parent_class" type="GtkContainerClass" />
+        <method signal_vm="child_activated" />
+        <method signal_vm="selected_children_changed" />
+        <method signal_vm="activate_cursor_child" />
+        <method signal_vm="toggle_cursor_child" />
+        <method signal_vm="move_cursor" />
+        <method signal_vm="select_all" />
+        <method signal_vm="unselect_all" />
+        <method vm="_gtk_reserved1" />
+        <method vm="_gtk_reserved2" />
+        <method vm="_gtk_reserved3" />
+        <method vm="_gtk_reserved4" />
+        <method vm="_gtk_reserved5" />
+        <method vm="_gtk_reserved6" />
+      </class_struct>
+      <property name="ColumnSpacing" cname="column-spacing" type="guint" readable="true" writeable="true" />
+      <signal name="ChildActivated" cname="child-activated" when="LAST" field_name="child_activated">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkFlowBoxChild*" name="child" />
+        </parameters>
+      </signal>
+      <signal name="SelectedChildrenChanged" cname="selected-children-changed" when="FIRST" field_name="selected_children_changed">
+        <return-type type="void" />
+        <parameters />
+      </signal>
+      <signal name="ActivateCursorChild" cname="activate-cursor-child" when="LAST" field_name="activate_cursor_child">
+        <return-type type="void" />
+        <parameters />
+      </signal>
+      <signal name="ToggleCursorChild" cname="toggle-cursor-child" when="LAST" field_name="toggle_cursor_child">
+        <return-type type="void" />
+        <parameters />
+      </signal>
+      <signal name="MoveCursor" cname="move-cursor" when="LAST" field_name="move_cursor">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkMovementStep" name="step" />
+          <parameter type="gint" name="count" />
+        </parameters>
+      </signal>
+      <signal name="SelectAll" cname="select-all" when="LAST" field_name="select_all">
+        <return-type type="void" />
+        <parameters />
+      </signal>
+      <signal name="UnselectAll" cname="unselect-all" when="LAST" field_name="unselect_all">
+        <return-type type="void" />
+        <parameters />
+      </signal>
+      <virtual_method name="GtkReserved1" cname="_gtk_reserved1" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <virtual_method name="GtkReserved2" cname="_gtk_reserved2" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <virtual_method name="GtkReserved3" cname="_gtk_reserved3" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <virtual_method name="GtkReserved4" cname="_gtk_reserved4" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <virtual_method name="GtkReserved5" cname="_gtk_reserved5" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <virtual_method name="GtkReserved6" cname="_gtk_reserved6" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <implements>
+        <interface cname="GtkOrientable" />
+      </implements>
+      <method name="GetActivateOnSingleClick" cname="gtk_flow_box_get_activate_on_single_click">
+        <return-type type="gboolean" />
+      </method>
+      <method name="GetChildAtIndex" cname="gtk_flow_box_get_child_at_index">
+        <return-type type="GtkFlowBoxChild*" />
+        <parameters>
+          <parameter type="gint" name="idx" />
+        </parameters>
+      </method>
+      <method name="GetColumnSpacing" cname="gtk_flow_box_get_column_spacing">
+        <return-type type="guint" />
+      </method>
+      <method name="GetHomogeneous" cname="gtk_flow_box_get_homogeneous">
+        <return-type type="gboolean" />
+      </method>
+      <method name="GetMaxChildrenPerLine" cname="gtk_flow_box_get_max_children_per_line">
+        <return-type type="guint" />
+      </method>
+      <method name="GetMinChildrenPerLine" cname="gtk_flow_box_get_min_children_per_line">
+        <return-type type="guint" />
+      </method>
+      <method name="GetRowSpacing" cname="gtk_flow_box_get_row_spacing">
+        <return-type type="guint" />
+      </method>
+      <method name="GetSelectedChildren" cname="gtk_flow_box_get_selected_children">
+        <return-type type="GList*" />
+      </method>
+      <method name="GetSelectionMode" cname="gtk_flow_box_get_selection_mode">
+        <return-type type="GtkSelectionMode" />
+      </method>
+      <method name="GetType" cname="gtk_flow_box_get_type" shared="true">
+        <return-type type="GType" />
+      </method>
+      <method name="Insert" cname="gtk_flow_box_insert">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkWidget*" name="widget" />
+          <parameter type="gint" name="position" />
+        </parameters>
+      </method>
+      <method name="InvalidateFilter" cname="gtk_flow_box_invalidate_filter">
+        <return-type type="void" />
+      </method>
+      <method name="InvalidateSort" cname="gtk_flow_box_invalidate_sort">
+        <return-type type="void" />
+      </method>
+      <constructor cname="gtk_flow_box_new" />
+      <method name="SelectAll" cname="gtk_flow_box_select_all">
+        <return-type type="void" />
+      </method>
+      <method name="SelectChild" cname="gtk_flow_box_select_child">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkFlowBoxChild*" name="child" />
+        </parameters>
+      </method>
+      <method name="SelectedForeach" cname="gtk_flow_box_selected_foreach">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkFlowBoxForeachFunc" name="func" />
+          <parameter type="gpointer" name="data" />
+        </parameters>
+      </method>
+      <method name="SetActivateOnSingleClick" cname="gtk_flow_box_set_activate_on_single_click">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gboolean" name="single" />
+        </parameters>
+      </method>
+      <method name="SetColumnSpacing" cname="gtk_flow_box_set_column_spacing">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="guint" name="spacing" />
+        </parameters>
+      </method>
+      <method name="SetFilterFunc" cname="gtk_flow_box_set_filter_func">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkFlowBoxFilterFunc" name="filter_func" />
+          <parameter type="gpointer" name="user_data" />
+          <parameter type="GDestroyNotify" name="destroy" />
+        </parameters>
+      </method>
+      <method name="SetHadjustment" cname="gtk_flow_box_set_hadjustment">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkAdjustment*" name="adjustment" />
+        </parameters>
+      </method>
+      <method name="SetHomogeneous" cname="gtk_flow_box_set_homogeneous">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gboolean" name="homogeneous" />
+        </parameters>
+      </method>
+      <method name="SetMaxChildrenPerLine" cname="gtk_flow_box_set_max_children_per_line">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="guint" name="n_children" />
+        </parameters>
+      </method>
+      <method name="SetMinChildrenPerLine" cname="gtk_flow_box_set_min_children_per_line">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="guint" name="n_children" />
+        </parameters>
+      </method>
+      <method name="SetRowSpacing" cname="gtk_flow_box_set_row_spacing">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="guint" name="spacing" />
+        </parameters>
+      </method>
+      <method name="SetSelectionMode" cname="gtk_flow_box_set_selection_mode">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkSelectionMode" name="mode" />
+        </parameters>
+      </method>
+      <method name="SetSortFunc" cname="gtk_flow_box_set_sort_func">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkFlowBoxSortFunc" name="sort_func" />
+          <parameter type="gpointer" name="user_data" />
+          <parameter type="GDestroyNotify" name="destroy" />
+        </parameters>
+      </method>
+      <method name="SetVadjustment" cname="gtk_flow_box_set_vadjustment">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkAdjustment*" name="adjustment" />
+        </parameters>
+      </method>
+      <method name="UnselectAll" cname="gtk_flow_box_unselect_all">
+        <return-type type="void" />
+      </method>
+      <method name="UnselectChild" cname="gtk_flow_box_unselect_child">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkFlowBoxChild*" name="child" />
+        </parameters>
+      </method>
+    </object>
+    <object name="FlowBoxChild" cname="GtkFlowBoxChild" parent="GtkBin">
+      <class_struct cname="GtkFlowBoxChildClass">
+        <field name="ParentClass" cname="parent_class" type="GtkBinClass" />
+        <method signal_vm="activate" />
+        <method vm="_gtk_reserved1" />
+        <method vm="_gtk_reserved2" />
+      </class_struct>
+      <signal name="Activate" cname="activate" when="FIRST" field_name="activate">
+        <return-type type="void" />
+        <parameters />
+      </signal>
+      <virtual_method name="GtkReserved1" cname="_gtk_reserved1" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <virtual_method name="GtkReserved2" cname="_gtk_reserved2" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <method name="Changed" cname="gtk_flow_box_child_changed">
+        <return-type type="void" />
+      </method>
+      <method name="GetIndex" cname="gtk_flow_box_child_get_index">
+        <return-type type="gint" />
+      </method>
+      <method name="GetType" cname="gtk_flow_box_child_get_type" shared="true">
+        <return-type type="GType" />
+      </method>
+      <method name="IsSelected" cname="gtk_flow_box_child_is_selected">
+        <return-type type="gboolean" />
+      </method>
+      <constructor cname="gtk_flow_box_child_new" />
+    </object>
     <object name="FontButton" cname="GtkFontButton" parent="GtkButton">
       <class_struct cname="GtkFontButtonClass">
         <field name="ParentClass" cname="parent_class" type="GtkButtonClass" />
@@ -9883,6 +11439,9 @@
       <virtual_method name="GtkReserved4" cname="_gtk_reserved4" shared="true" padding="true">
         <return-type type="void" />
       </virtual_method>
+      <implements>
+        <interface cname="GtkFontChooser" />
+      </implements>
       <method name="GetFontName" cname="gtk_font_button_get_font_name">
         <return-type type="const-gchar*" />
       </method>
@@ -9947,9 +11506,89 @@
         </parameters>
       </method>
     </object>
-    <object name="FontSelection" cname="GtkFontSelection" parent="GtkVBox">
+    <object name="FontChooserDialog" cname="GtkFontChooserDialog" parent="GtkDialog">
+      <class_struct cname="GtkFontChooserDialogClass">
+        <field name="ParentClass" cname="parent_class" type="GtkDialogClass" />
+        <method vm="_gtk_reserved1" />
+        <method vm="_gtk_reserved2" />
+        <method vm="_gtk_reserved3" />
+        <method vm="_gtk_reserved4" />
+      </class_struct>
+      <field name="Priv" cname="priv" type="GtkFontChooserDialogPrivate*" />
+      <virtual_method name="GtkReserved1" cname="_gtk_reserved1" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <virtual_method name="GtkReserved2" cname="_gtk_reserved2" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <virtual_method name="GtkReserved3" cname="_gtk_reserved3" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <virtual_method name="GtkReserved4" cname="_gtk_reserved4" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <implements>
+        <interface cname="GtkFontChooser" />
+        <interface cname="GtkBuildable" />
+      </implements>
+      <method name="GetType" cname="gtk_font_chooser_dialog_get_type" shared="true">
+        <return-type type="GType" />
+      </method>
+      <constructor cname="gtk_font_chooser_dialog_new">
+        <parameters>
+          <parameter type="const-gchar*" name="title" />
+          <parameter type="GtkWindow*" name="parent" />
+        </parameters>
+      </constructor>
+    </object>
+    <object name="FontChooserWidget" cname="GtkFontChooserWidget" parent="GtkBox">
+      <class_struct cname="GtkFontChooserWidgetClass">
+        <field name="ParentClass" cname="parent_class" type="GtkBoxClass" />
+        <method vm="_gtk_reserved1" />
+        <method vm="_gtk_reserved2" />
+        <method vm="_gtk_reserved3" />
+        <method vm="_gtk_reserved4" />
+        <method vm="_gtk_reserved5" />
+        <method vm="_gtk_reserved6" />
+        <method vm="_gtk_reserved7" />
+        <method vm="_gtk_reserved8" />
+      </class_struct>
+      <field name="Priv" cname="priv" type="GtkFontChooserWidgetPrivate*" />
+      <virtual_method name="GtkReserved1" cname="_gtk_reserved1" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <virtual_method name="GtkReserved2" cname="_gtk_reserved2" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <virtual_method name="GtkReserved3" cname="_gtk_reserved3" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <virtual_method name="GtkReserved4" cname="_gtk_reserved4" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <virtual_method name="GtkReserved5" cname="_gtk_reserved5" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <virtual_method name="GtkReserved6" cname="_gtk_reserved6" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <virtual_method name="GtkReserved7" cname="_gtk_reserved7" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <virtual_method name="GtkReserved8" cname="_gtk_reserved8" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <implements>
+        <interface cname="GtkFontChooser" />
+      </implements>
+      <method name="GetType" cname="gtk_font_chooser_widget_get_type" shared="true">
+        <return-type type="GType" />
+      </method>
+      <constructor cname="gtk_font_chooser_widget_new" />
+    </object>
+    <object name="FontSelection" cname="GtkFontSelection" parent="GtkBox">
       <class_struct cname="GtkFontSelectionClass">
-        <field name="ParentClass" cname="parent_class" type="GtkVBoxClass" />
+        <field name="ParentClass" cname="parent_class" type="GtkBoxClass" />
         <method vm="_gtk_reserved1" />
         <method vm="_gtk_reserved2" />
         <method vm="_gtk_reserved3" />
@@ -9970,47 +11609,47 @@
       <virtual_method name="GtkReserved4" cname="_gtk_reserved4" shared="true" padding="true">
         <return-type type="void" />
       </virtual_method>
-      <method name="GetFace" cname="gtk_font_selection_get_face">
+      <method name="GetFace" cname="gtk_font_selection_get_face" deprecated="1">
         <return-type type="PangoFontFace*" />
       </method>
-      <method name="GetFaceList" cname="gtk_font_selection_get_face_list">
+      <method name="GetFaceList" cname="gtk_font_selection_get_face_list" deprecated="1">
         <return-type type="GtkWidget*" />
       </method>
-      <method name="GetFamily" cname="gtk_font_selection_get_family">
+      <method name="GetFamily" cname="gtk_font_selection_get_family" deprecated="1">
         <return-type type="PangoFontFamily*" />
       </method>
-      <method name="GetFamilyList" cname="gtk_font_selection_get_family_list">
+      <method name="GetFamilyList" cname="gtk_font_selection_get_family_list" deprecated="1">
         <return-type type="GtkWidget*" />
       </method>
-      <method name="GetFontName" cname="gtk_font_selection_get_font_name">
+      <method name="GetFontName" cname="gtk_font_selection_get_font_name" deprecated="1">
         <return-type type="gchar*" />
       </method>
-      <method name="GetPreviewEntry" cname="gtk_font_selection_get_preview_entry">
+      <method name="GetPreviewEntry" cname="gtk_font_selection_get_preview_entry" deprecated="1">
         <return-type type="GtkWidget*" />
       </method>
-      <method name="GetPreviewText" cname="gtk_font_selection_get_preview_text">
+      <method name="GetPreviewText" cname="gtk_font_selection_get_preview_text" deprecated="1">
         <return-type type="const-gchar*" />
       </method>
-      <method name="GetSize" cname="gtk_font_selection_get_size">
+      <method name="GetSize" cname="gtk_font_selection_get_size" deprecated="1">
         <return-type type="gint" />
       </method>
-      <method name="GetSizeEntry" cname="gtk_font_selection_get_size_entry">
+      <method name="GetSizeEntry" cname="gtk_font_selection_get_size_entry" deprecated="1">
         <return-type type="GtkWidget*" />
       </method>
-      <method name="GetSizeList" cname="gtk_font_selection_get_size_list">
+      <method name="GetSizeList" cname="gtk_font_selection_get_size_list" deprecated="1">
         <return-type type="GtkWidget*" />
       </method>
-      <method name="GetType" cname="gtk_font_selection_get_type" shared="true">
+      <method name="GetType" cname="gtk_font_selection_get_type" deprecated="1" shared="true">
         <return-type type="GType" />
       </method>
-      <constructor cname="gtk_font_selection_new" />
-      <method name="SetFontName" cname="gtk_font_selection_set_font_name">
+      <constructor cname="gtk_font_selection_new" deprecated="1" />
+      <method name="SetFontName" cname="gtk_font_selection_set_font_name" deprecated="1">
         <return-type type="gboolean" />
         <parameters>
           <parameter type="const-gchar*" name="fontname" />
         </parameters>
       </method>
-      <method name="SetPreviewText" cname="gtk_font_selection_set_preview_text">
+      <method name="SetPreviewText" cname="gtk_font_selection_set_preview_text" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="const-gchar*" name="text" />
@@ -10041,36 +11680,36 @@
       <implements>
         <interface cname="GtkBuildable" />
       </implements>
-      <method name="GetCancelButton" cname="gtk_font_selection_dialog_get_cancel_button">
+      <method name="GetCancelButton" cname="gtk_font_selection_dialog_get_cancel_button" deprecated="1">
         <return-type type="GtkWidget*" />
       </method>
-      <method name="GetFontName" cname="gtk_font_selection_dialog_get_font_name">
+      <method name="GetFontName" cname="gtk_font_selection_dialog_get_font_name" deprecated="1">
         <return-type type="gchar*" />
       </method>
-      <method name="GetFontSelection" cname="gtk_font_selection_dialog_get_font_selection">
+      <method name="GetFontSelection" cname="gtk_font_selection_dialog_get_font_selection" deprecated="1">
         <return-type type="GtkWidget*" />
       </method>
-      <method name="GetOkButton" cname="gtk_font_selection_dialog_get_ok_button">
+      <method name="GetOkButton" cname="gtk_font_selection_dialog_get_ok_button" deprecated="1">
         <return-type type="GtkWidget*" />
       </method>
-      <method name="GetPreviewText" cname="gtk_font_selection_dialog_get_preview_text">
+      <method name="GetPreviewText" cname="gtk_font_selection_dialog_get_preview_text" deprecated="1">
         <return-type type="const-gchar*" />
       </method>
-      <method name="GetType" cname="gtk_font_selection_dialog_get_type" shared="true">
+      <method name="GetType" cname="gtk_font_selection_dialog_get_type" deprecated="1" shared="true">
         <return-type type="GType" />
       </method>
-      <constructor cname="gtk_font_selection_dialog_new">
+      <constructor cname="gtk_font_selection_dialog_new" deprecated="1">
         <parameters>
           <parameter type="const-gchar*" name="title" />
         </parameters>
       </constructor>
-      <method name="SetFontName" cname="gtk_font_selection_dialog_set_font_name">
+      <method name="SetFontName" cname="gtk_font_selection_dialog_set_font_name" deprecated="1">
         <return-type type="gboolean" />
         <parameters>
           <parameter type="const-gchar*" name="fontname" />
         </parameters>
       </method>
-      <method name="SetPreviewText" cname="gtk_font_selection_dialog_set_preview_text">
+      <method name="SetPreviewText" cname="gtk_font_selection_dialog_set_preview_text" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="const-gchar*" name="text" />
@@ -10163,6 +11802,437 @@
         </parameters>
       </method>
     </object>
+    <object name="Gesture" cname="GtkGesture" parent="GtkEventController">
+      <class_struct cname="GtkGestureClass">
+        <field name="ParentClass" cname="parent_class" type="GtkEventControllerClass" />
+        <method vm="check" />
+        <method signal_vm="begin" />
+        <method signal_vm="update" />
+        <method signal_vm="end" />
+        <method signal_vm="cancel" />
+        <method signal_vm="sequence_state_changed" />
+        <field name="Padding" cname="padding" type="gpointer" array_len="10" />
+      </class_struct>
+      <property name="NPoints" cname="n-points" type="guint" readable="true" writeable="true" construct-only="true" />
+      <property name="Window" cname="window" type="GdkWindow" readable="true" writeable="true" />
+      <signal name="Begin" cname="begin" when="LAST" field_name="begin">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GdkEventSequence*" name="sequence" />
+        </parameters>
+      </signal>
+      <signal name="End" cname="end" when="LAST" field_name="end">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GdkEventSequence*" name="sequence" />
+        </parameters>
+      </signal>
+      <signal name="Update" cname="update" when="LAST" field_name="update">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GdkEventSequence*" name="sequence" />
+        </parameters>
+      </signal>
+      <signal name="Cancel" cname="cancel" when="LAST" field_name="cancel">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GdkEventSequence*" name="sequence" />
+        </parameters>
+      </signal>
+      <signal name="SequenceStateChanged" cname="sequence-state-changed" when="LAST" field_name="sequence_state_changed">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GdkEventSequence*" name="sequence" />
+          <parameter type="GtkEventSequenceState" name="state" />
+        </parameters>
+      </signal>
+      <virtual_method name="Check" cname="check">
+        <return-type type="gboolean" />
+        <parameters />
+      </virtual_method>
+      <method name="GetBoundingBox" cname="gtk_gesture_get_bounding_box">
+        <return-type type="gboolean" />
+        <parameters>
+          <parameter type="GdkRectangle*" name="rect" />
+        </parameters>
+      </method>
+      <method name="GetBoundingBoxCenter" cname="gtk_gesture_get_bounding_box_center">
+        <return-type type="gboolean" />
+        <parameters>
+          <parameter type="gdouble*" name="x" />
+          <parameter type="gdouble*" name="y" />
+        </parameters>
+      </method>
+      <method name="GetDevice" cname="gtk_gesture_get_device">
+        <return-type type="GdkDevice*" />
+      </method>
+      <method name="GetGroup" cname="gtk_gesture_get_group">
+        <return-type type="GList*" />
+      </method>
+      <method name="GetLastEvent" cname="gtk_gesture_get_last_event">
+        <return-type type="const-GdkEvent*" />
+        <parameters>
+          <parameter type="GdkEventSequence*" name="sequence" />
+        </parameters>
+      </method>
+      <method name="GetLastUpdatedSequence" cname="gtk_gesture_get_last_updated_sequence">
+        <return-type type="GdkEventSequence*" />
+      </method>
+      <method name="GetPoint" cname="gtk_gesture_get_point">
+        <return-type type="gboolean" />
+        <parameters>
+          <parameter type="GdkEventSequence*" name="sequence" />
+          <parameter type="gdouble*" name="x" />
+          <parameter type="gdouble*" name="y" />
+        </parameters>
+      </method>
+      <method name="GetSequenceState" cname="gtk_gesture_get_sequence_state">
+        <return-type type="GtkEventSequenceState" />
+        <parameters>
+          <parameter type="GdkEventSequence*" name="sequence" />
+        </parameters>
+      </method>
+      <method name="GetSequences" cname="gtk_gesture_get_sequences">
+        <return-type type="GList*" />
+      </method>
+      <method name="GetType" cname="gtk_gesture_get_type" shared="true">
+        <return-type type="GType" />
+      </method>
+      <method name="GetWindow" cname="gtk_gesture_get_window">
+        <return-type type="GdkWindow*" />
+      </method>
+      <method name="Group" cname="gtk_gesture_group">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkGesture*" name="gesture" />
+        </parameters>
+      </method>
+      <method name="HandlesSequence" cname="gtk_gesture_handles_sequence">
+        <return-type type="gboolean" />
+        <parameters>
+          <parameter type="GdkEventSequence*" name="sequence" />
+        </parameters>
+      </method>
+      <method name="IsActive" cname="gtk_gesture_is_active">
+        <return-type type="gboolean" />
+      </method>
+      <method name="IsGroupedWith" cname="gtk_gesture_is_grouped_with">
+        <return-type type="gboolean" />
+        <parameters>
+          <parameter type="GtkGesture*" name="other" />
+        </parameters>
+      </method>
+      <method name="IsRecognized" cname="gtk_gesture_is_recognized">
+        <return-type type="gboolean" />
+      </method>
+      <method name="SetSequenceState" cname="gtk_gesture_set_sequence_state">
+        <return-type type="gboolean" />
+        <parameters>
+          <parameter type="GdkEventSequence*" name="sequence" />
+          <parameter type="GtkEventSequenceState" name="state" />
+        </parameters>
+      </method>
+      <method name="SetState" cname="gtk_gesture_set_state">
+        <return-type type="gboolean" />
+        <parameters>
+          <parameter type="GtkEventSequenceState" name="state" />
+        </parameters>
+      </method>
+      <method name="SetWindow" cname="gtk_gesture_set_window">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GdkWindow*" name="window" />
+        </parameters>
+      </method>
+      <method name="Ungroup" cname="gtk_gesture_ungroup">
+        <return-type type="void" />
+      </method>
+    </object>
+    <object name="GestureDrag" cname="GtkGestureDrag" parent="GtkGestureSingle">
+      <class_struct cname="GtkGestureDragClass">
+        <field name="ParentClass" cname="parent_class" type="GtkGestureSingleClass" />
+        <method signal_vm="drag_begin" />
+        <method signal_vm="drag_update" />
+        <method signal_vm="drag_end" />
+        <field name="Padding" cname="padding" type="gpointer" array_len="10" />
+      </class_struct>
+      <signal name="DragBegin" cname="drag-begin" when="LAST" field_name="drag_begin">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gdouble" name="start_x" />
+          <parameter type="gdouble" name="start_y" />
+        </parameters>
+      </signal>
+      <signal name="DragUpdate" cname="drag-update" when="LAST" field_name="drag_update">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gdouble" name="offset_x" />
+          <parameter type="gdouble" name="offset_y" />
+        </parameters>
+      </signal>
+      <signal name="DragEnd" cname="drag-end" when="LAST" field_name="drag_end">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gdouble" name="offset_x" />
+          <parameter type="gdouble" name="offset_y" />
+        </parameters>
+      </signal>
+      <method name="GetOffset" cname="gtk_gesture_drag_get_offset">
+        <return-type type="gboolean" />
+        <parameters>
+          <parameter type="gdouble*" name="x" />
+          <parameter type="gdouble*" name="y" />
+        </parameters>
+      </method>
+      <method name="GetStartPoint" cname="gtk_gesture_drag_get_start_point">
+        <return-type type="gboolean" />
+        <parameters>
+          <parameter type="gdouble*" name="x" />
+          <parameter type="gdouble*" name="y" />
+        </parameters>
+      </method>
+      <method name="GetType" cname="gtk_gesture_drag_get_type" shared="true">
+        <return-type type="GType" />
+      </method>
+      <constructor cname="gtk_gesture_drag_new">
+        <parameters>
+          <parameter type="GtkWidget*" name="widget" />
+        </parameters>
+      </constructor>
+    </object>
+    <object name="GestureLongPress" cname="GtkGestureLongPress" parent="GtkGestureSingle">
+      <class_struct cname="GtkGestureLongPressClass">
+        <field name="ParentClass" cname="parent_class" type="GtkGestureSingleClass" />
+        <method signal_vm="pressed" />
+        <method signal_vm="cancelled" />
+        <field name="Padding" cname="padding" type="gpointer" array_len="10" />
+      </class_struct>
+      <property name="DelayFactor" cname="delay-factor" type="gdouble" readable="true" writeable="true" />
+      <signal name="Pressed" cname="pressed" when="LAST" field_name="pressed">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gdouble" name="x" />
+          <parameter type="gdouble" name="y" />
+        </parameters>
+      </signal>
+      <signal name="Cancelled" cname="cancelled" when="LAST" field_name="cancelled">
+        <return-type type="void" />
+        <parameters />
+      </signal>
+      <method name="GetType" cname="gtk_gesture_long_press_get_type" shared="true">
+        <return-type type="GType" />
+      </method>
+      <constructor cname="gtk_gesture_long_press_new">
+        <parameters>
+          <parameter type="GtkWidget*" name="widget" />
+        </parameters>
+      </constructor>
+    </object>
+    <object name="GestureMultiPress" cname="GtkGestureMultiPress" parent="GtkGestureSingle">
+      <class_struct cname="GtkGestureMultiPressClass">
+        <field name="ParentClass" cname="parent_class" type="GtkGestureSingleClass" />
+        <method signal_vm="pressed" />
+        <method signal_vm="released" />
+        <method signal_vm="stopped" />
+        <field name="Padding" cname="padding" type="gpointer" array_len="10" />
+      </class_struct>
+      <signal name="Pressed" cname="pressed" when="LAST" field_name="pressed">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gint" name="n_press" />
+          <parameter type="gdouble" name="x" />
+          <parameter type="gdouble" name="y" />
+        </parameters>
+      </signal>
+      <signal name="Released" cname="released" when="LAST" field_name="released">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gint" name="n_press" />
+          <parameter type="gdouble" name="x" />
+          <parameter type="gdouble" name="y" />
+        </parameters>
+      </signal>
+      <signal name="Stopped" cname="stopped" when="LAST" field_name="stopped">
+        <return-type type="void" />
+        <parameters />
+      </signal>
+      <method name="GetArea" cname="gtk_gesture_multi_press_get_area">
+        <return-type type="gboolean" />
+        <parameters>
+          <parameter type="GdkRectangle*" name="rect" />
+        </parameters>
+      </method>
+      <method name="GetType" cname="gtk_gesture_multi_press_get_type" shared="true">
+        <return-type type="GType" />
+      </method>
+      <constructor cname="gtk_gesture_multi_press_new">
+        <parameters>
+          <parameter type="GtkWidget*" name="widget" />
+        </parameters>
+      </constructor>
+      <method name="SetArea" cname="gtk_gesture_multi_press_set_area">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="const-GdkRectangle*" name="rect" />
+        </parameters>
+      </method>
+    </object>
+    <object name="GesturePan" cname="GtkGesturePan" parent="GtkGestureDrag">
+      <class_struct cname="GtkGesturePanClass">
+        <field name="ParentClass" cname="parent_class" type="GtkGestureDragClass" />
+        <method signal_vm="pan" />
+        <field name="Padding" cname="padding" type="gpointer" array_len="10" />
+      </class_struct>
+      <property name="Orientation" cname="orientation" type="GtkOrientation" readable="true" writeable="true" />
+      <signal name="Pan" cname="pan" when="LAST" field_name="pan">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkPanDirection" name="direction" />
+          <parameter type="gdouble" name="offset" />
+        </parameters>
+      </signal>
+      <method name="GetOrientation" cname="gtk_gesture_pan_get_orientation">
+        <return-type type="GtkOrientation" />
+      </method>
+      <method name="GetType" cname="gtk_gesture_pan_get_type" shared="true">
+        <return-type type="GType" />
+      </method>
+      <constructor cname="gtk_gesture_pan_new">
+        <parameters>
+          <parameter type="GtkWidget*" name="widget" />
+          <parameter type="GtkOrientation" name="orientation" />
+        </parameters>
+      </constructor>
+      <method name="SetOrientation" cname="gtk_gesture_pan_set_orientation">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkOrientation" name="orientation" />
+        </parameters>
+      </method>
+    </object>
+    <object name="GestureRotate" cname="GtkGestureRotate" parent="GtkGesture">
+      <class_struct cname="GtkGestureRotateClass">
+        <field name="ParentClass" cname="parent_class" type="GtkGestureClass" />
+        <method signal_vm="angle_changed" />
+        <field name="Padding" cname="padding" type="gpointer" array_len="10" />
+      </class_struct>
+      <signal name="AngleChanged" cname="angle-changed" when="FIRST" field_name="angle_changed">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gdouble" name="angle" />
+          <parameter type="gdouble" name="delta" />
+        </parameters>
+      </signal>
+      <method name="GetAngleDelta" cname="gtk_gesture_rotate_get_angle_delta">
+        <return-type type="gdouble" />
+      </method>
+      <method name="GetType" cname="gtk_gesture_rotate_get_type" shared="true">
+        <return-type type="GType" />
+      </method>
+      <constructor cname="gtk_gesture_rotate_new">
+        <parameters>
+          <parameter type="GtkWidget*" name="widget" />
+        </parameters>
+      </constructor>
+    </object>
+    <object name="GestureSingle" cname="GtkGestureSingle" parent="GtkGesture">
+      <class_struct cname="GtkGestureSingleClass">
+        <field name="ParentClass" cname="parent_class" type="GtkGestureClass" />
+        <field name="Padding" cname="padding" type="gpointer" array_len="10" />
+      </class_struct>
+      <property name="TouchOnly" cname="touch-only" type="gboolean" readable="true" writeable="true" />
+      <property name="Exclusive" cname="exclusive" type="gboolean" readable="true" writeable="true" />
+      <property name="Button" cname="button" type="guint" readable="true" writeable="true" />
+      <method name="GetButton" cname="gtk_gesture_single_get_button">
+        <return-type type="guint" />
+      </method>
+      <method name="GetCurrentButton" cname="gtk_gesture_single_get_current_button">
+        <return-type type="guint" />
+      </method>
+      <method name="GetCurrentSequence" cname="gtk_gesture_single_get_current_sequence">
+        <return-type type="GdkEventSequence*" />
+      </method>
+      <method name="GetExclusive" cname="gtk_gesture_single_get_exclusive">
+        <return-type type="gboolean" />
+      </method>
+      <method name="GetTouchOnly" cname="gtk_gesture_single_get_touch_only">
+        <return-type type="gboolean" />
+      </method>
+      <method name="GetType" cname="gtk_gesture_single_get_type" shared="true">
+        <return-type type="GType" />
+      </method>
+      <method name="SetButton" cname="gtk_gesture_single_set_button">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="guint" name="button" />
+        </parameters>
+      </method>
+      <method name="SetExclusive" cname="gtk_gesture_single_set_exclusive">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gboolean" name="exclusive" />
+        </parameters>
+      </method>
+      <method name="SetTouchOnly" cname="gtk_gesture_single_set_touch_only">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gboolean" name="touch_only" />
+        </parameters>
+      </method>
+    </object>
+    <object name="GestureSwipe" cname="GtkGestureSwipe" parent="GtkGestureSingle">
+      <class_struct cname="GtkGestureSwipeClass">
+        <field name="ParentClass" cname="parent_class" type="GtkGestureSingleClass" />
+        <method signal_vm="swipe" />
+        <field name="Padding" cname="padding" type="gpointer" array_len="10" />
+      </class_struct>
+      <signal name="Swipe" cname="swipe" when="LAST" field_name="swipe">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gdouble" name="velocity_x" />
+          <parameter type="gdouble" name="velocity_y" />
+        </parameters>
+      </signal>
+      <method name="GetType" cname="gtk_gesture_swipe_get_type" shared="true">
+        <return-type type="GType" />
+      </method>
+      <method name="GetVelocity" cname="gtk_gesture_swipe_get_velocity">
+        <return-type type="gboolean" />
+        <parameters>
+          <parameter type="gdouble*" name="velocity_x" />
+          <parameter type="gdouble*" name="velocity_y" />
+        </parameters>
+      </method>
+      <constructor cname="gtk_gesture_swipe_new">
+        <parameters>
+          <parameter type="GtkWidget*" name="widget" />
+        </parameters>
+      </constructor>
+    </object>
+    <object name="GestureZoom" cname="GtkGestureZoom" parent="GtkGesture">
+      <class_struct cname="GtkGestureZoomClass">
+        <field name="ParentClass" cname="parent_class" type="GtkGestureClass" />
+        <method signal_vm="scale_changed" />
+        <field name="Padding" cname="padding" type="gpointer" array_len="10" />
+      </class_struct>
+      <signal name="ScaleChanged" cname="scale-changed" when="FIRST" field_name="scale_changed">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gdouble" name="scale" />
+        </parameters>
+      </signal>
+      <method name="GetScaleDelta" cname="gtk_gesture_zoom_get_scale_delta">
+        <return-type type="gdouble" />
+      </method>
+      <method name="GetType" cname="gtk_gesture_zoom_get_type" shared="true">
+        <return-type type="GType" />
+      </method>
+      <constructor cname="gtk_gesture_zoom_new">
+        <parameters>
+          <parameter type="GtkWidget*" name="widget" />
+        </parameters>
+      </constructor>
+    </object>
     <object name="Grid" cname="GtkGrid" parent="GtkContainer">
       <class_struct cname="GtkGridClass">
         <field name="ParentClass" cname="parent_class" type="GtkContainerClass" />
@@ -10176,10 +12246,7 @@
         <method vm="_gtk_reserved8" />
       </class_struct>
       <field name="Priv" cname="priv" type="GtkGridPrivate*" />
-      <property name="RowSpacing" cname="row-spacing" type="gint" readable="true" writeable="true" />
-      <property name="ColumnSpacing" cname="column-spacing" type="gint" readable="true" writeable="true" />
-      <property name="RowHomogeneous" cname="row-homogeneous" type="gboolean" readable="true" writeable="true" />
-      <property name="ColumnHomogeneous" cname="column-homogeneous" type="gboolean" readable="true" writeable="true" />
+      <property name="BaselineRow" cname="baseline-row" type="gint" readable="true" writeable="true" />
       <childprop name="LeftAttach" cname="left-attach" type="gint" readable="true" writeable="true" />
       <childprop name="TopAttach" cname="top-attach" type="gint" readable="true" writeable="true" />
       <childprop name="Width" cname="width" type="gint" readable="true" writeable="true" />
@@ -10231,11 +12298,27 @@
           <parameter type="gint" name="height" />
         </parameters>
       </method>
+      <method name="GetBaselineRow" cname="gtk_grid_get_baseline_row">
+        <return-type type="gint" />
+      </method>
+      <method name="GetChildAt" cname="gtk_grid_get_child_at">
+        <return-type type="GtkWidget*" />
+        <parameters>
+          <parameter type="gint" name="left" />
+          <parameter type="gint" name="top" />
+        </parameters>
+      </method>
       <method name="GetColumnHomogeneous" cname="gtk_grid_get_column_homogeneous">
         <return-type type="gboolean" />
       </method>
       <method name="GetColumnSpacing" cname="gtk_grid_get_column_spacing">
         <return-type type="guint" />
+      </method>
+      <method name="GetRowBaselinePosition" cname="gtk_grid_get_row_baseline_position">
+        <return-type type="GtkBaselinePosition" />
+        <parameters>
+          <parameter type="gint" name="row" />
+        </parameters>
       </method>
       <method name="GetRowHomogeneous" cname="gtk_grid_get_row_homogeneous">
         <return-type type="gboolean" />
@@ -10246,7 +12329,44 @@
       <method name="GetType" cname="gtk_grid_get_type" shared="true">
         <return-type type="GType" />
       </method>
+      <method name="InsertColumn" cname="gtk_grid_insert_column">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gint" name="position" />
+        </parameters>
+      </method>
+      <method name="InsertNextTo" cname="gtk_grid_insert_next_to">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkWidget*" name="sibling" />
+          <parameter type="GtkPositionType" name="side" />
+        </parameters>
+      </method>
+      <method name="InsertRow" cname="gtk_grid_insert_row">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gint" name="position" />
+        </parameters>
+      </method>
       <constructor cname="gtk_grid_new" />
+      <method name="RemoveColumn" cname="gtk_grid_remove_column">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gint" name="position" />
+        </parameters>
+      </method>
+      <method name="RemoveRow" cname="gtk_grid_remove_row">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gint" name="position" />
+        </parameters>
+      </method>
+      <method name="SetBaselineRow" cname="gtk_grid_set_baseline_row">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gint" name="row" />
+        </parameters>
+      </method>
       <method name="SetColumnHomogeneous" cname="gtk_grid_set_column_homogeneous">
         <return-type type="void" />
         <parameters>
@@ -10257,6 +12377,13 @@
         <return-type type="void" />
         <parameters>
           <parameter type="guint" name="spacing" />
+        </parameters>
+      </method>
+      <method name="SetRowBaselinePosition" cname="gtk_grid_set_row_baseline_position">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gint" name="row" />
+          <parameter type="GtkBaselinePosition" name="pos" />
         </parameters>
       </method>
       <method name="SetRowHomogeneous" cname="gtk_grid_set_row_homogeneous">
@@ -10312,35 +12439,35 @@
       <virtual_method name="GtkReserved4" cname="_gtk_reserved4" shared="true" padding="true">
         <return-type type="void" />
       </virtual_method>
-      <method name="GetChildDetached" cname="gtk_handle_box_get_child_detached">
+      <method name="GetChildDetached" cname="gtk_handle_box_get_child_detached" deprecated="1">
         <return-type type="gboolean" />
       </method>
-      <method name="GetHandlePosition" cname="gtk_handle_box_get_handle_position">
+      <method name="GetHandlePosition" cname="gtk_handle_box_get_handle_position" deprecated="1">
         <return-type type="GtkPositionType" />
       </method>
-      <method name="GetShadowType" cname="gtk_handle_box_get_shadow_type">
+      <method name="GetShadowType" cname="gtk_handle_box_get_shadow_type" deprecated="1">
         <return-type type="GtkShadowType" />
       </method>
-      <method name="GetSnapEdge" cname="gtk_handle_box_get_snap_edge">
+      <method name="GetSnapEdge" cname="gtk_handle_box_get_snap_edge" deprecated="1">
         <return-type type="GtkPositionType" />
       </method>
-      <method name="GetType" cname="gtk_handle_box_get_type" shared="true">
+      <method name="GetType" cname="gtk_handle_box_get_type" deprecated="1" shared="true">
         <return-type type="GType" />
       </method>
-      <constructor cname="gtk_handle_box_new" />
-      <method name="SetHandlePosition" cname="gtk_handle_box_set_handle_position">
+      <constructor cname="gtk_handle_box_new" deprecated="1" />
+      <method name="SetHandlePosition" cname="gtk_handle_box_set_handle_position" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="GtkPositionType" name="position" />
         </parameters>
       </method>
-      <method name="SetShadowType" cname="gtk_handle_box_set_shadow_type">
+      <method name="SetShadowType" cname="gtk_handle_box_set_shadow_type" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="GtkShadowType" name="type" />
         </parameters>
       </method>
-      <method name="SetSnapEdge" cname="gtk_handle_box_set_snap_edge">
+      <method name="SetSnapEdge" cname="gtk_handle_box_set_snap_edge" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="GtkPositionType" name="edge" />
@@ -10351,10 +12478,10 @@
       <class_struct cname="GtkHBoxClass">
         <field name="ParentClass" cname="parent_class" type="GtkBoxClass" />
       </class_struct>
-      <method name="GetType" cname="gtk_hbox_get_type" shared="true">
+      <method name="GetType" cname="gtk_hbox_get_type" deprecated="1" shared="true">
         <return-type type="GType" />
       </method>
-      <constructor cname="gtk_hbox_new">
+      <constructor cname="gtk_hbox_new" deprecated="1">
         <parameters>
           <parameter type="gboolean" name="homogeneous" />
           <parameter type="gint" name="spacing" />
@@ -10365,33 +12492,137 @@
       <class_struct cname="GtkHButtonBoxClass">
         <field name="ParentClass" cname="parent_class" type="GtkButtonBoxClass" />
       </class_struct>
-      <method name="GetType" cname="gtk_hbutton_box_get_type" shared="true">
+      <method name="GetType" cname="gtk_hbutton_box_get_type" deprecated="1" shared="true">
         <return-type type="GType" />
       </method>
-      <constructor cname="gtk_hbutton_box_new" />
+      <constructor cname="gtk_hbutton_box_new" deprecated="1" />
+    </object>
+    <object name="HeaderBar" cname="GtkHeaderBar" parent="GtkContainer">
+      <class_struct cname="GtkHeaderBarClass">
+        <field name="ParentClass" cname="parent_class" type="GtkContainerClass" />
+        <method vm="_gtk_reserved1" />
+        <method vm="_gtk_reserved2" />
+        <method vm="_gtk_reserved3" />
+        <method vm="_gtk_reserved4" />
+      </class_struct>
+      <childprop name="PackType" cname="pack-type" type="GtkPackType" readable="true" writeable="true" />
+      <childprop name="Position" cname="position" type="gint" readable="true" />
+      <property name="Title" cname="title" type="gchar*" readable="true" writeable="true" />
+      <property name="Subtitle" cname="subtitle" type="gchar*" readable="true" writeable="true" />
+      <property name="CustomTitle" cname="custom-title" type="GtkWidget" readable="true" writeable="true" construct="true" />
+      <property name="Spacing" cname="spacing" type="gint" readable="true" writeable="true" />
+      <property name="ShowCloseButton" cname="show-close-button" type="gboolean" readable="true" writeable="true" />
+      <property name="DecorationLayout" cname="decoration-layout" type="gchar*" readable="true" writeable="true" />
+      <property name="DecorationLayoutSet" cname="decoration-layout-set" type="gboolean" readable="true" writeable="true" />
+      <property name="HasSubtitle" cname="has-subtitle" type="gboolean" readable="true" writeable="true" />
+      <virtual_method name="GtkReserved1" cname="_gtk_reserved1" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <virtual_method name="GtkReserved2" cname="_gtk_reserved2" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <virtual_method name="GtkReserved3" cname="_gtk_reserved3" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <virtual_method name="GtkReserved4" cname="_gtk_reserved4" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <implements>
+        <interface cname="GtkBuildable" />
+      </implements>
+      <method name="GetCustomTitle" cname="gtk_header_bar_get_custom_title">
+        <return-type type="GtkWidget*" />
+      </method>
+      <method name="GetDecorationLayout" cname="gtk_header_bar_get_decoration_layout">
+        <return-type type="const-gchar*" />
+      </method>
+      <method name="GetHasSubtitle" cname="gtk_header_bar_get_has_subtitle">
+        <return-type type="gboolean" />
+      </method>
+      <method name="GetShowCloseButton" cname="gtk_header_bar_get_show_close_button">
+        <return-type type="gboolean" />
+      </method>
+      <method name="GetSubtitle" cname="gtk_header_bar_get_subtitle">
+        <return-type type="const-gchar*" />
+      </method>
+      <method name="GetTitle" cname="gtk_header_bar_get_title">
+        <return-type type="const-gchar*" />
+      </method>
+      <method name="GetType" cname="gtk_header_bar_get_type" shared="true">
+        <return-type type="GType" />
+      </method>
+      <constructor cname="gtk_header_bar_new" />
+      <method name="PackEnd" cname="gtk_header_bar_pack_end">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkWidget*" name="child" />
+        </parameters>
+      </method>
+      <method name="PackStart" cname="gtk_header_bar_pack_start">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkWidget*" name="child" />
+        </parameters>
+      </method>
+      <method name="SetCustomTitle" cname="gtk_header_bar_set_custom_title">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkWidget*" name="title_widget" />
+        </parameters>
+      </method>
+      <method name="SetDecorationLayout" cname="gtk_header_bar_set_decoration_layout">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="const-gchar*" name="layout" />
+        </parameters>
+      </method>
+      <method name="SetHasSubtitle" cname="gtk_header_bar_set_has_subtitle">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gboolean" name="setting" />
+        </parameters>
+      </method>
+      <method name="SetShowCloseButton" cname="gtk_header_bar_set_show_close_button">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gboolean" name="setting" />
+        </parameters>
+      </method>
+      <method name="SetSubtitle" cname="gtk_header_bar_set_subtitle">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="const-gchar*" name="subtitle" />
+        </parameters>
+      </method>
+      <method name="SetTitle" cname="gtk_header_bar_set_title">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="const-gchar*" name="title" />
+        </parameters>
+      </method>
     </object>
     <object name="HPaned" cname="GtkHPaned" parent="GtkPaned">
       <class_struct cname="GtkHPanedClass">
         <field name="ParentClass" cname="parent_class" type="GtkPanedClass" />
       </class_struct>
-      <method name="GetType" cname="gtk_hpaned_get_type" shared="true">
+      <method name="GetType" cname="gtk_hpaned_get_type" deprecated="1" shared="true">
         <return-type type="GType" />
       </method>
-      <constructor cname="gtk_hpaned_new" />
+      <constructor cname="gtk_hpaned_new" deprecated="1" />
     </object>
     <object name="HScale" cname="GtkHScale" parent="GtkScale">
       <class_struct cname="GtkHScaleClass">
         <field name="ParentClass" cname="parent_class" type="GtkScaleClass" />
       </class_struct>
-      <method name="GetType" cname="gtk_hscale_get_type" shared="true">
+      <method name="GetType" cname="gtk_hscale_get_type" deprecated="1" shared="true">
         <return-type type="GType" />
       </method>
-      <constructor cname="gtk_hscale_new">
+      <constructor cname="gtk_hscale_new" deprecated="1">
         <parameters>
           <parameter type="GtkAdjustment*" name="adjustment" />
         </parameters>
       </constructor>
-      <constructor cname="gtk_hscale_new_with_range">
+      <constructor cname="gtk_hscale_new_with_range" deprecated="1">
         <parameters>
           <parameter type="gdouble" name="min" />
           <parameter type="gdouble" name="max" />
@@ -10403,10 +12634,10 @@
       <class_struct cname="GtkHScrollbarClass">
         <field name="ParentClass" cname="parent_class" type="GtkScrollbarClass" />
       </class_struct>
-      <method name="GetType" cname="gtk_hscrollbar_get_type" shared="true">
+      <method name="GetType" cname="gtk_hscrollbar_get_type" deprecated="1" shared="true">
         <return-type type="GType" />
       </method>
-      <constructor cname="gtk_hscrollbar_new">
+      <constructor cname="gtk_hscrollbar_new" deprecated="1">
         <parameters>
           <parameter type="GtkAdjustment*" name="adjustment" />
         </parameters>
@@ -10416,10 +12647,10 @@
       <class_struct cname="GtkHSeparatorClass">
         <field name="ParentClass" cname="parent_class" type="GtkSeparatorClass" />
       </class_struct>
-      <method name="GetType" cname="gtk_hseparator_get_type" shared="true">
+      <method name="GetType" cname="gtk_hseparator_get_type" deprecated="1" shared="true">
         <return-type type="GType" />
       </method>
-      <constructor cname="gtk_hseparator_new" />
+      <constructor cname="gtk_hseparator_new" deprecated="1" />
     </object>
     <object name="HSV" cname="GtkHSV" parent="GtkWidget">
       <class_struct cname="GtkHSVClass">
@@ -10454,7 +12685,7 @@
       <virtual_method name="GtkReserved4" cname="_gtk_reserved4" shared="true" padding="true">
         <return-type type="void" />
       </virtual_method>
-      <method name="GetColor" cname="gtk_hsv_get_color">
+      <method name="GetColor" cname="gtk_hsv_get_color" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="gdouble*" name="h" />
@@ -10462,21 +12693,21 @@
           <parameter type="gdouble*" name="v" />
         </parameters>
       </method>
-      <method name="GetMetrics" cname="gtk_hsv_get_metrics">
+      <method name="GetMetrics" cname="gtk_hsv_get_metrics" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="gint*" name="size" />
           <parameter type="gint*" name="ring_width" />
         </parameters>
       </method>
-      <method name="GetType" cname="gtk_hsv_get_type" shared="true">
+      <method name="GetType" cname="gtk_hsv_get_type" deprecated="1" shared="true">
         <return-type type="GType" />
       </method>
-      <method name="IsAdjusting" cname="gtk_hsv_is_adjusting">
+      <method name="IsAdjusting" cname="gtk_hsv_is_adjusting" deprecated="1">
         <return-type type="gboolean" />
       </method>
-      <constructor cname="gtk_hsv_new" />
-      <method name="SetColor" cname="gtk_hsv_set_color">
+      <constructor cname="gtk_hsv_new" deprecated="1" />
+      <method name="SetColor" cname="gtk_hsv_set_color" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="double" name="h" />
@@ -10484,7 +12715,7 @@
           <parameter type="double" name="v" />
         </parameters>
       </method>
-      <method name="SetMetrics" cname="gtk_hsv_set_metrics">
+      <method name="SetMetrics" cname="gtk_hsv_set_metrics" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="gint" name="size" />
@@ -10527,34 +12758,184 @@
       <implements>
         <interface cname="GtkBuildable" />
       </implements>
-      <method name="Add" cname="gtk_icon_factory_add">
+      <method name="Add" cname="gtk_icon_factory_add" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="const-gchar*" name="stock_id" />
           <parameter type="GtkIconSet*" name="icon_set" />
         </parameters>
       </method>
-      <method name="AddDefault" cname="gtk_icon_factory_add_default">
+      <method name="AddDefault" cname="gtk_icon_factory_add_default" deprecated="1">
         <return-type type="void" />
       </method>
-      <method name="GetType" cname="gtk_icon_factory_get_type" shared="true">
+      <method name="GetType" cname="gtk_icon_factory_get_type" deprecated="1" shared="true">
         <return-type type="GType" />
       </method>
-      <method name="Lookup" cname="gtk_icon_factory_lookup">
+      <method name="Lookup" cname="gtk_icon_factory_lookup" deprecated="1">
         <return-type type="GtkIconSet*" />
         <parameters>
           <parameter type="const-gchar*" name="stock_id" />
         </parameters>
       </method>
-      <method name="LookupDefault" cname="gtk_icon_factory_lookup_default" shared="true">
+      <method name="LookupDefault" cname="gtk_icon_factory_lookup_default" deprecated="1" shared="true">
         <return-type type="GtkIconSet*" />
         <parameters>
           <parameter type="const-gchar*" name="stock_id" />
         </parameters>
       </method>
-      <constructor cname="gtk_icon_factory_new" />
-      <method name="RemoveDefault" cname="gtk_icon_factory_remove_default">
+      <constructor cname="gtk_icon_factory_new" deprecated="1" />
+      <method name="RemoveDefault" cname="gtk_icon_factory_remove_default" deprecated="1">
         <return-type type="void" />
+      </method>
+    </object>
+    <object name="IconInfo" cname="GtkIconInfo" parent="GObject">
+      <class_struct cname="GtkIconInfoClass">
+        <field name="ParentClass" cname="parent_class" type="GObjectClass" />
+      </class_struct>
+      <method name="Copy" cname="gtk_icon_info_copy" deprecated="1">
+        <return-type type="GtkIconInfo*" owned="true" />
+      </method>
+      <method name="Free" cname="gtk_icon_info_free" deprecated="1">
+        <return-type type="void" />
+      </method>
+      <method name="GetAttachPoints" cname="gtk_icon_info_get_attach_points" deprecated="1">
+        <return-type type="gboolean" />
+        <parameters>
+          <parameter type="GdkPoint**" name="points" />
+          <parameter type="gint*" name="n_points" />
+        </parameters>
+      </method>
+      <method name="GetBaseScale" cname="gtk_icon_info_get_base_scale">
+        <return-type type="gint" />
+      </method>
+      <method name="GetBaseSize" cname="gtk_icon_info_get_base_size">
+        <return-type type="gint" />
+      </method>
+      <method name="GetBuiltinPixbuf" cname="gtk_icon_info_get_builtin_pixbuf" deprecated="1">
+        <return-type type="GdkPixbuf*" />
+      </method>
+      <method name="GetDisplayName" cname="gtk_icon_info_get_display_name" deprecated="1">
+        <return-type type="const-gchar*" />
+      </method>
+      <method name="GetEmbeddedRect" cname="gtk_icon_info_get_embedded_rect" deprecated="1">
+        <return-type type="gboolean" />
+        <parameters>
+          <parameter type="GdkRectangle*" name="rectangle" />
+        </parameters>
+      </method>
+      <method name="GetFilename" cname="gtk_icon_info_get_filename">
+        <return-type type="const-gchar*" />
+      </method>
+      <method name="GetType" cname="gtk_icon_info_get_type" shared="true">
+        <return-type type="GType" />
+      </method>
+      <method name="IsSymbolic" cname="gtk_icon_info_is_symbolic">
+        <return-type type="gboolean" />
+      </method>
+      <method name="LoadIcon" cname="gtk_icon_info_load_icon">
+        <return-type type="GdkPixbuf*" />
+        <parameters>
+          <parameter type="GError**" name="error" />
+        </parameters>
+      </method>
+      <method name="LoadIconAsync" cname="gtk_icon_info_load_icon_async">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GCancellable*" name="cancellable" />
+          <parameter type="GAsyncReadyCallback" name="callback" />
+          <parameter type="gpointer" name="user_data" />
+        </parameters>
+      </method>
+      <method name="LoadIconFinish" cname="gtk_icon_info_load_icon_finish">
+        <return-type type="GdkPixbuf*" />
+        <parameters>
+          <parameter type="GAsyncResult*" name="res" />
+          <parameter type="GError**" name="error" />
+        </parameters>
+      </method>
+      <method name="LoadSurface" cname="gtk_icon_info_load_surface">
+        <return-type type="cairo_surface_t*" />
+        <parameters>
+          <parameter type="GdkWindow*" name="for_window" />
+          <parameter type="GError**" name="error" />
+        </parameters>
+      </method>
+      <method name="LoadSymbolic" cname="gtk_icon_info_load_symbolic">
+        <return-type type="GdkPixbuf*" />
+        <parameters>
+          <parameter type="const-GdkRGBA*" name="fg" />
+          <parameter type="const-GdkRGBA*" name="success_color" />
+          <parameter type="const-GdkRGBA*" name="warning_color" />
+          <parameter type="const-GdkRGBA*" name="error_color" />
+          <parameter type="gboolean*" name="was_symbolic" />
+          <parameter type="GError**" name="error" />
+        </parameters>
+      </method>
+      <method name="LoadSymbolicAsync" cname="gtk_icon_info_load_symbolic_async">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="const-GdkRGBA*" name="fg" />
+          <parameter type="const-GdkRGBA*" name="success_color" />
+          <parameter type="const-GdkRGBA*" name="warning_color" />
+          <parameter type="const-GdkRGBA*" name="error_color" />
+          <parameter type="GCancellable*" name="cancellable" />
+          <parameter type="GAsyncReadyCallback" name="callback" />
+          <parameter type="gpointer" name="user_data" />
+        </parameters>
+      </method>
+      <method name="LoadSymbolicFinish" cname="gtk_icon_info_load_symbolic_finish">
+        <return-type type="GdkPixbuf*" />
+        <parameters>
+          <parameter type="GAsyncResult*" name="res" />
+          <parameter type="gboolean*" name="was_symbolic" />
+          <parameter type="GError**" name="error" />
+        </parameters>
+      </method>
+      <method name="LoadSymbolicForContext" cname="gtk_icon_info_load_symbolic_for_context">
+        <return-type type="GdkPixbuf*" />
+        <parameters>
+          <parameter type="GtkStyleContext*" name="context" />
+          <parameter type="gboolean*" name="was_symbolic" />
+          <parameter type="GError**" name="error" />
+        </parameters>
+      </method>
+      <method name="LoadSymbolicForContextAsync" cname="gtk_icon_info_load_symbolic_for_context_async">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkStyleContext*" name="context" />
+          <parameter type="GCancellable*" name="cancellable" />
+          <parameter type="GAsyncReadyCallback" name="callback" />
+          <parameter type="gpointer" name="user_data" />
+        </parameters>
+      </method>
+      <method name="LoadSymbolicForContextFinish" cname="gtk_icon_info_load_symbolic_for_context_finish">
+        <return-type type="GdkPixbuf*" />
+        <parameters>
+          <parameter type="GAsyncResult*" name="res" />
+          <parameter type="gboolean*" name="was_symbolic" />
+          <parameter type="GError**" name="error" />
+        </parameters>
+      </method>
+      <method name="LoadSymbolicForStyle" cname="gtk_icon_info_load_symbolic_for_style" deprecated="1">
+        <return-type type="GdkPixbuf*" />
+        <parameters>
+          <parameter type="GtkStyle*" name="style" />
+          <parameter type="GtkStateType" name="state" />
+          <parameter type="gboolean*" name="was_symbolic" />
+          <parameter type="GError**" name="error" />
+        </parameters>
+      </method>
+      <constructor cname="gtk_icon_info_new_for_pixbuf">
+        <parameters>
+          <parameter type="GtkIconTheme*" name="icon_theme" />
+          <parameter type="GdkPixbuf*" name="pixbuf" />
+        </parameters>
+      </constructor>
+      <method name="SetRawCoordinates" cname="gtk_icon_info_set_raw_coordinates" deprecated="1">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gboolean" name="raw_coordinates" />
+        </parameters>
       </method>
     </object>
     <object name="IconTheme" cname="GtkIconTheme" parent="GObject">
@@ -10583,12 +12964,18 @@
       <virtual_method name="GtkReserved4" cname="_gtk_reserved4" shared="true" padding="true">
         <return-type type="void" />
       </virtual_method>
-      <method name="AddBuiltinIcon" cname="gtk_icon_theme_add_builtin_icon" shared="true">
+      <method name="AddBuiltinIcon" cname="gtk_icon_theme_add_builtin_icon" deprecated="1" shared="true">
         <return-type type="void" />
         <parameters>
           <parameter type="const-gchar*" name="icon_name" />
           <parameter type="gint" name="size" />
           <parameter type="GdkPixbuf*" name="pixbuf" />
+        </parameters>
+      </method>
+      <method name="AddResourcePath" cname="gtk_icon_theme_add_resource_path">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="const-gchar*" name="path" />
         </parameters>
       </method>
       <method name="AppendSearchPath" cname="gtk_icon_theme_append_search_path">
@@ -10602,6 +12989,15 @@
         <parameters>
           <parameter type="const-gchar*" array="true" name="icon_names" />
           <parameter type="gint" name="size" />
+          <parameter type="GtkIconLookupFlags" name="flags" />
+        </parameters>
+      </method>
+      <method name="ChooseIconForScale" cname="gtk_icon_theme_choose_icon_for_scale">
+        <return-type type="GtkIconInfo*" />
+        <parameters>
+          <parameter type="const-gchar*" array="true" name="icon_names" />
+          <parameter type="gint" name="size" />
+          <parameter type="gint" name="scale" />
           <parameter type="GtkIconLookupFlags" name="flags" />
         </parameters>
       </method>
@@ -10660,6 +13056,27 @@
           <parameter type="GError**" name="error" />
         </parameters>
       </method>
+      <method name="LoadIconForScale" cname="gtk_icon_theme_load_icon_for_scale">
+        <return-type type="GdkPixbuf*" />
+        <parameters>
+          <parameter type="const-gchar*" name="icon_name" />
+          <parameter type="gint" name="size" />
+          <parameter type="gint" name="scale" />
+          <parameter type="GtkIconLookupFlags" name="flags" />
+          <parameter type="GError**" name="error" />
+        </parameters>
+      </method>
+      <method name="LoadSurface" cname="gtk_icon_theme_load_surface">
+        <return-type type="cairo_surface_t*" />
+        <parameters>
+          <parameter type="const-gchar*" name="icon_name" />
+          <parameter type="gint" name="size" />
+          <parameter type="gint" name="scale" />
+          <parameter type="GdkWindow*" name="for_window" />
+          <parameter type="GtkIconLookupFlags" name="flags" />
+          <parameter type="GError**" name="error" />
+        </parameters>
+      </method>
       <method name="LookupByGicon" cname="gtk_icon_theme_lookup_by_gicon">
         <return-type type="GtkIconInfo*" />
         <parameters>
@@ -10668,11 +13085,29 @@
           <parameter type="GtkIconLookupFlags" name="flags" />
         </parameters>
       </method>
+      <method name="LookupByGiconForScale" cname="gtk_icon_theme_lookup_by_gicon_for_scale">
+        <return-type type="GtkIconInfo*" />
+        <parameters>
+          <parameter type="GIcon*" name="icon" />
+          <parameter type="gint" name="size" />
+          <parameter type="gint" name="scale" />
+          <parameter type="GtkIconLookupFlags" name="flags" />
+        </parameters>
+      </method>
       <method name="LookupIcon" cname="gtk_icon_theme_lookup_icon">
         <return-type type="GtkIconInfo*" />
         <parameters>
           <parameter type="const-gchar*" name="icon_name" />
           <parameter type="gint" name="size" />
+          <parameter type="GtkIconLookupFlags" name="flags" />
+        </parameters>
+      </method>
+      <method name="LookupIconForScale" cname="gtk_icon_theme_lookup_icon_for_scale">
+        <return-type type="GtkIconInfo*" />
+        <parameters>
+          <parameter type="const-gchar*" name="icon_name" />
+          <parameter type="gint" name="size" />
+          <parameter type="gint" name="scale" />
           <parameter type="GtkIconLookupFlags" name="flags" />
         </parameters>
       </method>
@@ -10739,6 +13174,7 @@
       <property name="TooltipColumn" cname="tooltip-column" type="gint" readable="true" writeable="true" />
       <property name="ItemPadding" cname="item-padding" type="gint" readable="true" writeable="true" />
       <property name="CellArea" cname="cell-area" type="GtkCellArea" readable="true" writeable="true" construct-only="true" />
+      <property name="ActivateOnSingleClick" cname="activate-on-single-click" type="gboolean" readable="true" writeable="true" />
       <signal name="ItemActivated" cname="item-activated" when="LAST" field_name="item_activated">
         <return-type type="void" />
         <parameters>
@@ -10823,6 +13259,17 @@
           <parameter type="const-GtkTargetEntry*" name="targets" />
           <parameter type="gint" name="n_targets" />
           <parameter type="GdkDragAction" name="actions" />
+        </parameters>
+      </method>
+      <method name="GetActivateOnSingleClick" cname="gtk_icon_view_get_activate_on_single_click">
+        <return-type type="gboolean" />
+      </method>
+      <method name="GetCellRect" cname="gtk_icon_view_get_cell_rect">
+        <return-type type="gboolean" />
+        <parameters>
+          <parameter type="GtkTreePath*" name="path" />
+          <parameter type="GtkCellRenderer*" name="cell" />
+          <parameter type="GdkRectangle*" name="rect" />
         </parameters>
       </method>
       <method name="GetColumnSpacing" cname="gtk_icon_view_get_column_spacing">
@@ -10987,6 +13434,12 @@
           <parameter type="gpointer" name="data" />
         </parameters>
       </method>
+      <method name="SetActivateOnSingleClick" cname="gtk_icon_view_set_activate_on_single_click">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gboolean" name="single" />
+        </parameters>
+      </method>
       <method name="SetColumnSpacing" cname="gtk_icon_view_set_column_spacing">
         <return-type type="void" />
         <parameters>
@@ -11133,6 +13586,7 @@
       </class_struct>
       <field name="Priv" cname="priv" type="GtkImagePrivate*" />
       <property name="Pixbuf" cname="pixbuf" type="GdkPixbuf" readable="true" writeable="true" />
+      <property name="Surface" cname="surface" type="CairoGobjectSurface" readable="true" writeable="true" />
       <property name="File" cname="file" type="gchar*" readable="true" writeable="true" />
       <property name="Stock" cname="stock" type="gchar*" readable="true" writeable="true" />
       <property name="IconSet" cname="icon-set" type="GtkIconSet" readable="true" writeable="true" />
@@ -11141,6 +13595,7 @@
       <property name="PixbufAnimation" cname="pixbuf-animation" type="GdkPixbufAnimation" readable="true" writeable="true" />
       <property name="IconName" cname="icon-name" type="gchar*" readable="true" writeable="true" />
       <property name="Gicon" cname="gicon" type="GIcon" readable="true" writeable="true" />
+      <property name="Resource" cname="resource" type="gchar*" readable="true" writeable="true" />
       <property name="StorageType" cname="storage-type" type="GtkImageType" readable="true" />
       <property name="UseFallback" cname="use-fallback" type="gboolean" readable="true" writeable="true" />
       <virtual_method name="GtkReserved1" cname="_gtk_reserved1" shared="true" padding="true">
@@ -11171,11 +13626,11 @@
       <method name="GetIconName" cname="gtk_image_get_icon_name">
         <return-type type="void" />
         <parameters>
-          <parameter type="const-gchar**" pass_as="out" name="icon_name" />
+          <parameter type="const-gchar**" name="icon_name" />
           <parameter type="GtkIconSize*" name="size" />
         </parameters>
       </method>
-      <method name="GetIconSet" cname="gtk_image_get_icon_set">
+      <method name="GetIconSet" cname="gtk_image_get_icon_set" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="GtkIconSet**" name="icon_set" />
@@ -11188,7 +13643,7 @@
       <method name="GetPixelSize" cname="gtk_image_get_pixel_size">
         <return-type type="gint" />
       </method>
-      <method name="GetStock" cname="gtk_image_get_stock">
+      <method name="GetStock" cname="gtk_image_get_stock" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="gchar**" name="stock_id" />
@@ -11224,7 +13679,7 @@
           <parameter type="GtkIconSize" name="size" />
         </parameters>
       </constructor>
-      <constructor cname="gtk_image_new_from_icon_set">
+      <constructor cname="gtk_image_new_from_icon_set" deprecated="1">
         <parameters>
           <parameter type="GtkIconSet*" name="icon_set" />
           <parameter type="GtkIconSize" name="size" />
@@ -11235,10 +13690,20 @@
           <parameter type="GdkPixbuf*" name="pixbuf" />
         </parameters>
       </constructor>
-      <constructor cname="gtk_image_new_from_stock">
+      <constructor cname="gtk_image_new_from_resource">
+        <parameters>
+          <parameter type="const-gchar*" name="resource_path" />
+        </parameters>
+      </constructor>
+      <constructor cname="gtk_image_new_from_stock" deprecated="1">
         <parameters>
           <parameter type="const-gchar*" name="stock_id" />
           <parameter type="GtkIconSize" name="size" />
+        </parameters>
+      </constructor>
+      <constructor cname="gtk_image_new_from_surface">
+        <parameters>
+          <parameter type="cairo_surface_t*" name="surface" />
         </parameters>
       </constructor>
       <method name="SetFromAnimation" cname="gtk_image_set_from_animation">
@@ -11267,7 +13732,7 @@
           <parameter type="GtkIconSize" name="size" />
         </parameters>
       </method>
-      <method name="SetFromIconSet" cname="gtk_image_set_from_icon_set">
+      <method name="SetFromIconSet" cname="gtk_image_set_from_icon_set" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="GtkIconSet*" name="icon_set" />
@@ -11280,11 +13745,23 @@
           <parameter type="GdkPixbuf*" name="pixbuf" />
         </parameters>
       </method>
-      <method name="SetFromStock" cname="gtk_image_set_from_stock">
+      <method name="SetFromResource" cname="gtk_image_set_from_resource">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="const-gchar*" name="resource_path" />
+        </parameters>
+      </method>
+      <method name="SetFromStock" cname="gtk_image_set_from_stock" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="const-gchar*" name="stock_id" />
           <parameter type="GtkIconSize" name="size" />
+        </parameters>
+      </method>
+      <method name="SetFromSurface" cname="gtk_image_set_from_surface">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="cairo_surface_t*" name="surface" />
         </parameters>
       </method>
       <method name="SetPixelSize" cname="gtk_image_set_pixel_size">
@@ -11322,54 +13799,54 @@
       <implements>
         <interface cname="GtkActivatable" />
       </implements>
-      <method name="GetAlwaysShowImage" cname="gtk_image_menu_item_get_always_show_image">
+      <method name="GetAlwaysShowImage" cname="gtk_image_menu_item_get_always_show_image" deprecated="1">
         <return-type type="gboolean" />
       </method>
-      <method name="GetImage" cname="gtk_image_menu_item_get_image">
+      <method name="GetImage" cname="gtk_image_menu_item_get_image" deprecated="1">
         <return-type type="GtkWidget*" />
       </method>
-      <method name="GetType" cname="gtk_image_menu_item_get_type" shared="true">
+      <method name="GetType" cname="gtk_image_menu_item_get_type" deprecated="1" shared="true">
         <return-type type="GType" />
       </method>
-      <method name="GetUseStock" cname="gtk_image_menu_item_get_use_stock">
+      <method name="GetUseStock" cname="gtk_image_menu_item_get_use_stock" deprecated="1">
         <return-type type="gboolean" />
       </method>
-      <constructor cname="gtk_image_menu_item_new" />
-      <constructor cname="gtk_image_menu_item_new_from_stock">
+      <constructor cname="gtk_image_menu_item_new" deprecated="1" />
+      <constructor cname="gtk_image_menu_item_new_from_stock" deprecated="1">
         <parameters>
           <parameter type="const-gchar*" name="stock_id" />
           <parameter type="GtkAccelGroup*" name="accel_group" />
         </parameters>
       </constructor>
-      <constructor cname="gtk_image_menu_item_new_with_label">
+      <constructor cname="gtk_image_menu_item_new_with_label" deprecated="1">
         <parameters>
           <parameter type="const-gchar*" name="label" />
         </parameters>
       </constructor>
-      <constructor cname="gtk_image_menu_item_new_with_mnemonic">
+      <constructor cname="gtk_image_menu_item_new_with_mnemonic" deprecated="1">
         <parameters>
           <parameter type="const-gchar*" name="label" />
         </parameters>
       </constructor>
-      <method name="SetAccelGroup" cname="gtk_image_menu_item_set_accel_group">
+      <method name="SetAccelGroup" cname="gtk_image_menu_item_set_accel_group" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="GtkAccelGroup*" name="accel_group" />
         </parameters>
       </method>
-      <method name="SetAlwaysShowImage" cname="gtk_image_menu_item_set_always_show_image">
+      <method name="SetAlwaysShowImage" cname="gtk_image_menu_item_set_always_show_image" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="gboolean" name="always_show" />
         </parameters>
       </method>
-      <method name="SetImage" cname="gtk_image_menu_item_set_image">
+      <method name="SetImage" cname="gtk_image_menu_item_set_image" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="GtkWidget*" name="image" />
         </parameters>
       </method>
-      <method name="SetUseStock" cname="gtk_image_menu_item_set_use_stock">
+      <method name="SetUseStock" cname="gtk_image_menu_item_set_use_stock" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="gboolean" name="use_stock" />
@@ -11431,6 +13908,7 @@
           <parameter type="gint" name="n_chars" />
         </parameters>
       </signal>
+      <property name="InputHints" cname="input-hints" type="GtkInputHints" readable="true" writeable="true" />
       <virtual_method name="SetClientWindow" cname="set_client_window">
         <return-type type="void" />
         <parameters>
@@ -11614,7 +14092,7 @@
       <virtual_method name="GtkReserved4" cname="_gtk_reserved4" shared="true" padding="true">
         <return-type type="void" />
       </virtual_method>
-      <method name="AppendMenuitems" cname="gtk_im_multicontext_append_menuitems">
+      <method name="AppendMenuitems" cname="gtk_im_multicontext_append_menuitems" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="GtkMenuShell*" name="menushell" />
@@ -11634,9 +14112,9 @@
         </parameters>
       </method>
     </object>
-    <object name="InfoBar" cname="GtkInfoBar" parent="GtkHBox">
+    <object name="InfoBar" cname="GtkInfoBar" parent="GtkBox">
       <class_struct cname="GtkInfoBarClass">
-        <field name="ParentClass" cname="parent_class" type="GtkHBoxClass" />
+        <field name="ParentClass" cname="parent_class" type="GtkBoxClass" />
         <method signal_vm="response" />
         <method signal_vm="close" />
         <method vm="_gtk_reserved1" />
@@ -11646,6 +14124,7 @@
       </class_struct>
       <field name="Priv" cname="priv" type="GtkInfoBarPrivate*" />
       <property name="MessageType" cname="message-type" type="GtkMessageType" readable="true" writeable="true" construct="true" />
+      <property name="ShowCloseButton" cname="show-close-button" type="gboolean" readable="true" writeable="true" construct="true" />
       <signal name="Response" cname="response" when="LAST" field_name="response">
         <return-type type="void" />
         <parameters>
@@ -11701,6 +14180,9 @@
       <method name="GetMessageType" cname="gtk_info_bar_get_message_type">
         <return-type type="GtkMessageType" />
       </method>
+      <method name="GetShowCloseButton" cname="gtk_info_bar_get_show_close_button">
+        <return-type type="gboolean" />
+      </method>
       <method name="GetType" cname="gtk_info_bar_get_type" shared="true">
         <return-type type="GType" />
       </method>
@@ -11733,6 +14215,12 @@
         <return-type type="void" />
         <parameters>
           <parameter type="gint" name="response_id" />
+          <parameter type="gboolean" name="setting" />
+        </parameters>
+      </method>
+      <method name="SetShowCloseButton" cname="gtk_info_bar_set_show_close_button">
+        <return-type type="void" />
+        <parameters>
           <parameter type="gboolean" name="setting" />
         </parameters>
       </method>
@@ -11842,6 +14330,7 @@
       <property name="Angle" cname="angle" type="gdouble" readable="true" writeable="true" />
       <property name="MaxWidthChars" cname="max-width-chars" type="gint" readable="true" writeable="true" />
       <property name="TrackVisitedLinks" cname="track-visited-links" type="gboolean" readable="true" writeable="true" />
+      <property name="Lines" cname="lines" type="gint" readable="true" writeable="true" />
       <virtual_method name="GtkReserved1" cname="_gtk_reserved1" shared="true" padding="true">
         <return-type type="void" />
       </virtual_method>
@@ -11902,6 +14391,9 @@
       </method>
       <method name="GetLineWrapMode" cname="gtk_label_get_line_wrap_mode">
         <return-type type="PangoWrapMode" />
+      </method>
+      <method name="GetLines" cname="gtk_label_get_lines">
+        <return-type type="gint" />
       </method>
       <method name="GetMaxWidthChars" cname="gtk_label_get_max_width_chars">
         <return-type type="gint" />
@@ -12000,6 +14492,12 @@
         <return-type type="void" />
         <parameters>
           <parameter type="PangoWrapMode" name="wrap_mode" />
+        </parameters>
+      </method>
+      <method name="SetLines" cname="gtk_label_set_lines">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gint" name="lines" />
         </parameters>
       </method>
       <method name="SetMarkup" cname="gtk_label_set_markup">
@@ -12170,6 +14668,100 @@
         </parameters>
       </method>
     </object>
+    <object name="LevelBar" cname="GtkLevelBar" parent="GtkWidget">
+      <class_struct cname="GtkLevelBarClass">
+        <field name="ParentClass" cname="parent_class" type="GtkWidgetClass" />
+        <method signal_vm="offset_changed" />
+        <field name="Padding" cname="padding" type="gpointer" array_len="16" />
+      </class_struct>
+      <field name="Priv" cname="priv" type="GtkLevelBarPrivate*" />
+      <signal name="OffsetChanged" cname="offset-changed" when="FIRST" field_name="offset_changed">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="const-gchar*" name="name" />
+        </parameters>
+      </signal>
+      <property name="MinBlockWidth" cname="min-block-width" type="gint" readable="true" writeable="true" />
+      <implements>
+        <interface cname="GtkOrientable" />
+        <interface cname="GtkBuildable" />
+      </implements>
+      <method name="AddOffsetValue" cname="gtk_level_bar_add_offset_value">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="const-gchar*" name="name" />
+          <parameter type="gdouble" name="value" />
+        </parameters>
+      </method>
+      <method name="GetInverted" cname="gtk_level_bar_get_inverted">
+        <return-type type="gboolean" />
+      </method>
+      <method name="GetMaxValue" cname="gtk_level_bar_get_max_value">
+        <return-type type="gdouble" />
+      </method>
+      <method name="GetMinValue" cname="gtk_level_bar_get_min_value">
+        <return-type type="gdouble" />
+      </method>
+      <method name="GetMode" cname="gtk_level_bar_get_mode">
+        <return-type type="GtkLevelBarMode" />
+      </method>
+      <method name="GetOffsetValue" cname="gtk_level_bar_get_offset_value">
+        <return-type type="gboolean" />
+        <parameters>
+          <parameter type="const-gchar*" name="name" />
+          <parameter type="gdouble*" name="value" />
+        </parameters>
+      </method>
+      <method name="GetType" cname="gtk_level_bar_get_type" shared="true">
+        <return-type type="GType" />
+      </method>
+      <method name="GetValue" cname="gtk_level_bar_get_value">
+        <return-type type="gdouble" />
+      </method>
+      <constructor cname="gtk_level_bar_new" />
+      <constructor cname="gtk_level_bar_new_for_interval">
+        <parameters>
+          <parameter type="gdouble" name="min_value" />
+          <parameter type="gdouble" name="max_value" />
+        </parameters>
+      </constructor>
+      <method name="RemoveOffsetValue" cname="gtk_level_bar_remove_offset_value">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="const-gchar*" name="name" />
+        </parameters>
+      </method>
+      <method name="SetInverted" cname="gtk_level_bar_set_inverted">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gboolean" name="inverted" />
+        </parameters>
+      </method>
+      <method name="SetMaxValue" cname="gtk_level_bar_set_max_value">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gdouble" name="value" />
+        </parameters>
+      </method>
+      <method name="SetMinValue" cname="gtk_level_bar_set_min_value">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gdouble" name="value" />
+        </parameters>
+      </method>
+      <method name="SetMode" cname="gtk_level_bar_set_mode">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkLevelBarMode" name="mode" />
+        </parameters>
+      </method>
+      <method name="SetValue" cname="gtk_level_bar_set_value">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gdouble" name="value" />
+        </parameters>
+      </method>
+    </object>
     <object name="LinkButton" cname="GtkLinkButton" parent="GtkButton">
       <class_struct cname="GtkLinkButtonClass">
         <field name="ParentClass" cname="parent_class" type="GtkButtonClass" />
@@ -12228,6 +14820,265 @@
         <return-type type="void" />
         <parameters>
           <parameter type="gboolean" name="visited" />
+        </parameters>
+      </method>
+    </object>
+    <object name="ListBox" cname="GtkListBox" parent="GtkContainer">
+      <class_struct cname="GtkListBoxClass">
+        <field name="ParentClass" cname="parent_class" type="GtkContainerClass" />
+        <method signal_vm="row_selected" />
+        <method signal_vm="row_activated" />
+        <method signal_vm="activate_cursor_row" />
+        <method signal_vm="toggle_cursor_row" />
+        <method signal_vm="move_cursor" />
+        <method signal_vm="selected_rows_changed" />
+        <method signal_vm="select_all" />
+        <method signal_vm="unselect_all" />
+        <method vm="_gtk_reserved1" />
+        <method vm="_gtk_reserved2" />
+        <method vm="_gtk_reserved3" />
+      </class_struct>
+      <property name="ActivateOnSingleClick" cname="activate-on-single-click" type="gboolean" readable="true" writeable="true" />
+      <signal name="RowSelected" cname="row-selected" when="LAST" field_name="row_selected">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkListBoxRow*" name="row" />
+        </parameters>
+      </signal>
+      <signal name="SelectedRowsChanged" cname="selected-rows-changed" when="FIRST" field_name="selected_rows_changed">
+        <return-type type="void" />
+        <parameters />
+      </signal>
+      <signal name="SelectAll" cname="select-all" when="LAST" field_name="select_all">
+        <return-type type="void" />
+        <parameters />
+      </signal>
+      <signal name="UnselectAll" cname="unselect-all" when="LAST" field_name="unselect_all">
+        <return-type type="void" />
+        <parameters />
+      </signal>
+      <signal name="RowActivated" cname="row-activated" when="LAST" field_name="row_activated">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkListBoxRow*" name="row" />
+        </parameters>
+      </signal>
+      <signal name="ActivateCursorRow" cname="activate-cursor-row" when="LAST" field_name="activate_cursor_row">
+        <return-type type="void" />
+        <parameters />
+      </signal>
+      <signal name="ToggleCursorRow" cname="toggle-cursor-row" when="LAST" field_name="toggle_cursor_row">
+        <return-type type="void" />
+        <parameters />
+      </signal>
+      <signal name="MoveCursor" cname="move-cursor" when="LAST" field_name="move_cursor">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkMovementStep" name="step" />
+          <parameter type="gint" name="count" />
+        </parameters>
+      </signal>
+      <virtual_method name="GtkReserved1" cname="_gtk_reserved1" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <virtual_method name="GtkReserved2" cname="_gtk_reserved2" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <virtual_method name="GtkReserved3" cname="_gtk_reserved3" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <method name="DragHighlightRow" cname="gtk_list_box_drag_highlight_row">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkListBoxRow*" name="row" />
+        </parameters>
+      </method>
+      <method name="DragUnhighlightRow" cname="gtk_list_box_drag_unhighlight_row">
+        <return-type type="void" />
+      </method>
+      <method name="GetActivateOnSingleClick" cname="gtk_list_box_get_activate_on_single_click">
+        <return-type type="gboolean" />
+      </method>
+      <method name="GetAdjustment" cname="gtk_list_box_get_adjustment">
+        <return-type type="GtkAdjustment*" />
+      </method>
+      <method name="GetRowAtIndex" cname="gtk_list_box_get_row_at_index">
+        <return-type type="GtkListBoxRow*" />
+        <parameters>
+          <parameter type="gint" name="index_" />
+        </parameters>
+      </method>
+      <method name="GetRowAtY" cname="gtk_list_box_get_row_at_y">
+        <return-type type="GtkListBoxRow*" />
+        <parameters>
+          <parameter type="gint" name="y" />
+        </parameters>
+      </method>
+      <method name="GetSelectedRow" cname="gtk_list_box_get_selected_row">
+        <return-type type="GtkListBoxRow*" />
+      </method>
+      <method name="GetSelectedRows" cname="gtk_list_box_get_selected_rows">
+        <return-type type="GList*" />
+      </method>
+      <method name="GetSelectionMode" cname="gtk_list_box_get_selection_mode">
+        <return-type type="GtkSelectionMode" />
+      </method>
+      <method name="GetType" cname="gtk_list_box_get_type" shared="true">
+        <return-type type="GType" />
+      </method>
+      <method name="Insert" cname="gtk_list_box_insert">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkWidget*" name="child" />
+          <parameter type="gint" name="position" />
+        </parameters>
+      </method>
+      <method name="InvalidateFilter" cname="gtk_list_box_invalidate_filter">
+        <return-type type="void" />
+      </method>
+      <method name="InvalidateHeaders" cname="gtk_list_box_invalidate_headers">
+        <return-type type="void" />
+      </method>
+      <method name="InvalidateSort" cname="gtk_list_box_invalidate_sort">
+        <return-type type="void" />
+      </method>
+      <constructor cname="gtk_list_box_new" />
+      <method name="Prepend" cname="gtk_list_box_prepend">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkWidget*" name="child" />
+        </parameters>
+      </method>
+      <method name="SelectAll" cname="gtk_list_box_select_all">
+        <return-type type="void" />
+      </method>
+      <method name="SelectRow" cname="gtk_list_box_select_row">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkListBoxRow*" name="row" />
+        </parameters>
+      </method>
+      <method name="SelectedForeach" cname="gtk_list_box_selected_foreach">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkListBoxForeachFunc" name="func" />
+          <parameter type="gpointer" name="data" />
+        </parameters>
+      </method>
+      <method name="SetActivateOnSingleClick" cname="gtk_list_box_set_activate_on_single_click">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gboolean" name="single" />
+        </parameters>
+      </method>
+      <method name="SetAdjustment" cname="gtk_list_box_set_adjustment">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkAdjustment*" name="adjustment" />
+        </parameters>
+      </method>
+      <method name="SetFilterFunc" cname="gtk_list_box_set_filter_func">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkListBoxFilterFunc" name="filter_func" />
+          <parameter type="gpointer" name="user_data" />
+          <parameter type="GDestroyNotify" name="destroy" />
+        </parameters>
+      </method>
+      <method name="SetHeaderFunc" cname="gtk_list_box_set_header_func">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkListBoxUpdateHeaderFunc" name="update_header" />
+          <parameter type="gpointer" name="user_data" />
+          <parameter type="GDestroyNotify" name="destroy" />
+        </parameters>
+      </method>
+      <method name="SetPlaceholder" cname="gtk_list_box_set_placeholder">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkWidget*" name="placeholder" />
+        </parameters>
+      </method>
+      <method name="SetSelectionMode" cname="gtk_list_box_set_selection_mode">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkSelectionMode" name="mode" />
+        </parameters>
+      </method>
+      <method name="SetSortFunc" cname="gtk_list_box_set_sort_func">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkListBoxSortFunc" name="sort_func" />
+          <parameter type="gpointer" name="user_data" />
+          <parameter type="GDestroyNotify" name="destroy" />
+        </parameters>
+      </method>
+      <method name="UnselectAll" cname="gtk_list_box_unselect_all">
+        <return-type type="void" />
+      </method>
+      <method name="UnselectRow" cname="gtk_list_box_unselect_row">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkListBoxRow*" name="row" />
+        </parameters>
+      </method>
+    </object>
+    <object name="ListBoxRow" cname="GtkListBoxRow" parent="GtkBin">
+      <class_struct cname="GtkListBoxRowClass">
+        <field name="ParentClass" cname="parent_class" type="GtkBinClass" />
+        <method signal_vm="activate" />
+        <method vm="_gtk_reserved1" />
+        <method vm="_gtk_reserved2" />
+      </class_struct>
+      <signal name="Activate" cname="activate" when="FIRST" field_name="activate">
+        <return-type type="void" />
+        <parameters />
+      </signal>
+      <property name="Selectable" cname="selectable" type="gboolean" readable="true" writeable="true" />
+      <virtual_method name="GtkReserved1" cname="_gtk_reserved1" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <virtual_method name="GtkReserved2" cname="_gtk_reserved2" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <method name="Changed" cname="gtk_list_box_row_changed">
+        <return-type type="void" />
+      </method>
+      <method name="GetActivatable" cname="gtk_list_box_row_get_activatable">
+        <return-type type="gboolean" />
+      </method>
+      <method name="GetHeader" cname="gtk_list_box_row_get_header">
+        <return-type type="GtkWidget*" />
+      </method>
+      <method name="GetIndex" cname="gtk_list_box_row_get_index">
+        <return-type type="gint" />
+      </method>
+      <method name="GetSelectable" cname="gtk_list_box_row_get_selectable">
+        <return-type type="gboolean" />
+      </method>
+      <method name="GetType" cname="gtk_list_box_row_get_type" shared="true">
+        <return-type type="GType" />
+      </method>
+      <method name="IsSelected" cname="gtk_list_box_row_is_selected">
+        <return-type type="gboolean" />
+      </method>
+      <constructor cname="gtk_list_box_row_new" />
+      <method name="SetActivatable" cname="gtk_list_box_row_set_activatable">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gboolean" name="activatable" />
+        </parameters>
+      </method>
+      <method name="SetHeader" cname="gtk_list_box_row_set_header">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkWidget*" name="header" />
+        </parameters>
+      </method>
+      <method name="SetSelectable" cname="gtk_list_box_row_set_selectable">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gboolean" name="selectable" />
         </parameters>
       </method>
     </object>
@@ -12489,16 +15340,21 @@
       <method name="GetReserveToggleSize" cname="gtk_menu_get_reserve_toggle_size">
         <return-type type="gboolean" />
       </method>
-      <method name="GetTearoffState" cname="gtk_menu_get_tearoff_state">
+      <method name="GetTearoffState" cname="gtk_menu_get_tearoff_state" deprecated="1">
         <return-type type="gboolean" />
       </method>
-      <method name="GetTitle" cname="gtk_menu_get_title">
+      <method name="GetTitle" cname="gtk_menu_get_title" deprecated="1">
         <return-type type="const-gchar*" />
       </method>
       <method name="GetType" cname="gtk_menu_get_type" shared="true">
         <return-type type="GType" />
       </method>
       <constructor cname="gtk_menu_new" />
+      <constructor cname="gtk_menu_new_from_model">
+        <parameters>
+          <parameter type="GMenuModel*" name="model" />
+        </parameters>
+      </constructor>
       <method name="Popdown" cname="gtk_menu_popdown">
         <return-type type="void" />
       </method>
@@ -12572,13 +15428,13 @@
           <parameter type="GdkScreen*" name="screen" />
         </parameters>
       </method>
-      <method name="SetTearoffState" cname="gtk_menu_set_tearoff_state">
+      <method name="SetTearoffState" cname="gtk_menu_set_tearoff_state" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="gboolean" name="torn_off" />
         </parameters>
       </method>
-      <method name="SetTitle" cname="gtk_menu_set_title">
+      <method name="SetTitle" cname="gtk_menu_set_title" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="const-gchar*" name="title" />
@@ -12618,6 +15474,11 @@
         <return-type type="GType" />
       </method>
       <constructor cname="gtk_menu_bar_new" />
+      <constructor cname="gtk_menu_bar_new_from_model">
+        <parameters>
+          <parameter type="GMenuModel*" name="model" />
+        </parameters>
+      </constructor>
       <method name="SetChildPackDirection" cname="gtk_menu_bar_set_child_pack_direction">
         <return-type type="void" />
         <parameters>
@@ -12628,6 +15489,92 @@
         <return-type type="void" />
         <parameters>
           <parameter type="GtkPackDirection" name="pack_dir" />
+        </parameters>
+      </method>
+    </object>
+    <object name="MenuButton" cname="GtkMenuButton" parent="GtkToggleButton">
+      <class_struct cname="GtkMenuButtonClass">
+        <field name="ParentClass" cname="parent_class" type="GtkToggleButtonClass" />
+        <method vm="_gtk_reserved1" />
+        <method vm="_gtk_reserved2" />
+        <method vm="_gtk_reserved3" />
+        <method vm="_gtk_reserved4" />
+      </class_struct>
+      <field name="Priv" cname="priv" type="GtkMenuButtonPrivate*" />
+      <property name="Popup" cname="popup" type="GtkMenu" readable="true" writeable="true" />
+      <property name="MenuModel" cname="menu-model" type="GMenuModel" readable="true" writeable="true" />
+      <property name="AlignWidget" cname="align-widget" type="GtkContainer" readable="true" writeable="true" />
+      <property name="Direction" cname="direction" type="GtkArrowType" readable="true" writeable="true" />
+      <property name="UsePopover" cname="use-popover" type="gboolean" readable="true" writeable="true" />
+      <property name="Popover" cname="popover" type="GtkPopover" readable="true" writeable="true" />
+      <virtual_method name="GtkReserved1" cname="_gtk_reserved1" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <virtual_method name="GtkReserved2" cname="_gtk_reserved2" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <virtual_method name="GtkReserved3" cname="_gtk_reserved3" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <virtual_method name="GtkReserved4" cname="_gtk_reserved4" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <method name="GetAlignWidget" cname="gtk_menu_button_get_align_widget">
+        <return-type type="GtkWidget*" />
+      </method>
+      <method name="GetDirection" cname="gtk_menu_button_get_direction">
+        <return-type type="GtkArrowType" />
+      </method>
+      <method name="GetMenuModel" cname="gtk_menu_button_get_menu_model">
+        <return-type type="GMenuModel*" />
+      </method>
+      <method name="GetPopover" cname="gtk_menu_button_get_popover">
+        <return-type type="GtkPopover*" />
+      </method>
+      <method name="GetPopup" cname="gtk_menu_button_get_popup">
+        <return-type type="GtkMenu*" />
+      </method>
+      <method name="GetType" cname="gtk_menu_button_get_type" shared="true">
+        <return-type type="GType" />
+      </method>
+      <method name="GetUsePopover" cname="gtk_menu_button_get_use_popover">
+        <return-type type="gboolean" />
+      </method>
+      <constructor cname="gtk_menu_button_new" />
+      <method name="SetAlignWidget" cname="gtk_menu_button_set_align_widget">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkWidget*" name="align_widget" />
+        </parameters>
+      </method>
+      <method name="SetDirection" cname="gtk_menu_button_set_direction">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkArrowType" name="direction" />
+        </parameters>
+      </method>
+      <method name="SetMenuModel" cname="gtk_menu_button_set_menu_model">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GMenuModel*" name="menu_model" />
+        </parameters>
+      </method>
+      <method name="SetPopover" cname="gtk_menu_button_set_popover">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkWidget*" name="popover" />
+        </parameters>
+      </method>
+      <method name="SetPopup" cname="gtk_menu_button_set_popup">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkWidget*" name="menu" />
+        </parameters>
+      </method>
+      <method name="SetUsePopover" cname="gtk_menu_button_set_use_popover">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gboolean" name="use_popover" />
         </parameters>
       </method>
     </object>
@@ -12689,7 +15636,7 @@
         </parameters>
       </virtual_method>
       <virtual_method name="GetLabel" cname="get_label">
-        <return-type type="const-gchar*" />
+        <return-type type="gchar*" />
         <parameters />
       </virtual_method>
       <virtual_method name="GtkReserved1" cname="_gtk_reserved1" shared="true" padding="true">
@@ -12707,6 +15654,7 @@
       <implements>
         <interface cname="GtkBuildable" />
         <interface cname="GtkActivatable" />
+        <interface cname="GtkActionable" />
       </implements>
       <method name="Activate" cname="gtk_menu_item_activate">
         <return-type type="void" />
@@ -12723,7 +15671,7 @@
       <method name="GetReserveIndicator" cname="gtk_menu_item_get_reserve_indicator">
         <return-type type="gboolean" />
       </method>
-      <method name="GetRightJustified" cname="gtk_menu_item_get_right_justified">
+      <method name="GetRightJustified" cname="gtk_menu_item_get_right_justified" deprecated="1">
         <return-type type="gboolean" />
       </method>
       <method name="GetSubmenu" cname="gtk_menu_item_get_submenu">
@@ -12767,7 +15715,7 @@
           <parameter type="gboolean" name="reserve" />
         </parameters>
       </method>
-      <method name="SetRightJustified" cname="gtk_menu_item_set_right_justified">
+      <method name="SetRightJustified" cname="gtk_menu_item_set_right_justified" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="gboolean" name="right_justified" />
@@ -12798,6 +15746,18 @@
         </parameters>
       </method>
     </object>
+    <object name="MenuSectionBox" cname="GtkMenuSectionBox" parent="GtkBox">
+      <method name="GetType" cname="gtk_menu_section_box_get_type" shared="true">
+        <return-type type="GType" />
+      </method>
+      <constructor cname="gtk_menu_section_box_new_toplevel">
+        <parameters>
+          <parameter type="GtkStack*" name="stack" />
+          <parameter type="GMenuModel*" name="model" />
+          <parameter type="const-gchar*" name="action_namespace" />
+        </parameters>
+      </constructor>
+    </object>
     <object name="MenuShell" cname="GtkMenuShell" parent="GtkContainer">
       <class_struct cname="GtkMenuShellClass">
         <field name="ParentClass" cname="parent_class" type="GtkContainerClass" />
@@ -12808,7 +15768,7 @@
         <method signal_vm="activate_current" />
         <method signal_vm="cancel" />
         <method vm="select_item" />
-        <method vm="insert" />
+        <method signal_vm="insert" />
         <method vm="get_popup_delay" />
         <method signal_vm="move_selected" />
         <method vm="_gtk_reserved1" />
@@ -12853,18 +15813,18 @@
           <parameter type="gint" name="distance" />
         </parameters>
       </signal>
+      <signal name="Insert" cname="insert" when="FIRST" field_name="insert">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkWidget*" name="child" />
+          <parameter type="gint" name="position" />
+        </parameters>
+      </signal>
       <property name="TakeFocus" cname="take-focus" type="gboolean" readable="true" writeable="true" />
       <virtual_method name="SelectItem" cname="select_item">
         <return-type type="void" />
         <parameters>
           <parameter type="GtkWidget*" name="menu_item" />
-        </parameters>
-      </virtual_method>
-      <virtual_method name="Insert" cname="insert">
-        <return-type type="void" />
-        <parameters>
-          <parameter type="GtkWidget*" name="child" />
-          <parameter type="gint" name="position" />
         </parameters>
       </virtual_method>
       <virtual_method name="GetPopupDelay" cname="get_popup_delay">
@@ -12894,6 +15854,14 @@
         <return-type type="void" />
         <parameters>
           <parameter type="GtkWidget*" name="child" />
+        </parameters>
+      </method>
+      <method name="BindModel" cname="gtk_menu_shell_bind_model">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GMenuModel*" name="model" />
+          <parameter type="const-gchar*" name="action_namespace" />
+          <parameter type="gboolean" name="with_separators" />
         </parameters>
       </method>
       <method name="Cancel" cname="gtk_menu_shell_cancel">
@@ -12991,7 +15959,7 @@
           <parameter type="const-gchar*" name="label" />
         </parameters>
       </constructor>
-      <constructor cname="gtk_menu_tool_button_new_from_stock">
+      <constructor cname="gtk_menu_tool_button_new_from_stock" deprecated="1">
         <parameters>
           <parameter type="const-gchar*" name="stock_id" />
         </parameters>
@@ -13012,6 +15980,72 @@
         <return-type type="void" />
         <parameters>
           <parameter type="GtkWidget*" name="menu" />
+        </parameters>
+      </method>
+    </object>
+    <object name="MenuTrackerItem" cname="GtkMenuTrackerItem" parent="GObject">
+      <property name="SubmenuShown" cname="submenu-shown" type="gboolean" readable="true" />
+      <implements>
+        <interface cname="GtkActionObserver" />
+      </implements>
+      <method name="Activated" cname="gtk_menu_tracker_item_activated">
+        <return-type type="void" />
+      </method>
+      <method name="GetAccel" cname="gtk_menu_tracker_item_get_accel">
+        <return-type type="const-gchar*" />
+      </method>
+      <method name="GetDisplayHint" cname="gtk_menu_tracker_item_get_display_hint">
+        <return-type type="const-gchar*" />
+      </method>
+      <method name="GetHasLink" cname="gtk_menu_tracker_item_get_has_link">
+        <return-type type="gboolean" />
+        <parameters>
+          <parameter type="const-gchar*" name="link_name" />
+        </parameters>
+      </method>
+      <method name="GetIcon" cname="gtk_menu_tracker_item_get_icon">
+        <return-type type="GIcon*" />
+      </method>
+      <method name="GetIsSeparator" cname="gtk_menu_tracker_item_get_is_separator">
+        <return-type type="gboolean" />
+      </method>
+      <method name="GetIsVisible" cname="gtk_menu_tracker_item_get_is_visible">
+        <return-type type="gboolean" />
+      </method>
+      <method name="GetLabel" cname="gtk_menu_tracker_item_get_label">
+        <return-type type="const-gchar*" />
+      </method>
+      <method name="GetRole" cname="gtk_menu_tracker_item_get_role">
+        <return-type type="GtkMenuTrackerItemRole" />
+      </method>
+      <method name="GetSensitive" cname="gtk_menu_tracker_item_get_sensitive">
+        <return-type type="gboolean" />
+      </method>
+      <method name="GetShouldRequestShow" cname="gtk_menu_tracker_item_get_should_request_show">
+        <return-type type="gboolean" />
+      </method>
+      <method name="GetSpecial" cname="gtk_menu_tracker_item_get_special">
+        <return-type type="const-gchar*" />
+      </method>
+      <method name="GetSubmenuShown" cname="gtk_menu_tracker_item_get_submenu_shown">
+        <return-type type="gboolean" />
+      </method>
+      <method name="GetToggled" cname="gtk_menu_tracker_item_get_toggled">
+        <return-type type="gboolean" />
+      </method>
+      <method name="GetType" cname="gtk_menu_tracker_item_get_type" shared="true">
+        <return-type type="GType" />
+      </method>
+      <method name="GetVerbIcon" cname="gtk_menu_tracker_item_get_verb_icon">
+        <return-type type="GIcon*" />
+      </method>
+      <method name="MayDisappear" cname="gtk_menu_tracker_item_may_disappear">
+        <return-type type="gboolean" />
+      </method>
+      <method name="RequestSubmenuShown" cname="gtk_menu_tracker_item_request_submenu_shown">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gboolean" name="shown" />
         </parameters>
       </method>
     </object>
@@ -13061,7 +16095,7 @@
           <parameter ellipsis="true" printf_format_args="true" />
         </parameters>
       </method>
-      <method name="GetImage" cname="gtk_message_dialog_get_image">
+      <method name="GetImage" cname="gtk_message_dialog_get_image" deprecated="1">
         <return-type type="GtkWidget*" />
       </method>
       <method name="GetMessageArea" cname="gtk_message_dialog_get_message_area">
@@ -13090,7 +16124,7 @@
           <parameter ellipsis="true" printf_format_args="true" />
         </parameters>
       </constructor>
-      <method name="SetImage" cname="gtk_message_dialog_set_image">
+      <method name="SetImage" cname="gtk_message_dialog_set_image" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="GtkWidget*" name="image" />
@@ -13128,37 +16162,63 @@
       <virtual_method name="GtkReserved4" cname="_gtk_reserved4" shared="true" padding="true">
         <return-type type="void" />
       </virtual_method>
-      <method name="GetAlignment" cname="gtk_misc_get_alignment">
+      <method name="GetAlignment" cname="gtk_misc_get_alignment" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="gfloat*" name="xalign" />
           <parameter type="gfloat*" name="yalign" />
         </parameters>
       </method>
-      <method name="GetPadding" cname="gtk_misc_get_padding">
+      <method name="GetPadding" cname="gtk_misc_get_padding" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="gint*" name="xpad" />
           <parameter type="gint*" name="ypad" />
         </parameters>
       </method>
-      <method name="GetType" cname="gtk_misc_get_type" shared="true">
+      <method name="GetType" cname="gtk_misc_get_type" deprecated="1" shared="true">
         <return-type type="GType" />
       </method>
-      <method name="SetAlignment" cname="gtk_misc_set_alignment">
+      <method name="SetAlignment" cname="gtk_misc_set_alignment" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="gfloat" name="xalign" />
           <parameter type="gfloat" name="yalign" />
         </parameters>
       </method>
-      <method name="SetPadding" cname="gtk_misc_set_padding">
+      <method name="SetPadding" cname="gtk_misc_set_padding" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="gint" name="xpad" />
           <parameter type="gint" name="ypad" />
         </parameters>
       </method>
+    </object>
+    <object name="ModelButton" cname="GtkModelButton" parent="GtkButton">
+      <property name="ActionRole" cname="action-role" type="GtkMenuTrackerItemRole" writeable="true" />
+      <property name="Icon" cname="icon" type="GIcon" writeable="true" />
+      <property name="Text" cname="text" type="gchar*" writeable="true" />
+      <property name="Toggled" cname="toggled" type="gboolean" writeable="true" />
+      <property name="Accel" cname="accel" type="gchar*" writeable="true" />
+      <property name="HasSubmenu" cname="has-submenu" type="gboolean" writeable="true" />
+      <property name="Inverted" cname="inverted" type="gboolean" writeable="true" />
+      <property name="Centered" cname="centered" type="gboolean" writeable="true" />
+      <property name="Iconic" cname="iconic" type="gboolean" writeable="true" />
+      <method name="GetType" cname="gtk_model_button_get_type" shared="true">
+        <return-type type="GType" />
+      </method>
+      <constructor cname="gtk_model_button_new" />
+    </object>
+    <object name="ModelMenuItem" cname="GtkModelMenuItem" parent="GtkCheckMenuItem">
+      <property name="ActionRole" cname="action-role" type="GtkMenuTrackerItemRole" readable="true" writeable="true" />
+      <property name="Icon" cname="icon" type="GIcon" readable="true" writeable="true" />
+      <property name="Text" cname="text" type="gchar*" readable="true" writeable="true" />
+      <property name="Toggled" cname="toggled" type="gboolean" readable="true" writeable="true" />
+      <property name="Accel" cname="accel" type="gchar*" readable="true" writeable="true" />
+      <method name="GetType" cname="gtk_model_menu_item_get_type" shared="true">
+        <return-type type="GType" />
+      </method>
+      <constructor cname="gtk_model_menu_item_new" />
     </object>
     <object name="ModifierStyle" cname="GtkModifierStyle" parent="GObject">
       <class_struct cname="GtkModifierStyleClass">
@@ -13168,11 +16228,7 @@
         <method vm="_gtk_reserved3" />
         <method vm="_gtk_reserved4" />
       </class_struct>
-      <field name="Priv" cname="priv" type="gpointer" />
-      <signal name="Changed" cname="changed" when="LAST">
-        <return-type type="void" />
-        <parameters />
-      </signal>
+      <field name="Priv" cname="priv" type="GtkModifierStylePrivate*" />
       <virtual_method name="GtkReserved1" cname="_gtk_reserved1" shared="true" padding="true">
         <return-type type="void" />
       </virtual_method>
@@ -13187,6 +16243,7 @@
       </virtual_method>
       <implements>
         <interface cname="GtkStyleProvider" />
+        <interface cname="GtkStyleProviderPrivate" />
       </implements>
     </object>
     <object name="MountOperation" cname="GtkMountOperation" parent="GMountOperation">
@@ -13447,7 +16504,7 @@
           <parameter type="GtkWidget*" name="child" />
         </parameters>
       </method>
-      <method name="GetTabHborder" cname="gtk_notebook_get_tab_hborder">
+      <method name="GetTabHborder" cname="gtk_notebook_get_tab_hborder" deprecated="1">
         <return-type type="guint16" />
       </method>
       <method name="GetTabLabel" cname="gtk_notebook_get_tab_label">
@@ -13471,7 +16528,7 @@
           <parameter type="GtkWidget*" name="child" />
         </parameters>
       </method>
-      <method name="GetTabVborder" cname="gtk_notebook_get_tab_vborder">
+      <method name="GetTabVborder" cname="gtk_notebook_get_tab_vborder" deprecated="1">
         <return-type type="guint16" />
       </method>
       <method name="GetType" cname="gtk_notebook_get_type" shared="true">
@@ -13628,60 +16685,60 @@
       </class_struct>
       <field name="Priv" cname="priv" type="GtkNumerableIconPrivate*" />
       <property name="BackgroundIconName" cname="background-icon-name" type="gchar*" readable="true" writeable="true" />
-      <method name="GetBackgroundGicon" cname="gtk_numerable_icon_get_background_gicon">
+      <method name="GetBackgroundGicon" cname="gtk_numerable_icon_get_background_gicon" deprecated="1">
         <return-type type="GIcon*" />
       </method>
-      <method name="GetBackgroundIconName" cname="gtk_numerable_icon_get_background_icon_name">
+      <method name="GetBackgroundIconName" cname="gtk_numerable_icon_get_background_icon_name" deprecated="1">
         <return-type type="const-gchar*" />
       </method>
-      <method name="GetCount" cname="gtk_numerable_icon_get_count">
+      <method name="GetCount" cname="gtk_numerable_icon_get_count" deprecated="1">
         <return-type type="gint" />
       </method>
-      <method name="GetLabel" cname="gtk_numerable_icon_get_label">
+      <method name="GetLabel" cname="gtk_numerable_icon_get_label" deprecated="1">
         <return-type type="const-gchar*" />
       </method>
-      <method name="GetStyleContext" cname="gtk_numerable_icon_get_style_context">
+      <method name="GetStyleContext" cname="gtk_numerable_icon_get_style_context" deprecated="1">
         <return-type type="GtkStyleContext*" />
       </method>
-      <method name="GetType" cname="gtk_numerable_icon_get_type" shared="true">
+      <method name="GetType" cname="gtk_numerable_icon_get_type" deprecated="1" shared="true">
         <return-type type="GType" />
       </method>
-      <constructor cname="gtk_numerable_icon_new">
+      <constructor cname="gtk_numerable_icon_new" deprecated="1">
         <parameters>
           <parameter type="GIcon*" name="base_icon" />
         </parameters>
       </constructor>
-      <constructor cname="gtk_numerable_icon_new_with_style_context">
+      <constructor cname="gtk_numerable_icon_new_with_style_context" deprecated="1">
         <parameters>
           <parameter type="GIcon*" name="base_icon" />
           <parameter type="GtkStyleContext*" name="context" />
         </parameters>
       </constructor>
-      <method name="SetBackgroundGicon" cname="gtk_numerable_icon_set_background_gicon">
+      <method name="SetBackgroundGicon" cname="gtk_numerable_icon_set_background_gicon" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="GIcon*" name="icon" />
         </parameters>
       </method>
-      <method name="SetBackgroundIconName" cname="gtk_numerable_icon_set_background_icon_name">
+      <method name="SetBackgroundIconName" cname="gtk_numerable_icon_set_background_icon_name" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="const-gchar*" name="icon_name" />
         </parameters>
       </method>
-      <method name="SetCount" cname="gtk_numerable_icon_set_count">
+      <method name="SetCount" cname="gtk_numerable_icon_set_count" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="gint" name="count" />
         </parameters>
       </method>
-      <method name="SetLabel" cname="gtk_numerable_icon_set_label">
+      <method name="SetLabel" cname="gtk_numerable_icon_set_label" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="const-gchar*" name="label" />
         </parameters>
       </method>
-      <method name="SetStyleContext" cname="gtk_numerable_icon_set_style_context">
+      <method name="SetStyleContext" cname="gtk_numerable_icon_set_style_context" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="GtkStyleContext*" name="style" />
@@ -13718,6 +16775,65 @@
         <return-type type="GType" />
       </method>
       <constructor cname="gtk_offscreen_window_new" />
+    </object>
+    <object name="Overlay" cname="GtkOverlay" parent="GtkBin">
+      <class_struct cname="GtkOverlayClass">
+        <field name="ParentClass" cname="parent_class" type="GtkBinClass" />
+        <method signal_vm="get_child_position" />
+        <method vm="_gtk_reserved1" />
+        <method vm="_gtk_reserved2" />
+        <method vm="_gtk_reserved3" />
+        <method vm="_gtk_reserved4" />
+        <method vm="_gtk_reserved5" />
+        <method vm="_gtk_reserved6" />
+        <method vm="_gtk_reserved7" />
+        <method vm="_gtk_reserved8" />
+      </class_struct>
+      <field name="Priv" cname="priv" type="GtkOverlayPrivate*" />
+      <signal name="GetChildPosition" cname="get-child-position" when="LAST" field_name="get_child_position">
+        <return-type type="gboolean" />
+        <parameters>
+          <parameter type="GtkWidget*" name="widget" />
+          <parameter type="GtkAllocation*" name="allocation" />
+        </parameters>
+      </signal>
+      <virtual_method name="GtkReserved1" cname="_gtk_reserved1" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <virtual_method name="GtkReserved2" cname="_gtk_reserved2" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <virtual_method name="GtkReserved3" cname="_gtk_reserved3" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <virtual_method name="GtkReserved4" cname="_gtk_reserved4" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <virtual_method name="GtkReserved5" cname="_gtk_reserved5" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <virtual_method name="GtkReserved6" cname="_gtk_reserved6" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <virtual_method name="GtkReserved7" cname="_gtk_reserved7" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <virtual_method name="GtkReserved8" cname="_gtk_reserved8" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <implements>
+        <interface cname="GtkBuildable" />
+      </implements>
+      <method name="AddOverlay" cname="gtk_overlay_add_overlay">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkWidget*" name="widget" />
+        </parameters>
+      </method>
+      <method name="GetType" cname="gtk_overlay_get_type" shared="true">
+        <return-type type="GType" />
+      </method>
+      <constructor cname="gtk_overlay_new" />
     </object>
     <object name="PageSetup" cname="GtkPageSetup" parent="GObject">
       <class_struct cname="GtkPageSetupClass">
@@ -14043,6 +17159,151 @@
         </parameters>
       </method>
     </object>
+    <object name="PlacesSidebar" cname="GtkPlacesSidebar" parent="GtkScrolledWindow">
+      <class_struct cname="GtkPlacesSidebarClass">
+        <field name="Parent" cname="parent" type="GtkScrolledWindowClass" />
+        <method signal_vm="open_location" />
+        <method signal_vm="populate_popup" />
+        <method signal_vm="show_error_message" />
+        <method signal_vm="show_connect_to_server" />
+        <method signal_vm="drag_action_requested" />
+        <method signal_vm="drag_action_ask" />
+        <method signal_vm="drag_perform_drop" />
+        <method signal_vm="show_enter_location" />
+      </class_struct>
+      <signal name="OpenLocation" cname="open-location" when="FIRST" field_name="open_location">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GFile*" name="location" />
+          <parameter type="GtkPlacesOpenFlags" name="open_flags" />
+        </parameters>
+      </signal>
+      <signal name="PopulatePopup" cname="populate-popup" when="FIRST" field_name="populate_popup">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkMenu*" name="menu" />
+          <parameter type="GFile*" name="selected_item" />
+          <parameter type="GVolume*" name="selected_volume" />
+        </parameters>
+      </signal>
+      <signal name="ShowErrorMessage" cname="show-error-message" when="FIRST" field_name="show_error_message">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="const-gchar*" name="primary" />
+          <parameter type="const-gchar*" name="secondary" />
+        </parameters>
+      </signal>
+      <signal name="ShowConnectToServer" cname="show-connect-to-server" when="FIRST" field_name="show_connect_to_server">
+        <return-type type="void" />
+        <parameters />
+      </signal>
+      <signal name="ShowEnterLocation" cname="show-enter-location" when="FIRST" field_name="show_enter_location">
+        <return-type type="void" />
+        <parameters />
+      </signal>
+      <signal name="DragActionRequested" cname="drag-action-requested" when="LAST" manual="true" field_name="drag_action_requested">
+        <return-type type="GdkDragAction" />
+        <parameters>
+          <parameter type="GdkDragContext*" name="context" />
+          <parameter type="GFile*" name="dest_file" />
+          <parameter type="GList*" name="source_file_list" />
+        </parameters>
+      </signal>
+      <signal name="DragActionAsk" cname="drag-action-ask" when="LAST" field_name="drag_action_ask">
+        <return-type type="GdkDragAction" />
+        <parameters>
+          <parameter type="GdkDragAction" name="actions" />
+        </parameters>
+      </signal>
+      <signal name="DragPerformDrop" cname="drag-perform-drop" when="FIRST" manual="true" field_name="drag_perform_drop">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GFile*" name="dest_file" />
+          <parameter type="GList*" name="source_file_list" />
+          <parameter type="GdkDragAction" name="action" />
+        </parameters>
+      </signal>
+      <property name="LocalOnly" cname="local-only" type="gboolean" readable="true" writeable="true" />
+      <method name="AddShortcut" cname="gtk_places_sidebar_add_shortcut">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GFile*" name="location" />
+        </parameters>
+      </method>
+      <method name="GetLocalOnly" cname="gtk_places_sidebar_get_local_only">
+        <return-type type="gboolean" />
+      </method>
+      <method name="GetLocation" cname="gtk_places_sidebar_get_location">
+        <return-type type="GFile*" />
+      </method>
+      <method name="GetNthBookmark" cname="gtk_places_sidebar_get_nth_bookmark">
+        <return-type type="GFile*" />
+        <parameters>
+          <parameter type="gint" name="n" />
+        </parameters>
+      </method>
+      <method name="GetOpenFlags" cname="gtk_places_sidebar_get_open_flags">
+        <return-type type="GtkPlacesOpenFlags" />
+      </method>
+      <method name="GetShowConnectToServer" cname="gtk_places_sidebar_get_show_connect_to_server">
+        <return-type type="gboolean" />
+      </method>
+      <method name="GetShowDesktop" cname="gtk_places_sidebar_get_show_desktop">
+        <return-type type="gboolean" />
+      </method>
+      <method name="GetShowEnterLocation" cname="gtk_places_sidebar_get_show_enter_location">
+        <return-type type="gboolean" />
+      </method>
+      <method name="GetType" cname="gtk_places_sidebar_get_type" shared="true">
+        <return-type type="GType" />
+      </method>
+      <method name="ListShortcuts" cname="gtk_places_sidebar_list_shortcuts">
+        <return-type type="GSList*" />
+      </method>
+      <constructor cname="gtk_places_sidebar_new" />
+      <method name="RemoveShortcut" cname="gtk_places_sidebar_remove_shortcut">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GFile*" name="location" />
+        </parameters>
+      </method>
+      <method name="SetLocalOnly" cname="gtk_places_sidebar_set_local_only">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gboolean" name="local_only" />
+        </parameters>
+      </method>
+      <method name="SetLocation" cname="gtk_places_sidebar_set_location">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GFile*" name="location" />
+        </parameters>
+      </method>
+      <method name="SetOpenFlags" cname="gtk_places_sidebar_set_open_flags">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkPlacesOpenFlags" name="flags" />
+        </parameters>
+      </method>
+      <method name="SetShowConnectToServer" cname="gtk_places_sidebar_set_show_connect_to_server">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gboolean" name="show_connect_to_server" />
+        </parameters>
+      </method>
+      <method name="SetShowDesktop" cname="gtk_places_sidebar_set_show_desktop">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gboolean" name="show_desktop" />
+        </parameters>
+      </method>
+      <method name="SetShowEnterLocation" cname="gtk_places_sidebar_set_show_enter_location">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gboolean" name="show_enter_location" />
+        </parameters>
+      </method>
+    </object>
     <object name="Plug" cname="GtkPlug" parent="GtkWindow">
       <class_struct cname="GtkPlugClass">
         <field name="ParentClass" cname="parent_class" type="GtkWindowClass" />
@@ -14107,6 +17368,82 @@
           <parameter type="Window" name="socket_id" />
         </parameters>
       </constructor>
+    </object>
+    <object name="Popover" cname="GtkPopover" parent="GtkBin">
+      <class_struct cname="GtkPopoverClass">
+        <field name="ParentClass" cname="parent_class" type="GtkBinClass" />
+        <method signal_vm="closed" />
+        <field name="Reserved" cname="reserved" type="gpointer" array_len="10" />
+      </class_struct>
+      <field name="Priv" cname="priv" type="GtkPopoverPrivate*" />
+      <property name="RelativeTo" cname="relative-to" type="GtkWidget" readable="true" writeable="true" />
+      <property name="PointingTo" cname="pointing-to" type="CairoGobjectRectangleInt" readable="true" writeable="true" />
+      <property name="Position" cname="position" type="GtkPositionType" readable="true" writeable="true" construct="true" />
+      <property name="Modal" cname="modal" type="gboolean" readable="true" writeable="true" />
+      <signal name="Closed" cname="closed" when="LAST" field_name="closed">
+        <return-type type="void" />
+        <parameters />
+      </signal>
+      <method name="BindModel" cname="gtk_popover_bind_model">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GMenuModel*" name="model" />
+          <parameter type="const-gchar*" name="action_namespace" />
+        </parameters>
+      </method>
+      <method name="GetModal" cname="gtk_popover_get_modal">
+        <return-type type="gboolean" />
+      </method>
+      <method name="GetPointingTo" cname="gtk_popover_get_pointing_to">
+        <return-type type="gboolean" />
+        <parameters>
+          <parameter type="GdkRectangle*" name="rect" />
+        </parameters>
+      </method>
+      <method name="GetPosition" cname="gtk_popover_get_position">
+        <return-type type="GtkPositionType" />
+      </method>
+      <method name="GetRelativeTo" cname="gtk_popover_get_relative_to">
+        <return-type type="GtkWidget*" />
+      </method>
+      <method name="GetType" cname="gtk_popover_get_type" shared="true">
+        <return-type type="GType" />
+      </method>
+      <constructor cname="gtk_popover_new">
+        <parameters>
+          <parameter type="GtkWidget*" name="relative_to" />
+        </parameters>
+      </constructor>
+      <constructor cname="gtk_popover_new_from_model">
+        <parameters>
+          <parameter type="GtkWidget*" name="relative_to" />
+          <parameter type="GMenuModel*" name="model" />
+        </parameters>
+      </constructor>
+      <method name="SetModal" cname="gtk_popover_set_modal">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gboolean" name="modal" />
+        </parameters>
+      </method>
+      <method name="SetPointingTo" cname="gtk_popover_set_pointing_to">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="const-GdkRectangle*" name="rect" />
+        </parameters>
+      </method>
+      <method name="SetPosition" cname="gtk_popover_set_position">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkPositionType" name="position" />
+        </parameters>
+      </method>
+      <method name="SetRelativeTo" cname="gtk_popover_set_relative_to">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkWidget*" name="relative_to" />
+        </parameters>
+      </method>
     </object>
     <object name="Printer" cname="GtkPrinter" parent="GObject">
       <class_struct cname="GtkPrinterClass">
@@ -15396,22 +18733,22 @@
       <virtual_method name="GtkReserved4" cname="_gtk_reserved4" shared="true" padding="true">
         <return-type type="void" />
       </virtual_method>
-      <method name="GetCurrentValue" cname="gtk_radio_action_get_current_value">
+      <method name="GetCurrentValue" cname="gtk_radio_action_get_current_value" deprecated="1">
         <return-type type="gint" />
       </method>
-      <method name="GetGroup" cname="gtk_radio_action_get_group">
+      <method name="GetGroup" cname="gtk_radio_action_get_group" deprecated="1">
         <return-type type="GSList*" />
       </method>
-      <method name="GetType" cname="gtk_radio_action_get_type" shared="true">
+      <method name="GetType" cname="gtk_radio_action_get_type" deprecated="1" shared="true">
         <return-type type="GType" />
       </method>
-      <method name="JoinGroup" cname="gtk_radio_action_join_group">
+      <method name="JoinGroup" cname="gtk_radio_action_join_group" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="GtkRadioAction*" name="group_source" />
         </parameters>
       </method>
-      <constructor cname="gtk_radio_action_new">
+      <constructor cname="gtk_radio_action_new" deprecated="1">
         <parameters>
           <parameter type="const-gchar*" name="name" />
           <parameter type="const-gchar*" name="label" />
@@ -15420,13 +18757,13 @@
           <parameter type="gint" name="value" />
         </parameters>
       </constructor>
-      <method name="SetCurrentValue" cname="gtk_radio_action_set_current_value">
+      <method name="SetCurrentValue" cname="gtk_radio_action_set_current_value" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="gint" name="current_value" />
         </parameters>
       </method>
-      <method name="SetGroup" cname="gtk_radio_action_set_group">
+      <method name="SetGroup" cname="gtk_radio_action_set_group" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="GSList*" name="group" />
@@ -15619,7 +18956,7 @@
           <parameter type="GSList*" name="group" />
         </parameters>
       </constructor>
-      <constructor cname="gtk_radio_tool_button_new_from_stock">
+      <constructor cname="gtk_radio_tool_button_new_from_stock" deprecated="1">
         <parameters>
           <parameter type="GSList*" name="group" />
           <parameter type="const-gchar*" name="stock_id" />
@@ -15630,7 +18967,7 @@
           <parameter type="GtkRadioToolButton*" name="group" />
         </parameters>
       </constructor>
-      <constructor cname="gtk_radio_tool_button_new_with_stock_from_widget">
+      <constructor cname="gtk_radio_tool_button_new_with_stock_from_widget" deprecated="1">
         <parameters>
           <parameter type="GtkRadioToolButton*" name="group" />
           <parameter type="const-gchar*" name="stock_id" />
@@ -15939,13 +19276,13 @@
       <implements>
         <interface cname="GtkRecentChooser" />
       </implements>
-      <method name="GetShowNumbers" cname="gtk_recent_action_get_show_numbers">
+      <method name="GetShowNumbers" cname="gtk_recent_action_get_show_numbers" deprecated="1">
         <return-type type="gboolean" />
       </method>
-      <method name="GetType" cname="gtk_recent_action_get_type" shared="true">
+      <method name="GetType" cname="gtk_recent_action_get_type" deprecated="1" shared="true">
         <return-type type="GType" />
       </method>
-      <constructor cname="gtk_recent_action_new">
+      <constructor cname="gtk_recent_action_new" deprecated="1">
         <parameters>
           <parameter type="const-gchar*" name="name" />
           <parameter type="const-gchar*" name="label" />
@@ -15953,7 +19290,7 @@
           <parameter type="const-gchar*" name="stock_id" />
         </parameters>
       </constructor>
-      <constructor cname="gtk_recent_action_new_for_manager">
+      <constructor cname="gtk_recent_action_new_for_manager" deprecated="1">
         <parameters>
           <parameter type="const-gchar*" name="name" />
           <parameter type="const-gchar*" name="label" />
@@ -15962,14 +19299,14 @@
           <parameter type="GtkRecentManager*" name="manager" />
         </parameters>
       </constructor>
-      <method name="SetShowNumbers" cname="gtk_recent_action_set_show_numbers">
+      <method name="SetShowNumbers" cname="gtk_recent_action_set_show_numbers" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="gboolean" name="show_numbers" />
         </parameters>
       </method>
     </object>
-    <object name="RecentChooserDefault" cname="GtkRecentChooserDefault" parent="GtkVBox">
+    <object name="RecentChooserDefault" cname="GtkRecentChooserDefault" parent="GtkBox">
       <implements>
         <interface cname="GtkRecentChooser" />
         <interface cname="GtkActivatable" />
@@ -16065,9 +19402,9 @@
         </parameters>
       </method>
     </object>
-    <object name="RecentChooserWidget" cname="GtkRecentChooserWidget" parent="GtkVBox">
+    <object name="RecentChooserWidget" cname="GtkRecentChooserWidget" parent="GtkBox">
       <class_struct cname="GtkRecentChooserWidgetClass">
-        <field name="ParentClass" cname="parent_class" type="GtkVBoxClass" />
+        <field name="ParentClass" cname="parent_class" type="GtkBoxClass" />
         <method vm="_gtk_reserved1" />
         <method vm="_gtk_reserved2" />
         <method vm="_gtk_reserved3" />
@@ -16260,6 +19597,46 @@
         </parameters>
       </method>
     </object>
+    <object name="Revealer" cname="GtkRevealer" parent="GtkBin">
+      <class_struct cname="GtkRevealerClass">
+        <field name="ParentClass" cname="parent_class" type="GtkBinClass" />
+      </class_struct>
+      <property name="ChildRevealed" cname="child-revealed" type="gboolean" readable="true" />
+      <method name="GetChildRevealed" cname="gtk_revealer_get_child_revealed">
+        <return-type type="gboolean" />
+      </method>
+      <method name="GetRevealChild" cname="gtk_revealer_get_reveal_child">
+        <return-type type="gboolean" />
+      </method>
+      <method name="GetTransitionDuration" cname="gtk_revealer_get_transition_duration">
+        <return-type type="guint" />
+      </method>
+      <method name="GetTransitionType" cname="gtk_revealer_get_transition_type">
+        <return-type type="GtkRevealerTransitionType" />
+      </method>
+      <method name="GetType" cname="gtk_revealer_get_type" shared="true">
+        <return-type type="GType" />
+      </method>
+      <constructor cname="gtk_revealer_new" />
+      <method name="SetRevealChild" cname="gtk_revealer_set_reveal_child">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gboolean" name="reveal_child" />
+        </parameters>
+      </method>
+      <method name="SetTransitionDuration" cname="gtk_revealer_set_transition_duration">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="guint" name="duration" />
+        </parameters>
+      </method>
+      <method name="SetTransitionType" cname="gtk_revealer_set_transition_type">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkRevealerTransitionType" name="transition" />
+        </parameters>
+      </method>
+    </object>
     <object name="Scale" cname="GtkScale" parent="GtkRange">
       <class_struct cname="GtkScaleClass">
         <field name="ParentClass" cname="parent_class" type="GtkRangeClass" />
@@ -16280,6 +19657,7 @@
       </signal>
       <property name="Digits" cname="digits" type="gint" readable="true" writeable="true" />
       <property name="DrawValue" cname="draw-value" type="gboolean" readable="true" writeable="true" />
+      <property name="HasOrigin" cname="has-origin" type="gboolean" readable="true" writeable="true" />
       <property name="ValuePos" cname="value-pos" type="GtkPositionType" readable="true" writeable="true" />
       <virtual_method name="DrawValue" cname="draw_value">
         <return-type type="void" />
@@ -16324,6 +19702,9 @@
       <method name="GetDrawValue" cname="gtk_scale_get_draw_value">
         <return-type type="gboolean" />
       </method>
+      <method name="GetHasOrigin" cname="gtk_scale_get_has_origin">
+        <return-type type="gboolean" />
+      </method>
       <method name="GetLayout" cname="gtk_scale_get_layout">
         <return-type type="PangoLayout*" />
       </method>
@@ -16364,6 +19745,12 @@
         <return-type type="void" />
         <parameters>
           <parameter type="gboolean" name="draw_value" />
+        </parameters>
+      </method>
+      <method name="SetHasOrigin" cname="gtk_scale_set_has_origin">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gboolean" name="has_origin" />
         </parameters>
       </method>
       <method name="SetValuePos" cname="gtk_scale_set_value_pos">
@@ -16513,6 +19900,7 @@
       <property name="ShadowType" cname="shadow-type" type="GtkShadowType" readable="true" writeable="true" />
       <property name="MinContentWidth" cname="min-content-width" type="gint" readable="true" writeable="true" />
       <property name="MinContentHeight" cname="min-content-height" type="gint" readable="true" writeable="true" />
+      <property name="KineticScrolling" cname="kinetic-scrolling" type="gboolean" readable="true" writeable="true" />
       <signal name="ScrollChild" cname="scroll-child" when="LAST" field_name="scroll_child">
         <return-type type="gboolean" />
         <parameters>
@@ -16538,17 +19926,23 @@
       <virtual_method name="GtkReserved4" cname="_gtk_reserved4" shared="true" padding="true">
         <return-type type="void" />
       </virtual_method>
-      <method name="AddWithViewport" cname="gtk_scrolled_window_add_with_viewport">
+      <method name="AddWithViewport" cname="gtk_scrolled_window_add_with_viewport" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="GtkWidget*" name="child" />
         </parameters>
+      </method>
+      <method name="GetCaptureButtonPress" cname="gtk_scrolled_window_get_capture_button_press">
+        <return-type type="gboolean" />
       </method>
       <method name="GetHadjustment" cname="gtk_scrolled_window_get_hadjustment">
         <return-type type="GtkAdjustment*" />
       </method>
       <method name="GetHscrollbar" cname="gtk_scrolled_window_get_hscrollbar">
         <return-type type="GtkWidget*" />
+      </method>
+      <method name="GetKineticScrolling" cname="gtk_scrolled_window_get_kinetic_scrolling">
+        <return-type type="gboolean" />
       </method>
       <method name="GetMinContentHeight" cname="gtk_scrolled_window_get_min_content_height">
         <return-type type="gint" />
@@ -16584,10 +19978,22 @@
           <parameter type="GtkAdjustment*" name="vadjustment" />
         </parameters>
       </constructor>
+      <method name="SetCaptureButtonPress" cname="gtk_scrolled_window_set_capture_button_press">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gboolean" name="capture_button_press" />
+        </parameters>
+      </method>
       <method name="SetHadjustment" cname="gtk_scrolled_window_set_hadjustment">
         <return-type type="void" />
         <parameters>
           <parameter type="GtkAdjustment*" name="hadjustment" />
+        </parameters>
+      </method>
+      <method name="SetKineticScrolling" cname="gtk_scrolled_window_set_kinetic_scrolling">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gboolean" name="kinetic_scrolling" />
         </parameters>
       </method>
       <method name="SetMinContentHeight" cname="gtk_scrolled_window_set_min_content_height">
@@ -16630,6 +20036,91 @@
       <method name="UnsetPlacement" cname="gtk_scrolled_window_unset_placement">
         <return-type type="void" />
       </method>
+    </object>
+    <object name="SearchBar" cname="GtkSearchBar" parent="GtkBin">
+      <class_struct cname="GtkSearchBarClass">
+        <field name="ParentClass" cname="parent_class" type="GtkBinClass" />
+        <method vm="_gtk_reserved1" />
+        <method vm="_gtk_reserved2" />
+        <method vm="_gtk_reserved3" />
+        <method vm="_gtk_reserved4" />
+      </class_struct>
+      <property name="ShowCloseButton" cname="show-close-button" type="gboolean" readable="true" writeable="true" construct="true" />
+      <virtual_method name="GtkReserved1" cname="_gtk_reserved1" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <virtual_method name="GtkReserved2" cname="_gtk_reserved2" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <virtual_method name="GtkReserved3" cname="_gtk_reserved3" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <virtual_method name="GtkReserved4" cname="_gtk_reserved4" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <method name="ConnectEntry" cname="gtk_search_bar_connect_entry">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkEntry*" name="entry" />
+        </parameters>
+      </method>
+      <method name="GetSearchMode" cname="gtk_search_bar_get_search_mode">
+        <return-type type="gboolean" />
+      </method>
+      <method name="GetShowCloseButton" cname="gtk_search_bar_get_show_close_button">
+        <return-type type="gboolean" />
+      </method>
+      <method name="GetType" cname="gtk_search_bar_get_type" shared="true">
+        <return-type type="GType" />
+      </method>
+      <method name="HandleEvent" cname="gtk_search_bar_handle_event">
+        <return-type type="gboolean" />
+        <parameters>
+          <parameter type="GdkEvent*" name="event" />
+        </parameters>
+      </method>
+      <constructor cname="gtk_search_bar_new" />
+      <method name="SetSearchMode" cname="gtk_search_bar_set_search_mode">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gboolean" name="search_mode" />
+        </parameters>
+      </method>
+      <method name="SetShowCloseButton" cname="gtk_search_bar_set_show_close_button">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gboolean" name="visible" />
+        </parameters>
+      </method>
+    </object>
+    <object name="SearchEntry" cname="GtkSearchEntry" parent="GtkEntry">
+      <class_struct cname="GtkSearchEntryClass">
+        <field name="ParentClass" cname="parent_class" type="GtkEntryClass" />
+        <method signal_vm="search_changed" />
+        <method vm="_gtk_reserved1" />
+        <method vm="_gtk_reserved2" />
+        <method vm="_gtk_reserved3" />
+      </class_struct>
+      <signal name="SearchChanged" cname="search-changed" when="LAST" field_name="search_changed">
+        <return-type type="void" />
+        <parameters />
+      </signal>
+      <virtual_method name="GtkReserved1" cname="_gtk_reserved1" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <virtual_method name="GtkReserved2" cname="_gtk_reserved2" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <virtual_method name="GtkReserved3" cname="_gtk_reserved3" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <implements>
+        <interface cname="GtkEditable" />
+      </implements>
+      <method name="GetType" cname="gtk_search_entry_get_type" shared="true">
+        <return-type type="GType" />
+      </method>
+      <constructor cname="gtk_search_entry_new" />
     </object>
     <object name="Separator" cname="GtkSeparator" parent="GtkWidget">
       <class_struct cname="GtkSeparatorClass">
@@ -16748,6 +20239,7 @@
       </virtual_method>
       <implements>
         <interface cname="GtkStyleProvider" />
+        <interface cname="GtkStyleProviderPrivate" />
       </implements>
       <method name="GetDefault" cname="gtk_settings_get_default" shared="true">
         <return-type type="GtkSettings*" />
@@ -17014,6 +20506,7 @@
         <return-type type="void" />
       </virtual_method>
       <implements>
+        <interface cname="GtkOrientable" />
         <interface cname="GtkEditable" />
       </implements>
       <method name="Configure" cname="gtk_spin_button_configure">
@@ -17146,9 +20639,135 @@
         <return-type type="void" />
       </method>
     </object>
-    <object name="Statusbar" cname="GtkStatusbar" parent="GtkHBox">
+    <object name="Stack" cname="GtkStack" parent="GtkContainer">
+      <class_struct cname="GtkStackClass">
+        <field name="ParentClass" cname="parent_class" type="GtkContainerClass" />
+      </class_struct>
+      <property name="TransitionRunning" cname="transition-running" type="gboolean" readable="true" />
+      <childprop name="Name" cname="name" type="gchar*" readable="true" writeable="true" />
+      <childprop name="Title" cname="title" type="gchar*" readable="true" writeable="true" />
+      <childprop name="IconName" cname="icon-name" type="gchar*" readable="true" writeable="true" />
+      <childprop name="Position" cname="position" type="gint" readable="true" writeable="true" />
+      <childprop name="NeedsAttention" cname="needs-attention" type="gboolean" readable="true" writeable="true" />
+      <method name="AddNamed" cname="gtk_stack_add_named">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkWidget*" name="child" />
+          <parameter type="const-gchar*" name="name" />
+        </parameters>
+      </method>
+      <method name="AddTitled" cname="gtk_stack_add_titled">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkWidget*" name="child" />
+          <parameter type="const-gchar*" name="name" />
+          <parameter type="const-gchar*" name="title" />
+        </parameters>
+      </method>
+      <method name="GetChildByName" cname="gtk_stack_get_child_by_name">
+        <return-type type="GtkWidget*" />
+        <parameters>
+          <parameter type="const-gchar*" name="name" />
+        </parameters>
+      </method>
+      <method name="GetHomogeneous" cname="gtk_stack_get_homogeneous">
+        <return-type type="gboolean" />
+      </method>
+      <method name="GetTransitionDuration" cname="gtk_stack_get_transition_duration">
+        <return-type type="guint" />
+      </method>
+      <method name="GetTransitionRunning" cname="gtk_stack_get_transition_running">
+        <return-type type="gboolean" />
+      </method>
+      <method name="GetTransitionType" cname="gtk_stack_get_transition_type">
+        <return-type type="GtkStackTransitionType" />
+      </method>
+      <method name="GetType" cname="gtk_stack_get_type" shared="true">
+        <return-type type="GType" />
+      </method>
+      <method name="GetVisibleChild" cname="gtk_stack_get_visible_child">
+        <return-type type="GtkWidget*" />
+      </method>
+      <method name="GetVisibleChildName" cname="gtk_stack_get_visible_child_name">
+        <return-type type="const-gchar*" />
+      </method>
+      <constructor cname="gtk_stack_new" />
+      <method name="SetHomogeneous" cname="gtk_stack_set_homogeneous">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gboolean" name="homogeneous" />
+        </parameters>
+      </method>
+      <method name="SetTransitionDuration" cname="gtk_stack_set_transition_duration">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="guint" name="duration" />
+        </parameters>
+      </method>
+      <method name="SetTransitionType" cname="gtk_stack_set_transition_type">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkStackTransitionType" name="transition" />
+        </parameters>
+      </method>
+      <method name="SetVisibleChild" cname="gtk_stack_set_visible_child">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkWidget*" name="child" />
+        </parameters>
+      </method>
+      <method name="SetVisibleChildFull" cname="gtk_stack_set_visible_child_full">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="const-gchar*" name="name" />
+          <parameter type="GtkStackTransitionType" name="transition" />
+        </parameters>
+      </method>
+      <method name="SetVisibleChildName" cname="gtk_stack_set_visible_child_name">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="const-gchar*" name="name" />
+        </parameters>
+      </method>
+    </object>
+    <object name="StackSwitcher" cname="GtkStackSwitcher" parent="GtkBox">
+      <class_struct cname="GtkStackSwitcherClass">
+        <field name="ParentClass" cname="parent_class" type="GtkBoxClass" />
+        <method vm="_gtk_reserved1" />
+        <method vm="_gtk_reserved2" />
+        <method vm="_gtk_reserved3" />
+        <method vm="_gtk_reserved4" />
+      </class_struct>
+      <property name="Stack" cname="stack" type="GtkStack" readable="true" writeable="true" construct="true" />
+      <virtual_method name="GtkReserved1" cname="_gtk_reserved1" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <virtual_method name="GtkReserved2" cname="_gtk_reserved2" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <virtual_method name="GtkReserved3" cname="_gtk_reserved3" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <virtual_method name="GtkReserved4" cname="_gtk_reserved4" shared="true" padding="true">
+        <return-type type="void" />
+      </virtual_method>
+      <method name="GetStack" cname="gtk_stack_switcher_get_stack">
+        <return-type type="GtkStack*" />
+      </method>
+      <method name="GetType" cname="gtk_stack_switcher_get_type" shared="true">
+        <return-type type="GType" />
+      </method>
+      <constructor cname="gtk_stack_switcher_new" />
+      <method name="SetStack" cname="gtk_stack_switcher_set_stack">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkStack*" name="stack" />
+        </parameters>
+      </method>
+    </object>
+    <object name="Statusbar" cname="GtkStatusbar" parent="GtkBox">
       <class_struct cname="GtkStatusbarClass">
-        <field name="ParentClass" cname="parent_class" type="GtkHBoxClass" />
+        <field name="ParentClass" cname="parent_class" type="GtkBoxClass" />
         <field name="Reserved" cname="reserved" type="gpointer" />
         <method signal_vm="text_pushed" />
         <method signal_vm="text_popped" />
@@ -17184,9 +20803,6 @@
       <virtual_method name="GtkReserved4" cname="_gtk_reserved4" shared="true" padding="true">
         <return-type type="void" />
       </virtual_method>
-      <implements>
-        <interface cname="GtkBuildable" />
-      </implements>
       <method name="GetContextId" cname="gtk_statusbar_get_context_id">
         <return-type type="guint" />
         <parameters>
@@ -17314,7 +20930,7 @@
       <virtual_method name="_GtkReserved4" cname="__gtk_reserved4" shared="true" padding="true">
         <return-type type="void" />
       </virtual_method>
-      <method name="GetGeometry" cname="gtk_status_icon_get_geometry">
+      <method name="GetGeometry" cname="gtk_status_icon_get_geometry" deprecated="1">
         <return-type type="gboolean" />
         <parameters>
           <parameter type="GdkScreen**" name="screen" />
@@ -17322,78 +20938,78 @@
           <parameter type="GtkOrientation*" name="orientation" />
         </parameters>
       </method>
-      <method name="GetGicon" cname="gtk_status_icon_get_gicon">
+      <method name="GetGicon" cname="gtk_status_icon_get_gicon" deprecated="1">
         <return-type type="GIcon*" />
       </method>
-      <method name="GetHasTooltip" cname="gtk_status_icon_get_has_tooltip">
+      <method name="GetHasTooltip" cname="gtk_status_icon_get_has_tooltip" deprecated="1">
         <return-type type="gboolean" />
       </method>
-      <method name="GetIconName" cname="gtk_status_icon_get_icon_name">
+      <method name="GetIconName" cname="gtk_status_icon_get_icon_name" deprecated="1">
         <return-type type="const-gchar*" />
       </method>
-      <method name="GetPixbuf" cname="gtk_status_icon_get_pixbuf">
+      <method name="GetPixbuf" cname="gtk_status_icon_get_pixbuf" deprecated="1">
         <return-type type="GdkPixbuf*" />
       </method>
-      <method name="GetScreen" cname="gtk_status_icon_get_screen">
+      <method name="GetScreen" cname="gtk_status_icon_get_screen" deprecated="1">
         <return-type type="GdkScreen*" />
       </method>
-      <method name="GetSize" cname="gtk_status_icon_get_size">
+      <method name="GetSize" cname="gtk_status_icon_get_size" deprecated="1">
         <return-type type="gint" />
       </method>
-      <method name="GetStock" cname="gtk_status_icon_get_stock">
+      <method name="GetStock" cname="gtk_status_icon_get_stock" deprecated="1">
         <return-type type="const-gchar*" />
       </method>
-      <method name="GetStorageType" cname="gtk_status_icon_get_storage_type">
+      <method name="GetStorageType" cname="gtk_status_icon_get_storage_type" deprecated="1">
         <return-type type="GtkImageType" />
       </method>
-      <method name="GetTitle" cname="gtk_status_icon_get_title">
+      <method name="GetTitle" cname="gtk_status_icon_get_title" deprecated="1">
         <return-type type="const-gchar*" />
       </method>
-      <method name="GetTooltipMarkup" cname="gtk_status_icon_get_tooltip_markup">
+      <method name="GetTooltipMarkup" cname="gtk_status_icon_get_tooltip_markup" deprecated="1">
         <return-type type="gchar*" />
       </method>
-      <method name="GetTooltipText" cname="gtk_status_icon_get_tooltip_text">
+      <method name="GetTooltipText" cname="gtk_status_icon_get_tooltip_text" deprecated="1">
         <return-type type="gchar*" />
       </method>
       <method name="GetType" cname="gtk_status_icon_get_type" shared="true">
         <return-type type="GType" />
       </method>
-      <method name="GetVisible" cname="gtk_status_icon_get_visible">
+      <method name="GetVisible" cname="gtk_status_icon_get_visible" deprecated="1">
         <return-type type="gboolean" />
       </method>
-      <method name="GetX11WindowId" cname="gtk_status_icon_get_x11_window_id">
+      <method name="GetX11WindowId" cname="gtk_status_icon_get_x11_window_id" deprecated="1">
         <return-type type="guint32" />
       </method>
-      <method name="IsEmbedded" cname="gtk_status_icon_is_embedded">
+      <method name="IsEmbedded" cname="gtk_status_icon_is_embedded" deprecated="1">
         <return-type type="gboolean" />
       </method>
-      <constructor cname="gtk_status_icon_new" />
-      <constructor cname="gtk_status_icon_new_from_file">
+      <constructor cname="gtk_status_icon_new" deprecated="1" />
+      <constructor cname="gtk_status_icon_new_from_file" deprecated="1">
         <parameters>
           <parameter type="const-gchar*" name="filename" />
         </parameters>
       </constructor>
-      <constructor cname="gtk_status_icon_new_from_gicon">
+      <constructor cname="gtk_status_icon_new_from_gicon" deprecated="1">
         <parameters>
           <parameter type="GIcon*" name="icon" />
         </parameters>
       </constructor>
-      <constructor cname="gtk_status_icon_new_from_icon_name">
+      <constructor cname="gtk_status_icon_new_from_icon_name" deprecated="1">
         <parameters>
           <parameter type="const-gchar*" name="icon_name" />
         </parameters>
       </constructor>
-      <constructor cname="gtk_status_icon_new_from_pixbuf">
+      <constructor cname="gtk_status_icon_new_from_pixbuf" deprecated="1">
         <parameters>
           <parameter type="GdkPixbuf*" name="pixbuf" />
         </parameters>
       </constructor>
-      <constructor cname="gtk_status_icon_new_from_stock">
+      <constructor cname="gtk_status_icon_new_from_stock" deprecated="1">
         <parameters>
           <parameter type="const-gchar*" name="stock_id" />
         </parameters>
       </constructor>
-      <method name="PositionMenu" cname="gtk_status_icon_position_menu" shared="true">
+      <method name="PositionMenu" cname="gtk_status_icon_position_menu" deprecated="1" shared="true">
         <return-type type="void" />
         <parameters>
           <parameter type="GtkMenu*" name="menu" />
@@ -17403,73 +21019,73 @@
           <parameter type="gpointer" name="user_data" />
         </parameters>
       </method>
-      <method name="SetFromFile" cname="gtk_status_icon_set_from_file">
+      <method name="SetFromFile" cname="gtk_status_icon_set_from_file" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="const-gchar*" name="filename" />
         </parameters>
       </method>
-      <method name="SetFromGicon" cname="gtk_status_icon_set_from_gicon">
+      <method name="SetFromGicon" cname="gtk_status_icon_set_from_gicon" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="GIcon*" name="icon" />
         </parameters>
       </method>
-      <method name="SetFromIconName" cname="gtk_status_icon_set_from_icon_name">
+      <method name="SetFromIconName" cname="gtk_status_icon_set_from_icon_name" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="const-gchar*" name="icon_name" />
         </parameters>
       </method>
-      <method name="SetFromPixbuf" cname="gtk_status_icon_set_from_pixbuf">
+      <method name="SetFromPixbuf" cname="gtk_status_icon_set_from_pixbuf" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="GdkPixbuf*" name="pixbuf" />
         </parameters>
       </method>
-      <method name="SetFromStock" cname="gtk_status_icon_set_from_stock">
+      <method name="SetFromStock" cname="gtk_status_icon_set_from_stock" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="const-gchar*" name="stock_id" />
         </parameters>
       </method>
-      <method name="SetHasTooltip" cname="gtk_status_icon_set_has_tooltip">
+      <method name="SetHasTooltip" cname="gtk_status_icon_set_has_tooltip" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="gboolean" name="has_tooltip" />
         </parameters>
       </method>
-      <method name="SetName" cname="gtk_status_icon_set_name">
+      <method name="SetName" cname="gtk_status_icon_set_name" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="const-gchar*" name="name" />
         </parameters>
       </method>
-      <method name="SetScreen" cname="gtk_status_icon_set_screen">
+      <method name="SetScreen" cname="gtk_status_icon_set_screen" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="GdkScreen*" name="screen" />
         </parameters>
       </method>
-      <method name="SetTitle" cname="gtk_status_icon_set_title">
+      <method name="SetTitle" cname="gtk_status_icon_set_title" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="const-gchar*" name="title" />
         </parameters>
       </method>
-      <method name="SetTooltipMarkup" cname="gtk_status_icon_set_tooltip_markup">
+      <method name="SetTooltipMarkup" cname="gtk_status_icon_set_tooltip_markup" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="const-gchar*" name="markup" />
         </parameters>
       </method>
-      <method name="SetTooltipText" cname="gtk_status_icon_set_tooltip_text">
+      <method name="SetTooltipText" cname="gtk_status_icon_set_tooltip_text" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="const-gchar*" name="text" />
         </parameters>
       </method>
-      <method name="SetVisible" cname="gtk_status_icon_set_visible">
+      <method name="SetVisible" cname="gtk_status_icon_set_visible" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="gboolean" name="visible" />
@@ -17949,7 +21565,7 @@
           <parameter type="va_list" name="var_args" />
         </parameters>
       </method>
-      <method name="HasContext" cname="gtk_style_has_context">
+      <method name="HasContext" cname="gtk_style_has_context" deprecated="1">
         <return-type type="gboolean" />
       </method>
       <method name="LookupColor" cname="gtk_style_lookup_color" deprecated="1">
@@ -17994,13 +21610,15 @@
         <method vm="_gtk_reserved3" />
         <method vm="_gtk_reserved4" />
       </class_struct>
-      <field name="Priv" cname="priv" type="gpointer" />
+      <field name="Priv" cname="priv" type="GtkStyleContextPrivate*" />
       <signal name="Changed" cname="changed" when="FIRST" field_name="changed">
         <return-type type="void" />
         <parameters />
       </signal>
       <property name="Screen" cname="screen" type="GdkScreen" readable="true" writeable="true" />
+      <property name="PaintClock" cname="paint-clock" type="GdkFrameClock" readable="true" writeable="true" />
       <property name="Direction" cname="direction" type="GtkTextDirection" readable="true" writeable="true" />
+      <property name="Parent" cname="parent" type="GtkStyleContext" readable="true" writeable="true" />
       <virtual_method name="GtkReserved1" cname="_gtk_reserved1" shared="true" padding="true">
         <return-type type="void" />
       </virtual_method>
@@ -18034,14 +21652,14 @@
           <parameter type="guint" name="priority" />
         </parameters>
       </method>
-      <method name="AddRegion" cname="gtk_style_context_add_region">
+      <method name="AddRegion" cname="gtk_style_context_add_region" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="const-gchar*" name="region_name" />
           <parameter type="GtkRegionFlags" name="flags" />
         </parameters>
       </method>
-      <method name="CancelAnimations" cname="gtk_style_context_cancel_animations">
+      <method name="CancelAnimations" cname="gtk_style_context_cancel_animations" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="gpointer" name="region_id" />
@@ -18082,14 +21700,17 @@
           <parameter type="GdkRGBA*" name="color" />
         </parameters>
       </method>
-      <method name="GetDirection" cname="gtk_style_context_get_direction">
+      <method name="GetDirection" cname="gtk_style_context_get_direction" deprecated="1">
         <return-type type="GtkTextDirection" />
       </method>
-      <method name="GetFont" cname="gtk_style_context_get_font">
+      <method name="GetFont" cname="gtk_style_context_get_font" deprecated="1">
         <return-type type="const-PangoFontDescription*" />
         <parameters>
           <parameter type="GtkStateFlags" name="state" />
         </parameters>
+      </method>
+      <method name="GetFrameClock" cname="gtk_style_context_get_frame_clock">
+        <return-type type="GdkFrameClock*" />
       </method>
       <method name="GetJunctionSides" cname="gtk_style_context_get_junction_sides">
         <return-type type="GtkJunctionSides" />
@@ -18108,6 +21729,9 @@
           <parameter type="GtkBorder*" name="padding" />
         </parameters>
       </method>
+      <method name="GetParent" cname="gtk_style_context_get_parent">
+        <return-type type="GtkStyleContext*" />
+      </method>
       <method name="GetPath" cname="gtk_style_context_get_path">
         <return-type type="const-GtkWidgetPath*" />
       </method>
@@ -18119,8 +21743,17 @@
           <parameter type="GValue*" name="value" />
         </parameters>
       </method>
+      <method name="GetScale" cname="gtk_style_context_get_scale">
+        <return-type type="gint" />
+      </method>
       <method name="GetScreen" cname="gtk_style_context_get_screen">
         <return-type type="GdkScreen*" />
+      </method>
+      <method name="GetSection" cname="gtk_style_context_get_section">
+        <return-type type="GtkCssSection*" />
+        <parameters>
+          <parameter type="const-gchar*" name="property" />
+        </parameters>
       </method>
       <method name="GetState" cname="gtk_style_context_get_state">
         <return-type type="GtkStateFlags" />
@@ -18160,20 +21793,20 @@
           <parameter type="const-gchar*" name="class_name" />
         </parameters>
       </method>
-      <method name="HasRegion" cname="gtk_style_context_has_region">
+      <method name="HasRegion" cname="gtk_style_context_has_region" deprecated="1">
         <return-type type="gboolean" />
         <parameters>
           <parameter type="const-gchar*" name="region_name" />
           <parameter type="GtkRegionFlags*" name="flags_return" />
         </parameters>
       </method>
-      <method name="Invalidate" cname="gtk_style_context_invalidate">
+      <method name="Invalidate" cname="gtk_style_context_invalidate" deprecated="1">
         <return-type type="void" />
       </method>
       <method name="ListClasses" cname="gtk_style_context_list_classes">
         <return-type type="GList*" />
       </method>
-      <method name="ListRegions" cname="gtk_style_context_list_regions">
+      <method name="ListRegions" cname="gtk_style_context_list_regions" deprecated="1">
         <return-type type="GList*" />
       </method>
       <method name="LookupColor" cname="gtk_style_context_lookup_color">
@@ -18183,14 +21816,14 @@
           <parameter type="GdkRGBA*" name="color" />
         </parameters>
       </method>
-      <method name="LookupIconSet" cname="gtk_style_context_lookup_icon_set">
+      <method name="LookupIconSet" cname="gtk_style_context_lookup_icon_set" deprecated="1">
         <return-type type="GtkIconSet*" />
         <parameters>
           <parameter type="const-gchar*" name="stock_id" />
         </parameters>
       </method>
       <constructor cname="gtk_style_context_new" />
-      <method name="NotifyStateChange" cname="gtk_style_context_notify_state_change">
+      <method name="NotifyStateChange" cname="gtk_style_context_notify_state_change" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="GdkWindow*" name="window" />
@@ -18199,10 +21832,10 @@
           <parameter type="gboolean" name="state_value" />
         </parameters>
       </method>
-      <method name="PopAnimatableRegion" cname="gtk_style_context_pop_animatable_region">
+      <method name="PopAnimatableRegion" cname="gtk_style_context_pop_animatable_region" deprecated="1">
         <return-type type="void" />
       </method>
-      <method name="PushAnimatableRegion" cname="gtk_style_context_push_animatable_region">
+      <method name="PushAnimatableRegion" cname="gtk_style_context_push_animatable_region" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="gpointer" name="region_id" />
@@ -18227,7 +21860,7 @@
           <parameter type="GtkStyleProvider*" name="provider" />
         </parameters>
       </method>
-      <method name="RemoveRegion" cname="gtk_style_context_remove_region">
+      <method name="RemoveRegion" cname="gtk_style_context_remove_region" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="const-gchar*" name="region_name" />
@@ -18245,7 +21878,7 @@
       <method name="Save" cname="gtk_style_context_save">
         <return-type type="void" />
       </method>
-      <method name="ScrollAnimations" cname="gtk_style_context_scroll_animations">
+      <method name="ScrollAnimations" cname="gtk_style_context_scroll_animations" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="GdkWindow*" name="window" />
@@ -18259,10 +21892,16 @@
           <parameter type="GdkWindow*" name="window" />
         </parameters>
       </method>
-      <method name="SetDirection" cname="gtk_style_context_set_direction">
+      <method name="SetDirection" cname="gtk_style_context_set_direction" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="GtkTextDirection" name="direction" />
+        </parameters>
+      </method>
+      <method name="SetFrameClock" cname="gtk_style_context_set_frame_clock">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GdkFrameClock*" name="frame_clock" />
         </parameters>
       </method>
       <method name="SetJunctionSides" cname="gtk_style_context_set_junction_sides">
@@ -18271,10 +21910,22 @@
           <parameter type="GtkJunctionSides" name="sides" />
         </parameters>
       </method>
+      <method name="SetParent" cname="gtk_style_context_set_parent">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkStyleContext*" name="parent" />
+        </parameters>
+      </method>
       <method name="SetPath" cname="gtk_style_context_set_path">
         <return-type type="void" />
         <parameters>
           <parameter type="GtkWidgetPath*" name="path" />
+        </parameters>
+      </method>
+      <method name="SetScale" cname="gtk_style_context_set_scale">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gint" name="scale" />
         </parameters>
       </method>
       <method name="SetScreen" cname="gtk_style_context_set_screen">
@@ -18289,7 +21940,7 @@
           <parameter type="GtkStateFlags" name="flags" />
         </parameters>
       </method>
-      <method name="StateIsRunning" cname="gtk_style_context_state_is_running">
+      <method name="StateIsRunning" cname="gtk_style_context_state_is_running" deprecated="1">
         <return-type type="gboolean" />
         <parameters>
           <parameter type="GtkStateType" name="state" />
@@ -18305,7 +21956,7 @@
         <method vm="_gtk_reserved3" />
         <method vm="_gtk_reserved4" />
       </class_struct>
-      <field name="Priv" cname="priv" type="gpointer" />
+      <field name="Priv" cname="priv" type="GtkStylePropertiesPrivate*" />
       <virtual_method name="GtkReserved1" cname="_gtk_reserved1" shared="true" padding="true">
         <return-type type="void" />
       </virtual_method>
@@ -18320,6 +21971,7 @@
       </virtual_method>
       <implements>
         <interface cname="GtkStyleProvider" />
+        <interface cname="GtkStyleProviderPrivate" />
       </implements>
       <method name="Clear" cname="gtk_style_properties_clear">
         <return-type type="void" />
@@ -18349,13 +22001,13 @@
           <parameter type="va_list" name="args" />
         </parameters>
       </method>
-      <method name="LookupColor" cname="gtk_style_properties_lookup_color">
+      <method name="LookupColor" cname="gtk_style_properties_lookup_color" deprecated="1">
         <return-type type="GtkSymbolicColor*" />
         <parameters>
           <parameter type="const-gchar*" name="name" />
         </parameters>
       </method>
-      <method name="LookupProperty" cname="gtk_style_properties_lookup_property" shared="true">
+      <method name="LookupProperty" cname="gtk_style_properties_lookup_property" deprecated="1" shared="true">
         <return-type type="gboolean" />
         <parameters>
           <parameter type="const-gchar*" name="property_name" />
@@ -18363,7 +22015,7 @@
           <parameter type="GParamSpec**" name="pspec" />
         </parameters>
       </method>
-      <method name="MapColor" cname="gtk_style_properties_map_color">
+      <method name="MapColor" cname="gtk_style_properties_map_color" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="const-gchar*" name="name" />
@@ -18378,7 +22030,7 @@
         </parameters>
       </method>
       <constructor cname="gtk_style_properties_new" />
-      <method name="RegisterProperty" cname="gtk_style_properties_register_property" shared="true">
+      <method name="RegisterProperty" cname="gtk_style_properties_register_property" deprecated="1" shared="true">
         <return-type type="void" />
         <parameters>
           <parameter type="GtkStylePropertyParser" name="parse_func" />
@@ -18418,16 +22070,26 @@
     <object name="Switch" cname="GtkSwitch" parent="GtkWidget">
       <class_struct cname="GtkSwitchClass">
         <field name="ParentClass" cname="parent_class" type="GtkWidgetClass" />
+        <method signal_vm="activate" />
+        <method signal_vm="state_set" />
         <method vm="_switch_padding_1" />
         <method vm="_switch_padding_2" />
         <method vm="_switch_padding_3" />
         <method vm="_switch_padding_4" />
         <method vm="_switch_padding_5" />
-        <method vm="_switch_padding_6" />
-        <method vm="_switch_padding_7" />
       </class_struct>
       <field name="Priv" cname="priv" type="GtkSwitchPrivate*" />
-      <property name="Active" cname="active" type="gboolean" readable="true" writeable="true" />
+      <property name="State" cname="state" type="gboolean" readable="true" writeable="true" />
+      <signal name="Activate" cname="activate" when="FIRST" field_name="activate">
+        <return-type type="void" />
+        <parameters />
+      </signal>
+      <signal name="StateSet" cname="state-set" when="LAST" field_name="state_set">
+        <return-type type="gboolean" />
+        <parameters>
+          <parameter type="gboolean" name="state" />
+        </parameters>
+      </signal>
       <virtual_method name="SwitchPadding1" cname="_switch_padding_1" shared="true" padding="true">
         <return-type type="void" />
       </virtual_method>
@@ -18443,16 +22105,14 @@
       <virtual_method name="SwitchPadding5" cname="_switch_padding_5" shared="true" padding="true">
         <return-type type="void" />
       </virtual_method>
-      <virtual_method name="SwitchPadding6" cname="_switch_padding_6" shared="true" padding="true">
-        <return-type type="void" />
-      </virtual_method>
-      <virtual_method name="SwitchPadding7" cname="_switch_padding_7" shared="true" padding="true">
-        <return-type type="void" />
-      </virtual_method>
       <implements>
+        <interface cname="GtkActionable" />
         <interface cname="GtkActivatable" />
       </implements>
       <method name="GetActive" cname="gtk_switch_get_active">
+        <return-type type="gboolean" />
+      </method>
+      <method name="GetState" cname="gtk_switch_get_state">
         <return-type type="gboolean" />
       </method>
       <method name="GetType" cname="gtk_switch_get_type" shared="true">
@@ -18463,6 +22123,12 @@
         <return-type type="void" />
         <parameters>
           <parameter type="gboolean" name="is_active" />
+        </parameters>
+      </method>
+      <method name="SetState" cname="gtk_switch_set_state">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gboolean" name="state" />
         </parameters>
       </method>
     </object>
@@ -18500,7 +22166,7 @@
       <virtual_method name="GtkReserved4" cname="_gtk_reserved4" shared="true" padding="true">
         <return-type type="void" />
       </virtual_method>
-      <method name="Attach" cname="gtk_table_attach">
+      <method name="Attach" cname="gtk_table_attach" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="GtkWidget*" name="child" />
@@ -18514,7 +22180,7 @@
           <parameter type="guint" name="ypadding" />
         </parameters>
       </method>
-      <method name="AttachDefaults" cname="gtk_table_attach_defaults">
+      <method name="AttachDefaults" cname="gtk_table_attach_defaults" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="GtkWidget*" name="widget" />
@@ -18524,78 +22190,78 @@
           <parameter type="guint" name="bottom_attach" />
         </parameters>
       </method>
-      <method name="GetColSpacing" cname="gtk_table_get_col_spacing">
+      <method name="GetColSpacing" cname="gtk_table_get_col_spacing" deprecated="1">
         <return-type type="guint" />
         <parameters>
           <parameter type="guint" name="column" />
         </parameters>
       </method>
-      <method name="GetDefaultColSpacing" cname="gtk_table_get_default_col_spacing">
+      <method name="GetDefaultColSpacing" cname="gtk_table_get_default_col_spacing" deprecated="1">
         <return-type type="guint" />
       </method>
-      <method name="GetDefaultRowSpacing" cname="gtk_table_get_default_row_spacing">
+      <method name="GetDefaultRowSpacing" cname="gtk_table_get_default_row_spacing" deprecated="1">
         <return-type type="guint" />
       </method>
-      <method name="GetHomogeneous" cname="gtk_table_get_homogeneous">
+      <method name="GetHomogeneous" cname="gtk_table_get_homogeneous" deprecated="1">
         <return-type type="gboolean" />
       </method>
-      <method name="GetRowSpacing" cname="gtk_table_get_row_spacing">
+      <method name="GetRowSpacing" cname="gtk_table_get_row_spacing" deprecated="1">
         <return-type type="guint" />
         <parameters>
           <parameter type="guint" name="row" />
         </parameters>
       </method>
-      <method name="GetSize" cname="gtk_table_get_size">
+      <method name="GetSize" cname="gtk_table_get_size" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="guint*" name="rows" />
           <parameter type="guint*" name="columns" />
         </parameters>
       </method>
-      <method name="GetType" cname="gtk_table_get_type" shared="true">
+      <method name="GetType" cname="gtk_table_get_type" deprecated="1" shared="true">
         <return-type type="GType" />
       </method>
-      <constructor cname="gtk_table_new">
+      <constructor cname="gtk_table_new" deprecated="1">
         <parameters>
           <parameter type="guint" name="rows" />
           <parameter type="guint" name="columns" />
           <parameter type="gboolean" name="homogeneous" />
         </parameters>
       </constructor>
-      <method name="Resize" cname="gtk_table_resize">
+      <method name="Resize" cname="gtk_table_resize" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="guint" name="rows" />
           <parameter type="guint" name="columns" />
         </parameters>
       </method>
-      <method name="SetColSpacing" cname="gtk_table_set_col_spacing">
+      <method name="SetColSpacing" cname="gtk_table_set_col_spacing" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="guint" name="column" />
           <parameter type="guint" name="spacing" />
         </parameters>
       </method>
-      <method name="SetColSpacings" cname="gtk_table_set_col_spacings">
+      <method name="SetColSpacings" cname="gtk_table_set_col_spacings" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="guint" name="spacing" />
         </parameters>
       </method>
-      <method name="SetHomogeneous" cname="gtk_table_set_homogeneous">
+      <method name="SetHomogeneous" cname="gtk_table_set_homogeneous" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="gboolean" name="homogeneous" />
         </parameters>
       </method>
-      <method name="SetRowSpacing" cname="gtk_table_set_row_spacing">
+      <method name="SetRowSpacing" cname="gtk_table_set_row_spacing" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="guint" name="row" />
           <parameter type="guint" name="spacing" />
         </parameters>
       </method>
-      <method name="SetRowSpacings" cname="gtk_table_set_row_spacings">
+      <method name="SetRowSpacings" cname="gtk_table_set_row_spacings" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="guint" name="spacing" />
@@ -18623,10 +22289,10 @@
       <virtual_method name="GtkReserved4" cname="_gtk_reserved4" shared="true" padding="true">
         <return-type type="void" />
       </virtual_method>
-      <method name="GetType" cname="gtk_tearoff_menu_item_get_type" shared="true">
+      <method name="GetType" cname="gtk_tearoff_menu_item_get_type" deprecated="1" shared="true">
         <return-type type="GType" />
       </method>
-      <constructor cname="gtk_tearoff_menu_item_new" />
+      <constructor cname="gtk_tearoff_menu_item_new" deprecated="1" />
     </object>
     <object name="TextBuffer" cname="GtkTextBuffer" parent="GObject">
       <class_struct cname="GtkTextBufferClass">
@@ -19334,10 +23000,12 @@
       <field name="Priv" cname="priv" type="GtkTextTagPrivate*" />
       <property name="Name" cname="name" type="gchar*" readable="true" writeable="true" construct-only="true" />
       <property name="Background" cname="background" type="gchar*" writeable="true" />
-      <property name="BackgroundGdk" cname="background-gdk" type="GdkColor" readable="true" writeable="true" />
+      <property name="BackgroundGdk" cname="background-gdk" type="GTypeFromName(&quot;gdkcolor&quot;)" readable="true" writeable="true" />
+      <property name="BackgroundRgba" cname="background-rgba" type="GdkRgba" readable="true" writeable="true" />
       <property name="BackgroundFullHeight" cname="background-full-height" type="gboolean" readable="true" writeable="true" />
       <property name="Foreground" cname="foreground" type="gchar*" writeable="true" />
-      <property name="ForegroundGdk" cname="foreground-gdk" type="GdkColor" readable="true" writeable="true" />
+      <property name="ForegroundGdk" cname="foreground-gdk" type="GTypeFromName(&quot;gdkcolor&quot;)" readable="true" writeable="true" />
+      <property name="ForegroundRgba" cname="foreground-rgba" type="GdkRgba" readable="true" writeable="true" />
       <property name="Direction" cname="direction" type="GtkTextDirection" readable="true" writeable="true" />
       <property name="Editable" cname="editable" type="gboolean" readable="true" writeable="true" />
       <property name="Font" cname="font" type="gchar*" readable="true" writeable="true" />
@@ -19365,7 +23033,8 @@
       <property name="Tabs" cname="tabs" type="PangoTabArray" readable="true" writeable="true" />
       <property name="Invisible" cname="invisible" type="gboolean" readable="true" writeable="true" />
       <property name="ParagraphBackground" cname="paragraph-background" type="gchar*" writeable="true" />
-      <property name="ParagraphBackgroundGdk" cname="paragraph-background-gdk" type="GdkColor" readable="true" writeable="true" />
+      <property name="ParagraphBackgroundGdk" cname="paragraph-background-gdk" type="GTypeFromName(&quot;gdkcolor&quot;)" readable="true" writeable="true" />
+      <property name="ParagraphBackgroundRgba" cname="paragraph-background-rgba" type="GdkRgba" readable="true" writeable="true" />
       <property name="AccumulativeMargin" cname="accumulative-margin" type="gboolean" readable="true" writeable="true" />
       <signal name="Event" cname="event" when="LAST" field_name="event">
         <return-type type="gboolean" />
@@ -19460,7 +23129,7 @@
         <interface cname="GtkBuildable" />
       </implements>
       <method name="Add" cname="gtk_text_tag_table_add">
-        <return-type type="void" />
+        <return-type type="gboolean" />
         <parameters>
           <parameter type="GtkTextTag*" name="tag" />
         </parameters>
@@ -19505,14 +23174,14 @@
         <method signal_vm="copy_clipboard" />
         <method signal_vm="paste_clipboard" />
         <method signal_vm="toggle_overwrite" />
+        <method vm="create_buffer" />
+        <method vm="draw_layer" />
         <method vm="_gtk_reserved1" />
         <method vm="_gtk_reserved2" />
         <method vm="_gtk_reserved3" />
         <method vm="_gtk_reserved4" />
         <method vm="_gtk_reserved5" />
         <method vm="_gtk_reserved6" />
-        <method vm="_gtk_reserved7" />
-        <method vm="_gtk_reserved8" />
       </class_struct>
       <field name="Priv" cname="priv" type="GtkTextViewPrivate*" />
       <property name="PixelsAboveLines" cname="pixels-above-lines" type="gint" readable="true" writeable="true" />
@@ -19530,6 +23199,9 @@
       <property name="Overwrite" cname="overwrite" type="gboolean" readable="true" writeable="true" />
       <property name="AcceptsTab" cname="accepts-tab" type="gboolean" readable="true" writeable="true" />
       <property name="ImModule" cname="im-module" type="gchar*" readable="true" writeable="true" />
+      <property name="InputPurpose" cname="input-purpose" type="GtkInputPurpose" readable="true" writeable="true" />
+      <property name="InputHints" cname="input-hints" type="GtkInputHints" readable="true" writeable="true" />
+      <property name="PopulateAll" cname="populate-all" type="gboolean" readable="true" writeable="true" />
       <signal name="MoveCursor" cname="move-cursor" when="LAST" field_name="move_cursor">
         <return-type type="void" />
         <parameters>
@@ -19585,7 +23257,7 @@
       <signal name="PopulatePopup" cname="populate-popup" when="LAST" field_name="populate_popup">
         <return-type type="void" />
         <parameters>
-          <parameter type="GtkMenu*" name="menu" />
+          <parameter type="GtkWidget*" name="popup" />
         </parameters>
       </signal>
       <signal name="SelectAll" cname="select-all" when="LAST">
@@ -19604,6 +23276,17 @@
           <parameter name="p0" type="gchar*" />
         </parameters>
       </signal>
+      <virtual_method name="CreateBuffer" cname="create_buffer">
+        <return-type type="GtkTextBuffer*" />
+        <parameters />
+      </virtual_method>
+      <virtual_method name="DrawLayer" cname="draw_layer">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkTextViewLayer" name="layer" />
+          <parameter type="cairo_t*" name="cr" />
+        </parameters>
+      </virtual_method>
       <virtual_method name="GtkReserved1" cname="_gtk_reserved1" shared="true" padding="true">
         <return-type type="void" />
       </virtual_method>
@@ -19620,12 +23303,6 @@
         <return-type type="void" />
       </virtual_method>
       <virtual_method name="GtkReserved6" cname="_gtk_reserved6" shared="true" padding="true">
-        <return-type type="void" />
-      </virtual_method>
-      <virtual_method name="GtkReserved7" cname="_gtk_reserved7" shared="true" padding="true">
-        <return-type type="void" />
-      </virtual_method>
-      <virtual_method name="GtkReserved8" cname="_gtk_reserved8" shared="true" padding="true">
         <return-type type="void" />
       </virtual_method>
       <implements>
@@ -19715,6 +23392,12 @@
       </method>
       <method name="GetIndent" cname="gtk_text_view_get_indent">
         <return-type type="gint" />
+      </method>
+      <method name="GetInputHints" cname="gtk_text_view_get_input_hints">
+        <return-type type="GtkInputHints" />
+      </method>
+      <method name="GetInputPurpose" cname="gtk_text_view_get_input_purpose">
+        <return-type type="GtkInputPurpose" />
       </method>
       <method name="GetIterAtLocation" cname="gtk_text_view_get_iter_at_location">
         <return-type type="void" />
@@ -19909,6 +23592,18 @@
           <parameter type="gint" name="indent" />
         </parameters>
       </method>
+      <method name="SetInputHints" cname="gtk_text_view_set_input_hints">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkInputHints" name="hints" />
+        </parameters>
+      </method>
+      <method name="SetInputPurpose" cname="gtk_text_view_set_input_purpose">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkInputPurpose" name="purpose" />
+        </parameters>
+      </method>
       <method name="SetJustification" cname="gtk_text_view_set_justification">
         <return-type type="void" />
         <parameters>
@@ -19998,9 +23693,11 @@
         <method vm="render_handle" />
         <method vm="render_activity" />
         <method vm="render_icon_pixbuf" />
-        <field name="Padding" cname="padding" type="gpointer" array_len="16" />
+        <method vm="render_icon" />
+        <method vm="render_icon_surface" />
+        <field name="Padding" cname="padding" type="gpointer" array_len="14" />
       </class_struct>
-      <field name="Priv" cname="priv" type="gpointer" />
+      <field name="Priv" cname="priv" type="GtkThemingEnginePrivate*" />
       <property name="Name" cname="name" type="gchar*" readable="true" writeable="true" construct-only="true" />
       <virtual_method name="RenderLine" cname="render_line">
         <return-type type="void" />
@@ -20153,71 +23850,89 @@
           <parameter type="GtkIconSize" name="size" />
         </parameters>
       </virtual_method>
-      <method name="Get" cname="gtk_theming_engine_get">
+      <virtual_method name="RenderIcon" cname="render_icon">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="cairo_t*" name="cr" />
+          <parameter type="GdkPixbuf*" name="pixbuf" />
+          <parameter type="gdouble" name="x" />
+          <parameter type="gdouble" name="y" />
+        </parameters>
+      </virtual_method>
+      <virtual_method name="RenderIconSurface" cname="render_icon_surface">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="cairo_t*" name="cr" />
+          <parameter type="cairo_surface_t*" name="surface" />
+          <parameter type="gdouble" name="x" />
+          <parameter type="gdouble" name="y" />
+        </parameters>
+      </virtual_method>
+      <method name="Get" cname="gtk_theming_engine_get" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="GtkStateFlags" name="state" />
           <parameter ellipsis="true" />
         </parameters>
       </method>
-      <method name="GetBackgroundColor" cname="gtk_theming_engine_get_background_color">
+      <method name="GetBackgroundColor" cname="gtk_theming_engine_get_background_color" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="GtkStateFlags" name="state" />
           <parameter type="GdkRGBA*" name="color" />
         </parameters>
       </method>
-      <method name="GetBorder" cname="gtk_theming_engine_get_border">
+      <method name="GetBorder" cname="gtk_theming_engine_get_border" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="GtkStateFlags" name="state" />
           <parameter type="GtkBorder*" name="border" />
         </parameters>
       </method>
-      <method name="GetBorderColor" cname="gtk_theming_engine_get_border_color">
+      <method name="GetBorderColor" cname="gtk_theming_engine_get_border_color" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="GtkStateFlags" name="state" />
           <parameter type="GdkRGBA*" name="color" />
         </parameters>
       </method>
-      <method name="GetColor" cname="gtk_theming_engine_get_color">
+      <method name="GetColor" cname="gtk_theming_engine_get_color" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="GtkStateFlags" name="state" />
           <parameter type="GdkRGBA*" name="color" />
         </parameters>
       </method>
-      <method name="GetDirection" cname="gtk_theming_engine_get_direction">
+      <method name="GetDirection" cname="gtk_theming_engine_get_direction" deprecated="1">
         <return-type type="GtkTextDirection" />
       </method>
-      <method name="GetFont" cname="gtk_theming_engine_get_font">
+      <method name="GetFont" cname="gtk_theming_engine_get_font" deprecated="1">
         <return-type type="const-PangoFontDescription*" />
         <parameters>
           <parameter type="GtkStateFlags" name="state" />
         </parameters>
       </method>
-      <method name="GetJunctionSides" cname="gtk_theming_engine_get_junction_sides">
+      <method name="GetJunctionSides" cname="gtk_theming_engine_get_junction_sides" deprecated="1">
         <return-type type="GtkJunctionSides" />
       </method>
-      <method name="GetMargin" cname="gtk_theming_engine_get_margin">
+      <method name="GetMargin" cname="gtk_theming_engine_get_margin" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="GtkStateFlags" name="state" />
           <parameter type="GtkBorder*" name="margin" />
         </parameters>
       </method>
-      <method name="GetPadding" cname="gtk_theming_engine_get_padding">
+      <method name="GetPadding" cname="gtk_theming_engine_get_padding" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="GtkStateFlags" name="state" />
           <parameter type="GtkBorder*" name="padding" />
         </parameters>
       </method>
-      <method name="GetPath" cname="gtk_theming_engine_get_path">
+      <method name="GetPath" cname="gtk_theming_engine_get_path" deprecated="1">
         <return-type type="const-GtkWidgetPath*" />
       </method>
-      <method name="GetProperty" cname="gtk_theming_engine_get_property">
+      <method name="GetProperty" cname="gtk_theming_engine_get_property" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="const-gchar*" name="property" />
@@ -20225,68 +23940,68 @@
           <parameter type="GValue*" name="value" />
         </parameters>
       </method>
-      <method name="GetScreen" cname="gtk_theming_engine_get_screen">
+      <method name="GetScreen" cname="gtk_theming_engine_get_screen" deprecated="1">
         <return-type type="GdkScreen*" />
       </method>
-      <method name="GetState" cname="gtk_theming_engine_get_state">
+      <method name="GetState" cname="gtk_theming_engine_get_state" deprecated="1">
         <return-type type="GtkStateFlags" />
       </method>
-      <method name="GetStyle" cname="gtk_theming_engine_get_style">
+      <method name="GetStyle" cname="gtk_theming_engine_get_style" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter ellipsis="true" />
         </parameters>
       </method>
-      <method name="GetStyleProperty" cname="gtk_theming_engine_get_style_property">
+      <method name="GetStyleProperty" cname="gtk_theming_engine_get_style_property" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="const-gchar*" name="property_name" />
           <parameter type="GValue*" name="value" />
         </parameters>
       </method>
-      <method name="GetStyleValist" cname="gtk_theming_engine_get_style_valist">
+      <method name="GetStyleValist" cname="gtk_theming_engine_get_style_valist" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="va_list" name="args" />
         </parameters>
       </method>
-      <method name="GetType" cname="gtk_theming_engine_get_type" shared="true">
+      <method name="GetType" cname="gtk_theming_engine_get_type" deprecated="1" shared="true">
         <return-type type="GType" />
       </method>
-      <method name="GetValist" cname="gtk_theming_engine_get_valist">
+      <method name="GetValist" cname="gtk_theming_engine_get_valist" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="GtkStateFlags" name="state" />
           <parameter type="va_list" name="args" />
         </parameters>
       </method>
-      <method name="HasClass" cname="gtk_theming_engine_has_class">
+      <method name="HasClass" cname="gtk_theming_engine_has_class" deprecated="1">
         <return-type type="gboolean" />
         <parameters>
           <parameter type="const-gchar*" name="style_class" />
         </parameters>
       </method>
-      <method name="HasRegion" cname="gtk_theming_engine_has_region">
+      <method name="HasRegion" cname="gtk_theming_engine_has_region" deprecated="1">
         <return-type type="gboolean" />
         <parameters>
           <parameter type="const-gchar*" name="style_region" />
           <parameter type="GtkRegionFlags*" name="flags" />
         </parameters>
       </method>
-      <method name="Load" cname="gtk_theming_engine_load" shared="true">
+      <method name="Load" cname="gtk_theming_engine_load" deprecated="1" shared="true">
         <return-type type="GtkThemingEngine*" />
         <parameters>
           <parameter type="const-gchar*" name="name" />
         </parameters>
       </method>
-      <method name="LookupColor" cname="gtk_theming_engine_lookup_color">
+      <method name="LookupColor" cname="gtk_theming_engine_lookup_color" deprecated="1">
         <return-type type="gboolean" />
         <parameters>
           <parameter type="const-gchar*" name="color_name" />
           <parameter type="GdkRGBA*" name="color" />
         </parameters>
       </method>
-      <method name="RegisterProperty" cname="gtk_theming_engine_register_property" shared="true">
+      <method name="RegisterProperty" cname="gtk_theming_engine_register_property" deprecated="1" shared="true">
         <return-type type="void" />
         <parameters>
           <parameter type="const-gchar*" name="name_space" />
@@ -20294,61 +24009,13 @@
           <parameter type="GParamSpec*" name="pspec" />
         </parameters>
       </method>
-      <method name="StateIsRunning" cname="gtk_theming_engine_state_is_running">
+      <method name="StateIsRunning" cname="gtk_theming_engine_state_is_running" deprecated="1">
         <return-type type="gboolean" />
         <parameters>
           <parameter type="GtkStateType" name="state" />
           <parameter type="gdouble*" name="progress" />
         </parameters>
       </method>
-    </object>
-    <object name="Timeline" cname="GtkTimeline" parent="GObject">
-      <class_struct cname="GtkTimelineClass">
-        <field name="ParentClass" cname="parent_class" type="GObjectClass" />
-        <method signal_vm="started" />
-        <method signal_vm="finished" />
-        <method signal_vm="paused" />
-        <method signal_vm="frame" />
-        <method vm="__gtk_reserved1" />
-        <method vm="__gtk_reserved2" />
-        <method vm="__gtk_reserved3" />
-        <method vm="__gtk_reserved4" />
-      </class_struct>
-      <field name="Priv" cname="priv" type="gpointer" />
-      <property name="Fps" cname="fps" type="guint" readable="true" writeable="true" />
-      <property name="Duration" cname="duration" type="guint" readable="true" writeable="true" />
-      <property name="Loop" cname="loop" type="gboolean" readable="true" writeable="true" />
-      <property name="Screen" cname="screen" type="GdkScreen" readable="true" writeable="true" />
-      <signal name="Started" cname="started" when="LAST" field_name="started">
-        <return-type type="void" />
-        <parameters />
-      </signal>
-      <signal name="Paused" cname="paused" when="LAST" field_name="paused">
-        <return-type type="void" />
-        <parameters />
-      </signal>
-      <signal name="Finished" cname="finished" when="LAST" field_name="finished">
-        <return-type type="void" />
-        <parameters />
-      </signal>
-      <signal name="Frame" cname="frame" when="LAST" field_name="frame">
-        <return-type type="void" />
-        <parameters>
-          <parameter type="gdouble" name="progress" />
-        </parameters>
-      </signal>
-      <virtual_method name="_GtkReserved1" cname="__gtk_reserved1" shared="true" padding="true">
-        <return-type type="void" />
-      </virtual_method>
-      <virtual_method name="_GtkReserved2" cname="__gtk_reserved2" shared="true" padding="true">
-        <return-type type="void" />
-      </virtual_method>
-      <virtual_method name="_GtkReserved3" cname="__gtk_reserved3" shared="true" padding="true">
-        <return-type type="void" />
-      </virtual_method>
-      <virtual_method name="_GtkReserved4" cname="__gtk_reserved4" shared="true" padding="true">
-        <return-type type="void" />
-      </virtual_method>
     </object>
     <object name="ToggleAction" cname="GtkToggleAction" parent="GtkAction">
       <class_struct cname="GtkToggleActionClass">
@@ -20378,16 +24045,16 @@
       <virtual_method name="GtkReserved4" cname="_gtk_reserved4" shared="true" padding="true">
         <return-type type="void" />
       </virtual_method>
-      <method name="GetActive" cname="gtk_toggle_action_get_active">
+      <method name="GetActive" cname="gtk_toggle_action_get_active" deprecated="1">
         <return-type type="gboolean" />
       </method>
-      <method name="GetDrawAsRadio" cname="gtk_toggle_action_get_draw_as_radio">
+      <method name="GetDrawAsRadio" cname="gtk_toggle_action_get_draw_as_radio" deprecated="1">
         <return-type type="gboolean" />
       </method>
-      <method name="GetType" cname="gtk_toggle_action_get_type" shared="true">
+      <method name="GetType" cname="gtk_toggle_action_get_type" deprecated="1" shared="true">
         <return-type type="GType" />
       </method>
-      <constructor cname="gtk_toggle_action_new">
+      <constructor cname="gtk_toggle_action_new" deprecated="1">
         <parameters>
           <parameter type="const-gchar*" name="name" />
           <parameter type="const-gchar*" name="label" />
@@ -20395,19 +24062,19 @@
           <parameter type="const-gchar*" name="stock_id" />
         </parameters>
       </constructor>
-      <method name="SetActive" cname="gtk_toggle_action_set_active">
+      <method name="SetActive" cname="gtk_toggle_action_set_active" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="gboolean" name="is_active" />
         </parameters>
       </method>
-      <method name="SetDrawAsRadio" cname="gtk_toggle_action_set_draw_as_radio">
+      <method name="SetDrawAsRadio" cname="gtk_toggle_action_set_draw_as_radio" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="gboolean" name="draw_as_radio" />
         </parameters>
       </method>
-      <method name="Toggled" cname="gtk_toggle_action_toggled">
+      <method name="Toggled" cname="gtk_toggle_action_toggled" deprecated="1">
         <return-type type="void" />
       </method>
     </object>
@@ -20525,7 +24192,7 @@
         <return-type type="GType" />
       </method>
       <constructor cname="gtk_toggle_tool_button_new" />
-      <constructor cname="gtk_toggle_tool_button_new_from_stock">
+      <constructor cname="gtk_toggle_tool_button_new_from_stock" deprecated="1">
         <parameters>
           <parameter type="const-gchar*" name="stock_id" />
         </parameters>
@@ -20577,7 +24244,7 @@
       </signal>
       <property name="ToolbarStyle" cname="toolbar-style" type="GtkToolbarStyle" readable="true" writeable="true" />
       <property name="ShowArrow" cname="show-arrow" type="gboolean" readable="true" writeable="true" />
-      <property name="IconSize" cname="icon-size" type="gint" readable="true" writeable="true" />
+      <property name="IconSize" cname="icon-size" type="GtkIconSize" readable="true" writeable="true" />
       <property name="IconSizeSet" cname="icon-size-set" type="gboolean" readable="true" writeable="true" />
       <childprop name="Expand" cname="expand" type="gboolean" readable="true" writeable="true" />
       <childprop name="Homogeneous" cname="homogeneous" type="gboolean" readable="true" writeable="true" />
@@ -20707,7 +24374,7 @@
           <parameter type="GtkIconSize" name="size" />
         </parameters>
       </method>
-      <method name="SetIconFromStock" cname="gtk_tooltip_set_icon_from_stock">
+      <method name="SetIconFromStock" cname="gtk_tooltip_set_icon_from_stock" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="const-gchar*" name="stock_id" />
@@ -20773,6 +24440,7 @@
         <return-type type="void" />
       </virtual_method>
       <implements>
+        <interface cname="GtkActionable" />
         <interface cname="GtkActivatable" />
       </implements>
       <method name="GetIconName" cname="gtk_tool_button_get_icon_name">
@@ -20787,7 +24455,7 @@
       <method name="GetLabelWidget" cname="gtk_tool_button_get_label_widget">
         <return-type type="GtkWidget*" />
       </method>
-      <method name="GetStockId" cname="gtk_tool_button_get_stock_id">
+      <method name="GetStockId" cname="gtk_tool_button_get_stock_id" deprecated="1">
         <return-type type="const-gchar*" />
       </method>
       <method name="GetType" cname="gtk_tool_button_get_type" shared="true">
@@ -20802,7 +24470,7 @@
           <parameter type="const-gchar*" name="label" />
         </parameters>
       </constructor>
-      <constructor cname="gtk_tool_button_new_from_stock">
+      <constructor cname="gtk_tool_button_new_from_stock" deprecated="1">
         <parameters>
           <parameter type="const-gchar*" name="stock_id" />
         </parameters>
@@ -20831,7 +24499,7 @@
           <parameter type="GtkWidget*" name="label_widget" />
         </parameters>
       </method>
-      <method name="SetStockId" cname="gtk_tool_button_set_stock_id">
+      <method name="SetStockId" cname="gtk_tool_button_set_stock_id" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="const-gchar*" name="stock_id" />
@@ -21267,6 +24935,16 @@
         <return-type type="void" />
       </method>
     </object>
+    <object name="TrashMonitor" cname="GtkTrashMonitor" parent="GObject">
+      <class_struct cname="GtkTrashMonitorClass">
+        <field name="ParentClass" cname="parent_class" type="GObjectClass" />
+        <method signal_vm="trash_state_changed" />
+      </class_struct>
+      <signal name="TrashStateChanged" cname="trash-state-changed" when="FIRST" field_name="trash_state_changed">
+        <return-type type="void" />
+        <parameters />
+      </signal>
+    </object>
     <object name="TrayIcon" cname="GtkTrayIcon" parent="GtkPlug">
       <class_struct cname="GtkTrayIconClass">
         <field name="ParentClass" cname="parent_class" type="GtkPlugClass" />
@@ -21277,11 +24955,12 @@
       </class_struct>
       <field name="Priv" cname="priv" type="GtkTrayIconPrivate*" />
       <property name="Orientation" cname="orientation" type="GtkOrientation" readable="true" />
-      <property name="FgColor" cname="fg-color" type="GdkColor" readable="true" />
-      <property name="ErrorColor" cname="error-color" type="GdkColor" readable="true" />
-      <property name="WarningColor" cname="warning-color" type="GdkColor" readable="true" />
-      <property name="SuccessColor" cname="success-color" type="GdkColor" readable="true" />
+      <property name="FgColor" cname="fg-color" type="GdkRgba" readable="true" />
+      <property name="ErrorColor" cname="error-color" type="GdkRgba" readable="true" />
+      <property name="WarningColor" cname="warning-color" type="GdkRgba" readable="true" />
+      <property name="SuccessColor" cname="success-color" type="GdkRgba" readable="true" />
       <property name="Padding" cname="padding" type="gint" readable="true" />
+      <property name="IconSize" cname="icon-size" type="gint" readable="true" />
       <virtual_method name="GtkReserved1" cname="_gtk_reserved1" shared="true" padding="true">
         <return-type type="void" />
       </virtual_method>
@@ -21545,6 +25224,7 @@
         <method vm="_gtk_reserved4" />
       </class_struct>
       <field name="Priv" cname="priv" type="GtkTreeSelectionPrivate*" />
+      <property name="Mode" cname="mode" type="GtkSelectionMode" readable="true" writeable="true" />
       <signal name="Changed" cname="changed" when="FIRST" field_name="changed">
         <return-type type="void" />
         <parameters />
@@ -21911,6 +25591,7 @@
       <property name="EnableGridLines" cname="enable-grid-lines" type="GtkTreeViewGridLines" readable="true" writeable="true" />
       <property name="EnableTreeLines" cname="enable-tree-lines" type="gboolean" readable="true" writeable="true" />
       <property name="TooltipColumn" cname="tooltip-column" type="gint" readable="true" writeable="true" />
+      <property name="ActivateOnSingleClick" cname="activate-on-single-click" type="gboolean" readable="true" writeable="true" />
       <signal name="RowActivated" cname="row-activated" when="LAST" field_name="row_activated">
         <return-type type="void" />
         <parameters>
@@ -22134,6 +25815,9 @@
           <parameter type="GtkTreePath*" name="path" />
         </parameters>
       </method>
+      <method name="GetActivateOnSingleClick" cname="gtk_tree_view_get_activate_on_single_click">
+        <return-type type="gboolean" />
+      </method>
       <method name="GetBackgroundArea" cname="gtk_tree_view_get_background_area">
         <return-type type="void" />
         <parameters>
@@ -22221,6 +25905,9 @@
       <method name="GetModel" cname="gtk_tree_view_get_model">
         <return-type type="GtkTreeModel*" />
       </method>
+      <method name="GetNColumns" cname="gtk_tree_view_get_n_columns">
+        <return-type type="guint" />
+      </method>
       <method name="GetPathAtPos" cname="gtk_tree_view_get_path_at_pos">
         <return-type type="gboolean" />
         <parameters>
@@ -22241,7 +25928,7 @@
       <method name="GetRubberBanding" cname="gtk_tree_view_get_rubber_banding">
         <return-type type="gboolean" />
       </method>
-      <method name="GetRulesHint" cname="gtk_tree_view_get_rules_hint">
+      <method name="GetRulesHint" cname="gtk_tree_view_get_rules_hint" deprecated="1">
         <return-type type="gboolean" />
       </method>
       <method name="GetSearchColumn" cname="gtk_tree_view_get_search_column">
@@ -22392,6 +26079,12 @@
           <parameter type="gint" name="tree_y" />
         </parameters>
       </method>
+      <method name="SetActivateOnSingleClick" cname="gtk_tree_view_set_activate_on_single_click">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gboolean" name="single" />
+        </parameters>
+      </method>
       <method name="SetColumnDragFunction" cname="gtk_tree_view_set_column_drag_function">
         <return-type type="void" />
         <parameters>
@@ -22417,7 +26110,7 @@
           <parameter type="gboolean" name="start_editing" />
         </parameters>
       </method>
-      <method name="SetDestroyCountFunc" cname="gtk_tree_view_set_destroy_count_func">
+      <method name="SetDestroyCountFunc" cname="gtk_tree_view_set_destroy_count_func" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="GtkTreeDestroyCountFunc" name="func" />
@@ -22524,7 +26217,7 @@
           <parameter type="gboolean" name="enable" />
         </parameters>
       </method>
-      <method name="SetRulesHint" cname="gtk_tree_view_set_rules_hint">
+      <method name="SetRulesHint" cname="gtk_tree_view_set_rules_hint" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="gboolean" name="setting" />
@@ -22615,6 +26308,7 @@
       </signal>
       <property name="Visible" cname="visible" type="gboolean" readable="true" writeable="true" />
       <property name="Resizable" cname="resizable" type="gboolean" readable="true" writeable="true" />
+      <property name="XOffset" cname="x-offset" type="gint" readable="true" />
       <property name="Width" cname="width" type="gint" readable="true" />
       <property name="Spacing" cname="spacing" type="gint" readable="true" writeable="true" />
       <property name="Sizing" cname="sizing" type="GtkTreeViewColumnSizing" readable="true" writeable="true" />
@@ -22761,6 +26455,9 @@
         <return-type type="GtkWidget*" />
       </method>
       <method name="GetWidth" cname="gtk_tree_view_column_get_width">
+        <return-type type="gint" />
+      </method>
+      <method name="GetXOffset" cname="gtk_tree_view_column_get_x_offset">
         <return-type type="gint" />
       </method>
       <constructor cname="gtk_tree_view_column_new" />
@@ -22988,7 +26685,7 @@
       <implements>
         <interface cname="GtkBuildable" />
       </implements>
-      <method name="AddUi" cname="gtk_ui_manager_add_ui">
+      <method name="AddUi" cname="gtk_ui_manager_add_ui" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="guint" name="merge_id" />
@@ -22999,14 +26696,21 @@
           <parameter type="gboolean" name="top" />
         </parameters>
       </method>
-      <method name="AddUiFromFile" cname="gtk_ui_manager_add_ui_from_file">
+      <method name="AddUiFromFile" cname="gtk_ui_manager_add_ui_from_file" deprecated="1">
         <return-type type="guint" />
         <parameters>
           <parameter type="const-gchar*" name="filename" />
           <parameter type="GError**" name="error" />
         </parameters>
       </method>
-      <method name="AddUiFromString" cname="gtk_ui_manager_add_ui_from_string">
+      <method name="AddUiFromResource" cname="gtk_ui_manager_add_ui_from_resource" deprecated="1">
+        <return-type type="guint" />
+        <parameters>
+          <parameter type="const-gchar*" name="resource_path" />
+          <parameter type="GError**" name="error" />
+        </parameters>
+      </method>
+      <method name="AddUiFromString" cname="gtk_ui_manager_add_ui_from_string" deprecated="1">
         <return-type type="guint" />
         <parameters>
           <parameter type="const-gchar*" name="buffer" />
@@ -23014,68 +26718,68 @@
           <parameter type="GError**" name="error" />
         </parameters>
       </method>
-      <method name="EnsureUpdate" cname="gtk_ui_manager_ensure_update">
+      <method name="EnsureUpdate" cname="gtk_ui_manager_ensure_update" deprecated="1">
         <return-type type="void" />
       </method>
-      <method name="GetAccelGroup" cname="gtk_ui_manager_get_accel_group">
+      <method name="GetAccelGroup" cname="gtk_ui_manager_get_accel_group" deprecated="1">
         <return-type type="GtkAccelGroup*" />
       </method>
-      <method name="GetAction" cname="gtk_ui_manager_get_action">
+      <method name="GetAction" cname="gtk_ui_manager_get_action" deprecated="1">
         <return-type type="GtkAction*" />
         <parameters>
           <parameter type="const-gchar*" name="path" />
         </parameters>
       </method>
-      <method name="GetActionGroups" cname="gtk_ui_manager_get_action_groups">
+      <method name="GetActionGroups" cname="gtk_ui_manager_get_action_groups" deprecated="1">
         <return-type type="GList*" />
       </method>
-      <method name="GetAddTearoffs" cname="gtk_ui_manager_get_add_tearoffs">
+      <method name="GetAddTearoffs" cname="gtk_ui_manager_get_add_tearoffs" deprecated="1">
         <return-type type="gboolean" />
       </method>
-      <method name="GetToplevels" cname="gtk_ui_manager_get_toplevels">
+      <method name="GetToplevels" cname="gtk_ui_manager_get_toplevels" deprecated="1">
         <return-type type="GSList*" />
         <parameters>
           <parameter type="GtkUIManagerItemType" name="types" />
         </parameters>
       </method>
-      <method name="GetType" cname="gtk_ui_manager_get_type" shared="true">
+      <method name="GetType" cname="gtk_ui_manager_get_type" deprecated="1" shared="true">
         <return-type type="GType" />
       </method>
-      <method name="GetUi" cname="gtk_ui_manager_get_ui">
+      <method name="GetUi" cname="gtk_ui_manager_get_ui" deprecated="1">
         <return-type type="gchar*" />
       </method>
-      <method name="GetWidget" cname="gtk_ui_manager_get_widget">
+      <method name="GetWidget" cname="gtk_ui_manager_get_widget" deprecated="1">
         <return-type type="GtkWidget*" />
         <parameters>
           <parameter type="const-gchar*" name="path" />
         </parameters>
       </method>
-      <method name="InsertActionGroup" cname="gtk_ui_manager_insert_action_group">
+      <method name="InsertActionGroup" cname="gtk_ui_manager_insert_action_group" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="GtkActionGroup*" name="action_group" />
           <parameter type="gint" name="pos" />
         </parameters>
       </method>
-      <constructor cname="gtk_ui_manager_new" />
-      <constructor cname="gtk_ui_manager_new_merge_id">
+      <constructor cname="gtk_ui_manager_new" deprecated="1" />
+      <constructor cname="gtk_ui_manager_new_merge_id" deprecated="1">
         <parameters>
           <parameter type="GtkUIManager*" name="manager" />
         </parameters>
       </constructor>
-      <method name="RemoveActionGroup" cname="gtk_ui_manager_remove_action_group">
+      <method name="RemoveActionGroup" cname="gtk_ui_manager_remove_action_group" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="GtkActionGroup*" name="action_group" />
         </parameters>
       </method>
-      <method name="RemoveUi" cname="gtk_ui_manager_remove_ui">
+      <method name="RemoveUi" cname="gtk_ui_manager_remove_ui" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="guint" name="merge_id" />
         </parameters>
       </method>
-      <method name="SetAddTearoffs" cname="gtk_ui_manager_set_add_tearoffs">
+      <method name="SetAddTearoffs" cname="gtk_ui_manager_set_add_tearoffs" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="gboolean" name="add_tearoffs" />
@@ -23086,10 +26790,10 @@
       <class_struct cname="GtkVBoxClass">
         <field name="ParentClass" cname="parent_class" type="GtkBoxClass" />
       </class_struct>
-      <method name="GetType" cname="gtk_vbox_get_type" shared="true">
+      <method name="GetType" cname="gtk_vbox_get_type" deprecated="1" shared="true">
         <return-type type="GType" />
       </method>
-      <constructor cname="gtk_vbox_new">
+      <constructor cname="gtk_vbox_new" deprecated="1">
         <parameters>
           <parameter type="gboolean" name="homogeneous" />
           <parameter type="gint" name="spacing" />
@@ -23100,10 +26804,10 @@
       <class_struct cname="GtkVButtonBoxClass">
         <field name="ParentClass" cname="parent_class" type="GtkButtonBoxClass" />
       </class_struct>
-      <method name="GetType" cname="gtk_vbutton_box_get_type" shared="true">
+      <method name="GetType" cname="gtk_vbutton_box_get_type" deprecated="1" shared="true">
         <return-type type="GType" />
       </method>
-      <constructor cname="gtk_vbutton_box_new" />
+      <constructor cname="gtk_vbutton_box_new" deprecated="1" />
     </object>
     <object name="Viewport" cname="GtkViewport" parent="GtkBin">
       <class_struct cname="GtkViewportClass">
@@ -23181,7 +26885,7 @@
         <method vm="_gtk_reserved3" />
         <method vm="_gtk_reserved4" />
       </class_struct>
-      <property name="UseSymbolic" cname="use-symbolic" type="gboolean" readable="true" writeable="true" />
+      <property name="UseSymbolic" cname="use-symbolic" type="gboolean" readable="true" writeable="true" construct="true" />
       <virtual_method name="GtkReserved1" cname="_gtk_reserved1" shared="true" padding="true">
         <return-type type="void" />
       </virtual_method>
@@ -23203,24 +26907,24 @@
       <class_struct cname="GtkVPanedClass">
         <field name="ParentClass" cname="parent_class" type="GtkPanedClass" />
       </class_struct>
-      <method name="GetType" cname="gtk_vpaned_get_type" shared="true">
+      <method name="GetType" cname="gtk_vpaned_get_type" deprecated="1" shared="true">
         <return-type type="GType" />
       </method>
-      <constructor cname="gtk_vpaned_new" />
+      <constructor cname="gtk_vpaned_new" deprecated="1" />
     </object>
     <object name="VScale" cname="GtkVScale" parent="GtkScale">
       <class_struct cname="GtkVScaleClass">
         <field name="ParentClass" cname="parent_class" type="GtkScaleClass" />
       </class_struct>
-      <method name="GetType" cname="gtk_vscale_get_type" shared="true">
+      <method name="GetType" cname="gtk_vscale_get_type" deprecated="1" shared="true">
         <return-type type="GType" />
       </method>
-      <constructor cname="gtk_vscale_new">
+      <constructor cname="gtk_vscale_new" deprecated="1">
         <parameters>
           <parameter type="GtkAdjustment*" name="adjustment" />
         </parameters>
       </constructor>
-      <constructor cname="gtk_vscale_new_with_range">
+      <constructor cname="gtk_vscale_new_with_range" deprecated="1">
         <parameters>
           <parameter type="gdouble" name="min" />
           <parameter type="gdouble" name="max" />
@@ -23232,10 +26936,10 @@
       <class_struct cname="GtkVScrollbarClass">
         <field name="ParentClass" cname="parent_class" type="GtkScrollbarClass" />
       </class_struct>
-      <method name="GetType" cname="gtk_vscrollbar_get_type" shared="true">
+      <method name="GetType" cname="gtk_vscrollbar_get_type" deprecated="1" shared="true">
         <return-type type="GType" />
       </method>
-      <constructor cname="gtk_vscrollbar_new">
+      <constructor cname="gtk_vscrollbar_new" deprecated="1">
         <parameters>
           <parameter type="GtkAdjustment*" name="adjustment" />
         </parameters>
@@ -23245,10 +26949,10 @@
       <class_struct cname="GtkVSeparatorClass">
         <field name="ParentClass" cname="parent_class" type="GtkSeparatorClass" />
       </class_struct>
-      <method name="GetType" cname="gtk_vseparator_get_type" shared="true">
+      <method name="GetType" cname="gtk_vseparator_get_type" deprecated="1" shared="true">
         <return-type type="GType" />
       </method>
-      <constructor cname="gtk_vseparator_new" />
+      <constructor cname="gtk_vseparator_new" deprecated="1" />
     </object>
     <object name="Widget" cname="GtkWidget" parent="GInitiallyUnowned">
       <class_struct cname="GtkWidgetClass">
@@ -23331,14 +27035,14 @@
         <method vm="adjust_size_request" />
         <method vm="adjust_size_allocation" />
         <method signal_vm="style_updated" />
-        <method vm="_gtk_reserved1" />
-        <method vm="_gtk_reserved2" />
-        <method vm="_gtk_reserved3" />
-        <method vm="_gtk_reserved4" />
-        <method vm="_gtk_reserved5" />
+        <method signal_vm="touch_event" />
+        <method vm="get_preferred_height_and_baseline_for_width" />
+        <method vm="adjust_baseline_request" />
+        <method vm="adjust_baseline_allocation" />
+        <method vm="queue_draw_region" />
+        <field name="Priv" cname="priv" type="GtkWidgetClassPrivate*" />
         <method vm="_gtk_reserved6" />
         <method vm="_gtk_reserved7" />
-        <method vm="_gtk_reserved8" />
       </class_struct>
       <field name="Priv" cname="priv" type="GtkWidgetPrivate*" />
       <property name="Name" cname="name" type="gchar*" readable="true" writeable="true" />
@@ -23367,6 +27071,8 @@
       <property name="Valign" cname="valign" type="GtkAlign" readable="true" writeable="true" />
       <property name="MarginLeft" cname="margin-left" type="gint" readable="true" writeable="true" />
       <property name="MarginRight" cname="margin-right" type="gint" readable="true" writeable="true" />
+      <property name="MarginStart" cname="margin-start" type="gint" readable="true" writeable="true" />
+      <property name="MarginEnd" cname="margin-end" type="gint" readable="true" writeable="true" />
       <property name="MarginTop" cname="margin-top" type="gint" readable="true" writeable="true" />
       <property name="MarginBottom" cname="margin-bottom" type="gint" readable="true" writeable="true" />
       <property name="Margin" cname="margin" type="gint" readable="true" writeable="true" />
@@ -23379,6 +27085,8 @@
       <property name="Vexpand" cname="vexpand" type="gboolean" readable="true" writeable="true" />
       <property name="VexpandSet" cname="vexpand-set" type="gboolean" readable="true" writeable="true" />
       <property name="Expand" cname="expand" type="gboolean" readable="true" writeable="true" />
+      <property name="Opacity" cname="opacity" type="gdouble" readable="true" writeable="true" />
+      <property name="ScaleFactor" cname="scale-factor" type="gint" readable="true" />
       <signal name="Show" cname="show" when="FIRST" field_name="show">
         <return-type type="void" />
         <parameters />
@@ -23458,7 +27166,7 @@
       <signal name="ChildNotify" cname="child-notify" when="FIRST" field_name="child_notify">
         <return-type type="void" />
         <parameters>
-          <parameter type="GParamSpec*" name="pspec" />
+          <parameter type="GParamSpec*" name="child_property" />
         </parameters>
       </signal>
       <signal name="Draw" cname="draw" when="LAST" field_name="draw">
@@ -23517,6 +27225,12 @@
         <return-type type="gboolean" />
         <parameters>
           <parameter type="GdkEventButton*" name="event" />
+        </parameters>
+      </signal>
+      <signal name="TouchEvent" cname="touch-event" when="LAST" field_name="touch_event">
+        <return-type type="gboolean" />
+        <parameters>
+          <parameter type="GdkEventTouch*" name="event" />
         </parameters>
       </signal>
       <signal name="ScrollEvent" cname="scroll-event" when="LAST" field_name="scroll_event">
@@ -23855,28 +27569,39 @@
           <parameter type="gint*" name="allocated_size" />
         </parameters>
       </virtual_method>
-      <virtual_method name="GtkReserved1" cname="_gtk_reserved1" shared="true" padding="true">
+      <virtual_method name="GetPreferredHeightAndBaselineForWidth" cname="get_preferred_height_and_baseline_for_width">
         <return-type type="void" />
+        <parameters>
+          <parameter type="gint" name="width" />
+          <parameter type="gint*" name="minimum_height" />
+          <parameter type="gint*" name="natural_height" />
+          <parameter type="gint*" name="minimum_baseline" />
+          <parameter type="gint*" name="natural_baseline" />
+        </parameters>
       </virtual_method>
-      <virtual_method name="GtkReserved2" cname="_gtk_reserved2" shared="true" padding="true">
+      <virtual_method name="AdjustBaselineRequest" cname="adjust_baseline_request">
         <return-type type="void" />
+        <parameters>
+          <parameter type="gint*" name="minimum_baseline" />
+          <parameter type="gint*" name="natural_baseline" />
+        </parameters>
       </virtual_method>
-      <virtual_method name="GtkReserved3" cname="_gtk_reserved3" shared="true" padding="true">
+      <virtual_method name="AdjustBaselineAllocation" cname="adjust_baseline_allocation">
         <return-type type="void" />
+        <parameters>
+          <parameter type="gint*" name="baseline" />
+        </parameters>
       </virtual_method>
-      <virtual_method name="GtkReserved4" cname="_gtk_reserved4" shared="true" padding="true">
+      <virtual_method name="QueueDrawRegion" cname="queue_draw_region">
         <return-type type="void" />
-      </virtual_method>
-      <virtual_method name="GtkReserved5" cname="_gtk_reserved5" shared="true" padding="true">
-        <return-type type="void" />
+        <parameters>
+          <parameter type="const-cairo_region_t*" name="region" />
+        </parameters>
       </virtual_method>
       <virtual_method name="GtkReserved6" cname="_gtk_reserved6" shared="true" padding="true">
         <return-type type="void" />
       </virtual_method>
       <virtual_method name="GtkReserved7" cname="_gtk_reserved7" shared="true" padding="true">
-        <return-type type="void" />
-      </virtual_method>
-      <virtual_method name="GtkReserved8" cname="_gtk_reserved8" shared="true" padding="true">
         <return-type type="void" />
       </virtual_method>
       <implements>
@@ -23915,6 +27640,14 @@
           <parameter type="GtkWidget*" name="label" />
         </parameters>
       </method>
+      <method name="AddTickCallback" cname="gtk_widget_add_tick_callback">
+        <return-type type="guint" />
+        <parameters>
+          <parameter type="GtkTickCallback" name="callback" />
+          <parameter type="gpointer" name="user_data" />
+          <parameter type="GDestroyNotify" name="notify" />
+        </parameters>
+      </method>
       <method name="CanActivateAccel" cname="gtk_widget_can_activate_accel">
         <return-type type="gboolean" />
         <parameters>
@@ -23931,6 +27664,23 @@
         <return-type type="void" />
         <parameters>
           <parameter type="const-gchar*" name="child_property" />
+        </parameters>
+      </method>
+      <method name="ClassBindTemplateCallbackFull" cname="gtk_widget_class_bind_template_callback_full" shared="true">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkWidgetClass*" name="widget_class" />
+          <parameter type="const-gchar*" name="callback_name" />
+          <parameter type="GCallback" name="callback_symbol" />
+        </parameters>
+      </method>
+      <method name="ClassBindTemplateChildFull" cname="gtk_widget_class_bind_template_child_full" shared="true">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkWidgetClass*" name="widget_class" />
+          <parameter type="const-gchar*" name="name" />
+          <parameter type="gboolean" name="internal_child" />
+          <parameter type="gssize" name="struct_offset" />
         </parameters>
       </method>
       <method name="ClassFindStyleProperty" cname="gtk_widget_class_find_style_property" shared="true">
@@ -23968,6 +27718,43 @@
           <parameter type="guint*" name="path_length" />
           <parameter type="gchar**" name="path" />
           <parameter type="gchar**" name="path_reversed" />
+        </parameters>
+      </method>
+      <method name="ClassSetAccessibleRole" cname="gtk_widget_class_set_accessible_role" shared="true">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkWidgetClass*" name="widget_class" />
+          <parameter type="AtkRole" name="role" />
+        </parameters>
+      </method>
+      <method name="ClassSetAccessibleType" cname="gtk_widget_class_set_accessible_type" shared="true">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkWidgetClass*" name="widget_class" />
+          <parameter type="GType" name="type" />
+        </parameters>
+      </method>
+      <method name="ClassSetConnectFunc" cname="gtk_widget_class_set_connect_func" shared="true">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkWidgetClass*" name="widget_class" />
+          <parameter type="GtkBuilderConnectFunc" name="connect_func" />
+          <parameter type="gpointer" name="connect_data" />
+          <parameter type="GDestroyNotify" name="connect_data_destroy" />
+        </parameters>
+      </method>
+      <method name="ClassSetTemplate" cname="gtk_widget_class_set_template" shared="true">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkWidgetClass*" name="widget_class" />
+          <parameter type="GBytes*" name="template_bytes" />
+        </parameters>
+      </method>
+      <method name="ClassSetTemplateFromResource" cname="gtk_widget_class_set_template_from_resource" shared="true">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkWidgetClass*" name="widget_class" />
+          <parameter type="const-gchar*" name="resource_name" />
         </parameters>
       </method>
       <method name="ComputeExpand" cname="gtk_widget_compute_expand">
@@ -24024,6 +27811,9 @@
       <method name="GetAccessible" cname="gtk_widget_get_accessible">
         <return-type type="AtkObject*" />
       </method>
+      <method name="GetAllocatedBaseline" cname="gtk_widget_get_allocated_baseline">
+        <return-type type="int" />
+      </method>
       <method name="GetAllocatedHeight" cname="gtk_widget_get_allocated_height">
         <return-type type="int" />
       </method>
@@ -24060,13 +27850,19 @@
       <method name="GetChildVisible" cname="gtk_widget_get_child_visible">
         <return-type type="gboolean" />
       </method>
+      <method name="GetClip" cname="gtk_widget_get_clip">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkAllocation*" name="clip" />
+        </parameters>
+      </method>
       <method name="GetClipboard" cname="gtk_widget_get_clipboard">
         <return-type type="GtkClipboard*" />
         <parameters>
           <parameter type="GdkAtom" name="selection" />
         </parameters>
       </method>
-      <method name="GetCompositeName" cname="gtk_widget_get_composite_name">
+      <method name="GetCompositeName" cname="gtk_widget_get_composite_name" deprecated="1">
         <return-type type="gchar*" />
       </method>
       <method name="GetDefaultDirection" cname="gtk_widget_get_default_direction" shared="true">
@@ -24093,11 +27889,14 @@
       <method name="GetDisplay" cname="gtk_widget_get_display">
         <return-type type="GdkDisplay*" />
       </method>
-      <method name="GetDoubleBuffered" cname="gtk_widget_get_double_buffered">
+      <method name="GetDoubleBuffered" cname="gtk_widget_get_double_buffered" deprecated="1">
         <return-type type="gboolean" />
       </method>
       <method name="GetEvents" cname="gtk_widget_get_events">
         <return-type type="gint" />
+      </method>
+      <method name="GetFrameClock" cname="gtk_widget_get_frame_clock">
+        <return-type type="GdkFrameClock*" />
       </method>
       <method name="GetHalign" cname="gtk_widget_get_halign">
         <return-type type="GtkAlign" />
@@ -24120,14 +27919,26 @@
       <method name="GetMarginBottom" cname="gtk_widget_get_margin_bottom">
         <return-type type="gint" />
       </method>
-      <method name="GetMarginLeft" cname="gtk_widget_get_margin_left">
+      <method name="GetMarginEnd" cname="gtk_widget_get_margin_end">
         <return-type type="gint" />
       </method>
-      <method name="GetMarginRight" cname="gtk_widget_get_margin_right">
+      <method name="GetMarginLeft" cname="gtk_widget_get_margin_left" deprecated="1">
+        <return-type type="gint" />
+      </method>
+      <method name="GetMarginRight" cname="gtk_widget_get_margin_right" deprecated="1">
+        <return-type type="gint" />
+      </method>
+      <method name="GetMarginStart" cname="gtk_widget_get_margin_start">
         <return-type type="gint" />
       </method>
       <method name="GetMarginTop" cname="gtk_widget_get_margin_top">
         <return-type type="gint" />
+      </method>
+      <method name="GetModifierMask" cname="gtk_widget_get_modifier_mask">
+        <return-type type="GdkModifierType" />
+        <parameters>
+          <parameter type="GdkModifierIntent" name="intent" />
+        </parameters>
       </method>
       <method name="GetModifierStyle" cname="gtk_widget_get_modifier_style" deprecated="1">
         <return-type type="GtkRcStyle*" />
@@ -24137,6 +27948,9 @@
       </method>
       <method name="GetNoShowAll" cname="gtk_widget_get_no_show_all">
         <return-type type="gboolean" />
+      </method>
+      <method name="GetOpacity" cname="gtk_widget_get_opacity">
+        <return-type type="double" />
       </method>
       <method name="GetPangoContext" cname="gtk_widget_get_pango_context">
         <return-type type="PangoContext*" />
@@ -24150,7 +27964,7 @@
       <method name="GetPath" cname="gtk_widget_get_path">
         <return-type type="GtkWidgetPath*" />
       </method>
-      <method name="GetPointer" cname="gtk_widget_get_pointer">
+      <method name="GetPointer" cname="gtk_widget_get_pointer" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="gint*" name="x" />
@@ -24162,6 +27976,16 @@
         <parameters>
           <parameter type="gint*" name="minimum_height" />
           <parameter type="gint*" name="natural_height" />
+        </parameters>
+      </method>
+      <method name="GetPreferredHeightAndBaselineForWidth" cname="gtk_widget_get_preferred_height_and_baseline_for_width">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gint" name="width" />
+          <parameter type="gint*" name="minimum_height" />
+          <parameter type="gint*" name="natural_height" />
+          <parameter type="gint*" name="minimum_baseline" />
+          <parameter type="gint*" name="natural_baseline" />
         </parameters>
       </method>
       <method name="GetPreferredHeightForWidth" cname="gtk_widget_get_preferred_height_for_width">
@@ -24203,14 +28027,11 @@
       <method name="GetRequestMode" cname="gtk_widget_get_request_mode">
         <return-type type="GtkSizeRequestMode" />
       </method>
-      <method name="GetRequisition" cname="gtk_widget_get_requisition">
-        <return-type type="void" />
-        <parameters>
-          <parameter type="GtkRequisition*" name="requisition" />
-        </parameters>
-      </method>
-      <method name="GetRootWindow" cname="gtk_widget_get_root_window">
+      <method name="GetRootWindow" cname="gtk_widget_get_root_window" deprecated="1">
         <return-type type="GdkWindow*" />
+      </method>
+      <method name="GetScaleFactor" cname="gtk_widget_get_scale_factor">
+        <return-type type="gint" />
       </method>
       <method name="GetScreen" cname="gtk_widget_get_screen">
         <return-type type="GdkScreen*" />
@@ -24228,7 +28049,7 @@
           <parameter type="gint*" name="height" />
         </parameters>
       </method>
-      <method name="GetState" cname="gtk_widget_get_state">
+      <method name="GetState" cname="gtk_widget_get_state" deprecated="1">
         <return-type type="GtkStateType" />
       </method>
       <method name="GetStateFlags" cname="gtk_widget_get_state_flags">
@@ -24242,6 +28063,13 @@
       </method>
       <method name="GetSupportMultidevice" cname="gtk_widget_get_support_multidevice">
         <return-type type="gboolean" />
+      </method>
+      <method name="GetTemplateChild" cname="gtk_widget_get_template_child">
+        <return-type type="GObject*" />
+        <parameters>
+          <parameter type="GType" name="widget_type" />
+          <parameter type="const-gchar*" name="name" />
+        </parameters>
       </method>
       <method name="GetTooltipMarkup" cname="gtk_widget_get_tooltip_markup">
         <return-type type="gchar*" />
@@ -24259,6 +28087,9 @@
         <return-type type="GType" />
       </method>
       <method name="GetValign" cname="gtk_widget_get_valign">
+        <return-type type="GtkAlign" />
+      </method>
+      <method name="GetValignWithBaseline" cname="gtk_widget_get_valign_with_baseline">
         <return-type type="GtkAlign" />
       </method>
       <method name="GetVexpand" cname="gtk_widget_get_vexpand">
@@ -24297,6 +28128,9 @@
       <method name="HasScreen" cname="gtk_widget_has_screen">
         <return-type type="gboolean" />
       </method>
+      <method name="HasVisibleFocus" cname="gtk_widget_has_visible_focus">
+        <return-type type="gboolean" />
+      </method>
       <method name="Hide" cname="gtk_widget_hide">
         <return-type type="void" />
       </method>
@@ -24306,10 +28140,20 @@
       <method name="InDestruction" cname="gtk_widget_in_destruction">
         <return-type type="gboolean" />
       </method>
+      <method name="InitTemplate" cname="gtk_widget_init_template">
+        <return-type type="void" />
+      </method>
       <method name="InputShapeCombineRegion" cname="gtk_widget_input_shape_combine_region">
         <return-type type="void" />
         <parameters>
           <parameter type="cairo_region_t*" name="region" />
+        </parameters>
+      </method>
+      <method name="InsertActionGroup" cname="gtk_widget_insert_action_group">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="const-gchar*" name="name" />
+          <parameter type="GActionGroup*" name="group" />
         </parameters>
       </method>
       <method name="Intersect" cname="gtk_widget_intersect">
@@ -24338,6 +28182,9 @@
         <return-type type="gboolean" />
       </method>
       <method name="IsToplevel" cname="gtk_widget_is_toplevel">
+        <return-type type="gboolean" />
+      </method>
+      <method name="IsVisible" cname="gtk_widget_is_visible">
         <return-type type="gboolean" />
       </method>
       <method name="KeynavFailed" cname="gtk_widget_keynav_failed">
@@ -24457,10 +28304,10 @@
           <parameter type="gchar**" name="path_reversed" />
         </parameters>
       </method>
-      <method name="PopCompositeChild" cname="gtk_widget_pop_composite_child" shared="true">
+      <method name="PopCompositeChild" cname="gtk_widget_pop_composite_child" deprecated="1" shared="true">
         <return-type type="void" />
       </method>
-      <method name="PushCompositeChild" cname="gtk_widget_push_composite_child" shared="true">
+      <method name="PushCompositeChild" cname="gtk_widget_push_composite_child" deprecated="1" shared="true">
         <return-type type="void" />
       </method>
       <method name="QueueComputeExpand" cname="gtk_widget_queue_compute_expand">
@@ -24493,10 +28340,16 @@
       <method name="Realize" cname="gtk_widget_realize">
         <return-type type="void" />
       </method>
-      <method name="RegionIntersect" cname="gtk_widget_region_intersect">
+      <method name="RegionIntersect" cname="gtk_widget_region_intersect" deprecated="1">
         <return-type type="cairo_region_t*" />
         <parameters>
           <parameter type="const-cairo_region_t*" name="region" />
+        </parameters>
+      </method>
+      <method name="RegisterWindow" cname="gtk_widget_register_window">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GdkWindow*" name="window" />
         </parameters>
       </method>
       <method name="RemoveAccelerator" cname="gtk_widget_remove_accelerator">
@@ -24513,6 +28366,12 @@
           <parameter type="GtkWidget*" name="label" />
         </parameters>
       </method>
+      <method name="RemoveTickCallback" cname="gtk_widget_remove_tick_callback">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="guint" name="id" />
+        </parameters>
+      </method>
       <method name="RenderIcon" cname="gtk_widget_render_icon" deprecated="1">
         <return-type type="GdkPixbuf*" />
         <parameters>
@@ -24521,14 +28380,14 @@
           <parameter type="const-gchar*" name="detail" />
         </parameters>
       </method>
-      <method name="RenderIconPixbuf" cname="gtk_widget_render_icon_pixbuf">
+      <method name="RenderIconPixbuf" cname="gtk_widget_render_icon_pixbuf" deprecated="1">
         <return-type type="GdkPixbuf*" />
         <parameters>
           <parameter type="const-gchar*" name="stock_id" />
           <parameter type="GtkIconSize" name="size" />
         </parameters>
       </method>
-      <method name="Reparent" cname="gtk_widget_reparent">
+      <method name="Reparent" cname="gtk_widget_reparent" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="GtkWidget*" name="new_parent" />
@@ -24589,7 +28448,13 @@
           <parameter type="gboolean" name="is_visible" />
         </parameters>
       </method>
-      <method name="SetCompositeName" cname="gtk_widget_set_composite_name">
+      <method name="SetClip" cname="gtk_widget_set_clip">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="const-GtkAllocation*" name="clip" />
+        </parameters>
+      </method>
+      <method name="SetCompositeName" cname="gtk_widget_set_composite_name" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="const-gchar*" name="name" />
@@ -24621,7 +28486,7 @@
           <parameter type="GtkTextDirection" name="dir" />
         </parameters>
       </method>
-      <method name="SetDoubleBuffered" cname="gtk_widget_set_double_buffered">
+      <method name="SetDoubleBuffered" cname="gtk_widget_set_double_buffered" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="gboolean" name="double_buffered" />
@@ -24675,13 +28540,25 @@
           <parameter type="gint" name="margin" />
         </parameters>
       </method>
-      <method name="SetMarginLeft" cname="gtk_widget_set_margin_left">
+      <method name="SetMarginEnd" cname="gtk_widget_set_margin_end">
         <return-type type="void" />
         <parameters>
           <parameter type="gint" name="margin" />
         </parameters>
       </method>
-      <method name="SetMarginRight" cname="gtk_widget_set_margin_right">
+      <method name="SetMarginLeft" cname="gtk_widget_set_margin_left" deprecated="1">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gint" name="margin" />
+        </parameters>
+      </method>
+      <method name="SetMarginRight" cname="gtk_widget_set_margin_right" deprecated="1">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gint" name="margin" />
+        </parameters>
+      </method>
+      <method name="SetMarginStart" cname="gtk_widget_set_margin_start">
         <return-type type="void" />
         <parameters>
           <parameter type="gint" name="margin" />
@@ -24703,6 +28580,12 @@
         <return-type type="void" />
         <parameters>
           <parameter type="gboolean" name="no_show_all" />
+        </parameters>
+      </method>
+      <method name="SetOpacity" cname="gtk_widget_set_opacity">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="double" name="opacity" />
         </parameters>
       </method>
       <method name="SetParent" cname="gtk_widget_set_parent">
@@ -24748,7 +28631,7 @@
           <parameter type="gint" name="height" />
         </parameters>
       </method>
-      <method name="SetState" cname="gtk_widget_set_state">
+      <method name="SetState" cname="gtk_widget_set_state" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="GtkStateType" name="state" />
@@ -24848,6 +28731,13 @@
           <parameter type="GtkAllocation*" name="allocation" />
         </parameters>
       </method>
+      <method name="SizeAllocateWithBaseline" cname="gtk_widget_size_allocate_with_baseline">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkAllocation*" name="allocation" />
+          <parameter type="gint" name="baseline" />
+        </parameters>
+      </method>
       <method name="SizeRequest" cname="gtk_widget_size_request" deprecated="1">
         <return-type type="void" />
         <parameters>
@@ -24903,6 +28793,12 @@
       <method name="Unrealize" cname="gtk_widget_unrealize">
         <return-type type="void" />
       </method>
+      <method name="UnregisterWindow" cname="gtk_widget_unregister_window">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GdkWindow*" name="window" />
+        </parameters>
+      </method>
       <method name="UnsetStateFlags" cname="gtk_widget_unset_state_flags">
         <return-type type="void" />
         <parameters>
@@ -24943,10 +28839,10 @@
         <method signal_vm="activate_focus" />
         <method signal_vm="activate_default" />
         <method signal_vm="keys_changed" />
+        <method signal_vm="enable_debugging" />
         <method vm="_gtk_reserved1" />
         <method vm="_gtk_reserved2" />
         <method vm="_gtk_reserved3" />
-        <method vm="_gtk_reserved4" />
       </class_struct>
       <field name="Priv" cname="priv" type="GtkWindowPrivate*" />
       <property name="Type" cname="type" type="GtkWindowType" readable="true" writeable="true" construct-only="true" />
@@ -24959,8 +28855,10 @@
       <property name="DefaultWidth" cname="default-width" type="gint" readable="true" writeable="true" />
       <property name="DefaultHeight" cname="default-height" type="gint" readable="true" writeable="true" />
       <property name="DestroyWithParent" cname="destroy-with-parent" type="gboolean" readable="true" writeable="true" />
+      <property name="HideTitlebarWhenMaximized" cname="hide-titlebar-when-maximized" type="gboolean" readable="true" writeable="true" />
       <property name="Icon" cname="icon" type="GdkPixbuf" readable="true" writeable="true" />
       <property name="MnemonicsVisible" cname="mnemonics-visible" type="gboolean" readable="true" writeable="true" />
+      <property name="FocusVisible" cname="focus-visible" type="gboolean" readable="true" writeable="true" />
       <property name="IconName" cname="icon-name" type="gchar*" readable="true" writeable="true" />
       <property name="Screen" cname="screen" type="GdkScreen" readable="true" writeable="true" />
       <property name="IsActive" cname="is-active" type="gboolean" readable="true" />
@@ -24977,7 +28875,8 @@
       <property name="ResizeGripVisible" cname="resize-grip-visible" type="gboolean" readable="true" />
       <property name="Gravity" cname="gravity" type="GdkGravity" readable="true" writeable="true" />
       <property name="TransientFor" cname="transient-for" type="GtkWindow" readable="true" writeable="true" construct="true" />
-      <property name="Opacity" cname="opacity" type="gdouble" readable="true" writeable="true" />
+      <property name="AttachedTo" cname="attached-to" type="GtkWidget" readable="true" writeable="true" construct="true" />
+      <property name="IsMaximized" cname="is-maximized" type="gboolean" readable="true" />
       <property name="Application" cname="application" type="GtkApplication" readable="true" writeable="true" />
       <signal name="SetFocus" cname="set-focus" when="LAST" field_name="set_focus">
         <return-type type="void" />
@@ -24997,6 +28896,12 @@
         <return-type type="void" />
         <parameters />
       </signal>
+      <signal name="EnableDebugging" cname="enable-debugging" when="LAST" field_name="enable_debugging">
+        <return-type type="gboolean" />
+        <parameters>
+          <parameter type="gboolean" name="toggle" />
+        </parameters>
+      </signal>
       <virtual_method name="GtkReserved1" cname="_gtk_reserved1" shared="true" padding="true">
         <return-type type="void" />
       </virtual_method>
@@ -25004,9 +28909,6 @@
         <return-type type="void" />
       </virtual_method>
       <virtual_method name="GtkReserved3" cname="_gtk_reserved3" shared="true" padding="true">
-        <return-type type="void" />
-      </virtual_method>
-      <virtual_method name="GtkReserved4" cname="_gtk_reserved4" shared="true" padding="true">
         <return-type type="void" />
       </virtual_method>
       <implements>
@@ -25056,6 +28958,9 @@
           <parameter type="guint32" name="timestamp" />
         </parameters>
       </method>
+      <method name="Close" cname="gtk_window_close">
+        <return-type type="void" />
+      </method>
       <method name="Deiconify" cname="gtk_window_deiconify">
         <return-type type="void" />
       </method>
@@ -25067,6 +28972,9 @@
       </method>
       <method name="GetApplication" cname="gtk_window_get_application">
         <return-type type="GtkApplication*" />
+      </method>
+      <method name="GetAttachedTo" cname="gtk_window_get_attached_to">
+        <return-type type="GtkWidget*" />
       </method>
       <method name="GetDecorated" cname="gtk_window_get_decorated">
         <return-type type="gboolean" />
@@ -25099,13 +29007,19 @@
       <method name="GetFocusOnMap" cname="gtk_window_get_focus_on_map">
         <return-type type="gboolean" />
       </method>
+      <method name="GetFocusVisible" cname="gtk_window_get_focus_visible">
+        <return-type type="gboolean" />
+      </method>
       <method name="GetGravity" cname="gtk_window_get_gravity">
         <return-type type="GdkGravity" />
       </method>
       <method name="GetGroup" cname="gtk_window_get_group">
         <return-type type="GtkWindowGroup*" />
       </method>
-      <method name="GetHasResizeGrip" cname="gtk_window_get_has_resize_grip">
+      <method name="GetHasResizeGrip" cname="gtk_window_get_has_resize_grip" deprecated="1">
+        <return-type type="gboolean" />
+      </method>
+      <method name="GetHideTitlebarWhenMaximized" cname="gtk_window_get_hide_titlebar_when_maximized">
         <return-type type="gboolean" />
       </method>
       <method name="GetIcon" cname="gtk_window_get_icon">
@@ -25126,7 +29040,7 @@
       <method name="GetModal" cname="gtk_window_get_modal">
         <return-type type="gboolean" />
       </method>
-      <method name="GetOpacity" cname="gtk_window_get_opacity">
+      <method name="GetOpacity" cname="gtk_window_get_opacity" deprecated="1">
         <return-type type="gdouble" />
       </method>
       <method name="GetPosition" cname="gtk_window_get_position">
@@ -25139,7 +29053,7 @@
       <method name="GetResizable" cname="gtk_window_get_resizable">
         <return-type type="gboolean" />
       </method>
-      <method name="GetResizeGripArea" cname="gtk_window_get_resize_grip_area">
+      <method name="GetResizeGripArea" cname="gtk_window_get_resize_grip_area" deprecated="1">
         <return-type type="gboolean" />
         <parameters>
           <parameter type="GdkRectangle*" name="rect" />
@@ -25192,6 +29106,9 @@
         <return-type type="void" />
       </method>
       <method name="IsActive" cname="gtk_window_is_active">
+        <return-type type="gboolean" />
+      </method>
+      <method name="IsMaximized" cname="gtk_window_is_maximized">
         <return-type type="gboolean" />
       </method>
       <method name="ListToplevels" cname="gtk_window_list_toplevels" shared="true">
@@ -25253,7 +29170,7 @@
           <parameter type="GtkWidget*" name="target" />
         </parameters>
       </method>
-      <method name="ReshowWithInitialSize" cname="gtk_window_reshow_with_initial_size">
+      <method name="ReshowWithInitialSize" cname="gtk_window_reshow_with_initial_size" deprecated="1">
         <return-type type="void" />
       </method>
       <method name="Resize" cname="gtk_window_resize">
@@ -25263,7 +29180,7 @@
           <parameter type="gint" name="height" />
         </parameters>
       </method>
-      <method name="ResizeGripIsVisible" cname="gtk_window_resize_grip_is_visible">
+      <method name="ResizeGripIsVisible" cname="gtk_window_resize_grip_is_visible" deprecated="1">
         <return-type type="gboolean" />
       </method>
       <method name="ResizeToGeometry" cname="gtk_window_resize_to_geometry">
@@ -25283,6 +29200,12 @@
         <return-type type="void" />
         <parameters>
           <parameter type="GtkApplication*" name="application" />
+        </parameters>
+      </method>
+      <method name="SetAttachedTo" cname="gtk_window_set_attached_to">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkWidget*" name="attach_widget" />
         </parameters>
       </method>
       <method name="SetAutoStartupNotification" cname="gtk_window_set_auto_startup_notification" shared="true">
@@ -25366,6 +29289,12 @@
           <parameter type="gboolean" name="setting" />
         </parameters>
       </method>
+      <method name="SetFocusVisible" cname="gtk_window_set_focus_visible">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gboolean" name="setting" />
+        </parameters>
+      </method>
       <method name="SetGeometryHints" cname="gtk_window_set_geometry_hints">
         <return-type type="void" />
         <parameters>
@@ -25380,13 +29309,19 @@
           <parameter type="GdkGravity" name="gravity" />
         </parameters>
       </method>
-      <method name="SetHasResizeGrip" cname="gtk_window_set_has_resize_grip">
+      <method name="SetHasResizeGrip" cname="gtk_window_set_has_resize_grip" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="gboolean" name="value" />
         </parameters>
       </method>
       <method name="SetHasUserRefCount" cname="gtk_window_set_has_user_ref_count">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gboolean" name="setting" />
+        </parameters>
+      </method>
+      <method name="SetHideTitlebarWhenMaximized" cname="gtk_window_set_hide_titlebar_when_maximized">
         <return-type type="void" />
         <parameters>
           <parameter type="gboolean" name="setting" />
@@ -25415,6 +29350,12 @@
         <return-type type="void" />
         <parameters>
           <parameter type="const-gchar*" name="name" />
+        </parameters>
+      </method>
+      <method name="SetInteractiveDebugging" cname="gtk_window_set_interactive_debugging" shared="true">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gboolean" name="enable" />
         </parameters>
       </method>
       <method name="SetKeepAbove" cname="gtk_window_set_keep_above">
@@ -25447,7 +29388,7 @@
           <parameter type="gboolean" name="modal" />
         </parameters>
       </method>
-      <method name="SetOpacity" cname="gtk_window_set_opacity">
+      <method name="SetOpacity" cname="gtk_window_set_opacity" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="gdouble" name="opacity" />
@@ -25499,6 +29440,12 @@
         <return-type type="void" />
         <parameters>
           <parameter type="const-gchar*" name="title" />
+        </parameters>
+      </method>
+      <method name="SetTitlebar" cname="gtk_window_set_titlebar">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkWidget*" name="titlebar" />
         </parameters>
       </method>
       <method name="SetTransientFor" cname="gtk_window_set_transient_for">
@@ -25589,18 +29536,19 @@
         </parameters>
       </method>
     </object>
-    <struct name="AnimationInfo" cname="AnimationInfo" opaque="true" />
     <struct name="CacheEntry" cname="CacheEntry" opaque="true" />
     <struct name="CachedIcon" cname="CachedIcon" opaque="true" />
+    <struct name="Child" cname="Child" opaque="true" />
     <struct name="ClipboardRequest" cname="ClipboardRequest" opaque="true" />
     <struct name="ColorStop" cname="ColorStop" opaque="true" />
     <struct name="CompareInfo" cname="CompareInfo" opaque="true" />
-    <struct name="ComparePathData" cname="ComparePathData" opaque="true" />
+    <struct name="CountingData" cname="CountingData" opaque="true" />
+    <struct name="DecomposedMatrix" cname="DecomposedMatrix" opaque="true" />
     <struct name="EntryIconInfo" cname="EntryIconInfo" opaque="true" />
+    <struct name="EventData" cname="EventData" opaque="true" />
     <struct name="FilterElt" cname="FilterElt" opaque="true" />
     <struct name="FilterLevel" cname="FilterLevel" opaque="true" />
     <struct name="FilterRule" cname="FilterRule" opaque="true" />
-    <boxed name="9_Slice" cname="Gtk9Slice" opaque="true" />
     <struct name="AccelGroupEntry" cname="GtkAccelGroupEntry">
       <field name="Key" cname="key" type="GtkAccelKey" />
       <field name="Closure" cname="closure" type="GClosure*" />
@@ -25620,10 +29568,7 @@
       <field name="Callback" cname="callback" type="GCallback" />
     </struct>
     <alias name="Allocation" cname="GtkAllocation" type="GdkRectangle" />
-    <boxed name="AnimationDescription" cname="GtkAnimationDescription" opaque="true" />
     <struct name="AppChooserIface" cname="GtkAppChooserIface" opaque="true" />
-    <struct name="AssistantAccessible" cname="GtkAssistantAccessible" opaque="true" />
-    <struct name="AssistantAccessibleClass" cname="GtkAssistantAccessibleClass" opaque="true" />
     <struct name="AssistantPage" cname="GtkAssistantPage" opaque="true" />
     <struct name="BindingArg" cname="GtkBindingArg">
       <field name="ArgType" cname="arg_type" type="GType" />
@@ -25726,6 +29671,18 @@
       <field name="NArgs" cname="n_args" type="guint" />
       <field name="Args" cname="args" type="GtkBindingArg*" />
     </struct>
+    <struct name="Bitmask" cname="GtkBitmask" opaque="true" />
+    <struct name="Bookmark" cname="GtkBookmark">
+      <field name="File" cname="file" type="GFile*" />
+      <field name="Label" cname="label" type="gchar*" />
+    </struct>
+    <struct name="BookmarksManager" cname="GtkBookmarksManager">
+      <field name="Bookmarks" cname="bookmarks" type="GSList*" />
+      <field name="BookmarksMonitor" cname="bookmarks_monitor" type="GFileMonitor*" />
+      <field name="BookmarksMonitorChangedId" cname="bookmarks_monitor_changed_id" type="gulong" />
+      <field name="ChangedFuncData" cname="changed_func_data" type="gpointer" />
+      <field name="ChangedFunc" cname="changed_func" type="GtkBookmarksChangedFunc" />
+    </struct>
     <boxed name="Border" cname="GtkBorder" opaque="true">
       <field name="Left" cname="left" type="gint16" access="public" writeable="true" />
       <field name="Right" cname="right" type="gint16" access="public" writeable="true" />
@@ -25742,12 +29699,100 @@
       </method>
       <constructor cname="gtk_border_new" />
     </boxed>
+    <struct name="BorderImage" cname="GtkBorderImage" opaque="true" />
+    <struct name="BorderImageSliceSize" cname="GtkBorderImageSliceSize" opaque="true" />
     <struct name="BoxChild" cname="GtkBoxChild" opaque="true" />
     <struct name="CellAreaBoxContext" cname="GtkCellAreaBoxContext" opaque="true" />
     <struct name="CellAreaBoxContextClass" cname="GtkCellAreaBoxContextClass" opaque="true" />
     <struct name="CellEditableEventBox" cname="GtkCellEditableEventBox" opaque="true" />
+    <struct name="ColorEditor" cname="GtkColorEditor" opaque="true" />
+    <struct name="ColorEditorClass" cname="GtkColorEditorClass" opaque="true" />
+    <struct name="ColorPlane" cname="GtkColorPlane" opaque="true" />
+    <struct name="ColorPlaneClass" cname="GtkColorPlaneClass" opaque="true" />
+    <struct name="ColorScale" cname="GtkColorScale" opaque="true" />
+    <struct name="ColorScaleClass" cname="GtkColorScaleClass" opaque="true" />
+    <struct name="ColorSwatch" cname="GtkColorSwatch" opaque="true" />
+    <struct name="ColorSwatchClass" cname="GtkColorSwatchClass" opaque="true" />
     <struct name="ComposeTable" cname="GtkComposeTable" opaque="true" />
     <struct name="ComposeTableCompact" cname="GtkComposeTableCompact" opaque="true" />
+    <struct name="CssAnimation" cname="GtkCssAnimation" opaque="true" />
+    <struct name="CssAnimationClass" cname="GtkCssAnimationClass" opaque="true" />
+    <struct name="CssChangeTranslation" cname="GtkCssChangeTranslation" opaque="true" />
+    <struct name="CssComputedValues" cname="GtkCssComputedValues" opaque="true" />
+    <struct name="CssComputedValuesClass" cname="GtkCssComputedValuesClass" opaque="true" />
+    <struct name="CssCustomProperty" cname="GtkCssCustomProperty" opaque="true" />
+    <struct name="CssCustomPropertyClass" cname="GtkCssCustomPropertyClass" opaque="true" />
+    <struct name="CssImage" cname="GtkCssImage" opaque="true" />
+    <struct name="CssImageClass" cname="GtkCssImageClass" opaque="true" />
+    <struct name="CssImageCrossFade" cname="GtkCssImageCrossFade" opaque="true" />
+    <struct name="CssImageCrossFadeClass" cname="GtkCssImageCrossFadeClass" opaque="true" />
+    <struct name="CssImageGradient" cname="GtkCssImageGradient" opaque="true" />
+    <struct name="CssImageGradientClass" cname="GtkCssImageGradientClass" opaque="true" />
+    <struct name="CssImageIconTheme" cname="GtkCssImageIconTheme" opaque="true" />
+    <struct name="CssImageIconThemeClass" cname="GtkCssImageIconThemeClass" opaque="true" />
+    <struct name="CssImageLinear" cname="GtkCssImageLinear" opaque="true" />
+    <struct name="CssImageLinearClass" cname="GtkCssImageLinearClass" opaque="true" />
+    <struct name="CssImageLinearColorStop" cname="GtkCssImageLinearColorStop" opaque="true" />
+    <struct name="CssImageScaled" cname="GtkCssImageScaled" opaque="true" />
+    <struct name="CssImageScaledClass" cname="GtkCssImageScaledClass" opaque="true" />
+    <struct name="CssImageSurface" cname="GtkCssImageSurface" opaque="true" />
+    <struct name="CssImageSurfaceClass" cname="GtkCssImageSurfaceClass" opaque="true" />
+    <struct name="CssImageUrl" cname="GtkCssImageUrl" opaque="true" />
+    <struct name="CssImageUrlClass" cname="GtkCssImageUrlClass" opaque="true" />
+    <struct name="CssImageWin32" cname="GtkCssImageWin32" opaque="true" />
+    <struct name="CssImageWin32Class" cname="GtkCssImageWin32Class" opaque="true" />
+    <struct name="CssKeyframes" cname="GtkCssKeyframes" opaque="true" />
+    <struct name="CssLookup" cname="GtkCssLookup" opaque="true" />
+    <struct name="CssMatcherClass" cname="GtkCssMatcherClass" opaque="true" />
+    <struct name="CssMatcherSuperset" cname="GtkCssMatcherSuperset" opaque="true" />
+    <struct name="CssMatcherWidgetPath" cname="GtkCssMatcherWidgetPath" opaque="true" />
+    <struct name="CssParser" cname="GtkCssParser" opaque="true" />
+    <struct name="CssRuleset" cname="GtkCssRuleset" opaque="true" />
+    <struct name="CssScanner" cname="GtkCssScanner" opaque="true" />
+    <boxed name="CssSection" cname="GtkCssSection" opaque="true">
+      <method name="GetEndLine" cname="gtk_css_section_get_end_line">
+        <return-type type="guint" />
+      </method>
+      <method name="GetEndPosition" cname="gtk_css_section_get_end_position">
+        <return-type type="guint" />
+      </method>
+      <method name="GetFile" cname="gtk_css_section_get_file">
+        <return-type type="GFile*" />
+      </method>
+      <method name="GetParent" cname="gtk_css_section_get_parent">
+        <return-type type="GtkCssSection*" />
+      </method>
+      <method name="GetSectionType" cname="gtk_css_section_get_section_type">
+        <return-type type="GtkCssSectionType" />
+      </method>
+      <method name="GetStartLine" cname="gtk_css_section_get_start_line">
+        <return-type type="guint" />
+      </method>
+      <method name="GetStartPosition" cname="gtk_css_section_get_start_position">
+        <return-type type="guint" />
+      </method>
+      <method name="GetType" cname="gtk_css_section_get_type" shared="true">
+        <return-type type="GType" />
+      </method>
+      <method name="Ref" cname="gtk_css_section_ref">
+        <return-type type="GtkCssSection*" />
+      </method>
+      <method name="Unref" cname="gtk_css_section_unref">
+        <return-type type="void" />
+      </method>
+    </boxed>
+    <struct name="CssSelector" cname="GtkCssSelector" opaque="true" />
+    <struct name="CssSelectorClass" cname="GtkCssSelectorClass" opaque="true" />
+    <struct name="CssSelectorTree" cname="GtkCssSelectorTree" opaque="true" />
+    <struct name="CssSelectorTreeBuilder" cname="GtkCssSelectorTreeBuilder" opaque="true" />
+    <struct name="CssShorthandProperty" cname="GtkCssShorthandProperty" opaque="true" />
+    <struct name="CssShorthandPropertyClass" cname="GtkCssShorthandPropertyClass" opaque="true" />
+    <struct name="CssStyleProperty" cname="GtkCssStyleProperty" opaque="true" />
+    <struct name="CssStylePropertyClass" cname="GtkCssStylePropertyClass" opaque="true" />
+    <struct name="CssTransition" cname="GtkCssTransition" opaque="true" />
+    <struct name="CssTransitionClass" cname="GtkCssTransitionClass" opaque="true" />
+    <boxed name="CssValue" cname="GtkCssValue" opaque="true" />
+    <struct name="CssValueClass" cname="GtkCssValueClass" opaque="true" />
     <struct name="DeviceGrabInfo" cname="GtkDeviceGrabInfo" opaque="true" />
     <struct name="DragAnim" cname="GtkDragAnim" opaque="true" />
     <struct name="DragDestInfo" cname="GtkDragDestInfo" opaque="true" />
@@ -25772,17 +29817,17 @@
       <field name="Y" cname="y" type="gint" />
     </struct>
     <boxed name="Gradient" cname="GtkGradient" opaque="true">
-      <method name="AddColorStop" cname="gtk_gradient_add_color_stop">
+      <method name="AddColorStop" cname="gtk_gradient_add_color_stop" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="gdouble" name="offset" />
           <parameter type="GtkSymbolicColor*" name="color" />
         </parameters>
       </method>
-      <method name="GetType" cname="gtk_gradient_get_type" shared="true">
+      <method name="GetType" cname="gtk_gradient_get_type" deprecated="1" shared="true">
         <return-type type="GType" />
       </method>
-      <constructor cname="gtk_gradient_new_linear">
+      <constructor cname="gtk_gradient_new_linear" deprecated="1">
         <parameters>
           <parameter type="gdouble" name="x0" />
           <parameter type="gdouble" name="y0" />
@@ -25790,7 +29835,7 @@
           <parameter type="gdouble" name="y1" />
         </parameters>
       </constructor>
-      <constructor cname="gtk_gradient_new_radial">
+      <constructor cname="gtk_gradient_new_radial" deprecated="1">
         <parameters>
           <parameter type="gdouble" name="x0" />
           <parameter type="gdouble" name="y0" />
@@ -25800,17 +29845,26 @@
           <parameter type="gdouble" name="radius1" />
         </parameters>
       </constructor>
-      <method name="Ref" cname="gtk_gradient_ref">
+      <method name="Ref" cname="gtk_gradient_ref" deprecated="1">
         <return-type type="GtkGradient*" />
       </method>
-      <method name="Resolve" cname="gtk_gradient_resolve">
+      <method name="Resolve" cname="gtk_gradient_resolve" deprecated="1">
         <return-type type="gboolean" />
         <parameters>
           <parameter type="GtkStyleProperties*" name="props" />
           <parameter type="cairo_pattern_t**" name="resolved_gradient" />
         </parameters>
       </method>
-      <method name="Unref" cname="gtk_gradient_unref">
+      <method name="ResolveForContext" cname="gtk_gradient_resolve_for_context" deprecated="1">
+        <return-type type="cairo_pattern_t*" />
+        <parameters>
+          <parameter type="GtkStyleContext*" name="context" />
+        </parameters>
+      </method>
+      <method name="ToString" cname="gtk_gradient_to_string" deprecated="1">
+        <return-type type="char*" />
+      </method>
+      <method name="Unref" cname="gtk_gradient_unref" deprecated="1">
         <return-type type="void" />
       </method>
     </boxed>
@@ -25820,6 +29874,8 @@
     <struct name="GridLineData" cname="GtkGridLineData" opaque="true" />
     <struct name="GridLines" cname="GtkGridLines" opaque="true" />
     <struct name="GridRequest" cname="GtkGridRequest" opaque="true" />
+    <struct name="GridRowProperties" cname="GtkGridRowProperties" opaque="true" />
+    <struct name="HSLA" cname="GtkHSLA" opaque="true" />
     <struct name="IMContextInfo" cname="GtkIMContextInfo">
       <field name="ContextId" cname="context_id" type="const-gchar*" />
       <field name="ContextName" cname="context_name" type="const-gchar*" />
@@ -25829,115 +29885,35 @@
     </struct>
     <struct name="IMModule" cname="GtkIMModule" opaque="true" />
     <struct name="IMModuleClass" cname="GtkIMModuleClass" opaque="true" />
-    <boxed name="IconInfo" cname="GtkIconInfo" opaque="true">
-      <method name="Copy" cname="gtk_icon_info_copy">
-        <return-type type="GtkIconInfo*" owned="true" />
-      </method>
-      <method name="Free" cname="gtk_icon_info_free">
-        <return-type type="void" />
-      </method>
-      <method name="GetAttachPoints" cname="gtk_icon_info_get_attach_points">
-        <return-type type="gboolean" />
-        <parameters>
-          <parameter type="GdkPoint**" name="points" />
-          <parameter type="gint*" name="n_points" />
-        </parameters>
-      </method>
-      <method name="GetBaseSize" cname="gtk_icon_info_get_base_size">
-        <return-type type="gint" />
-      </method>
-      <method name="GetBuiltinPixbuf" cname="gtk_icon_info_get_builtin_pixbuf">
-        <return-type type="GdkPixbuf*" />
-      </method>
-      <method name="GetDisplayName" cname="gtk_icon_info_get_display_name">
-        <return-type type="const-gchar*" />
-      </method>
-      <method name="GetEmbeddedRect" cname="gtk_icon_info_get_embedded_rect">
-        <return-type type="gboolean" />
-        <parameters>
-          <parameter type="GdkRectangle*" name="rectangle" />
-        </parameters>
-      </method>
-      <method name="GetFilename" cname="gtk_icon_info_get_filename">
-        <return-type type="const-gchar*" />
-      </method>
-      <method name="GetType" cname="gtk_icon_info_get_type" shared="true">
-        <return-type type="GType" />
-      </method>
-      <method name="LoadIcon" cname="gtk_icon_info_load_icon">
-        <return-type type="GdkPixbuf*" />
-        <parameters>
-          <parameter type="GError**" name="error" />
-        </parameters>
-      </method>
-      <method name="LoadSymbolic" cname="gtk_icon_info_load_symbolic">
-        <return-type type="GdkPixbuf*" />
-        <parameters>
-          <parameter type="GdkRGBA*" name="fg" />
-          <parameter type="GdkRGBA*" name="success_color" />
-          <parameter type="GdkRGBA*" name="warning_color" />
-          <parameter type="GdkRGBA*" name="error_color" />
-          <parameter type="gboolean*" name="was_symbolic" />
-          <parameter type="GError**" name="error" />
-        </parameters>
-      </method>
-      <method name="LoadSymbolicForContext" cname="gtk_icon_info_load_symbolic_for_context">
-        <return-type type="GdkPixbuf*" />
-        <parameters>
-          <parameter type="GtkStyleContext*" name="context" />
-          <parameter type="gboolean*" name="was_symbolic" />
-          <parameter type="GError**" name="error" />
-        </parameters>
-      </method>
-      <method name="LoadSymbolicForStyle" cname="gtk_icon_info_load_symbolic_for_style" deprecated="1">
-        <return-type type="GdkPixbuf*" />
-        <parameters>
-          <parameter type="GtkStyle*" name="style" />
-          <parameter type="GtkStateType" name="state" />
-          <parameter type="gboolean*" name="was_symbolic" />
-          <parameter type="GError**" name="error" />
-        </parameters>
-      </method>
-      <constructor cname="gtk_icon_info_new_for_pixbuf">
-        <parameters>
-          <parameter type="GtkIconTheme*" name="icon_theme" />
-          <parameter type="GdkPixbuf*" name="pixbuf" />
-        </parameters>
-      </constructor>
-      <method name="SetRawCoordinates" cname="gtk_icon_info_set_raw_coordinates">
-        <return-type type="void" />
-        <parameters>
-          <parameter type="gboolean" name="raw_coordinates" />
-        </parameters>
-      </method>
-    </boxed>
+    <struct name="IconHelper" cname="GtkIconHelper" opaque="true" />
+    <struct name="IconHelperClass" cname="GtkIconHelperClass" opaque="true" />
     <boxed name="IconSet" cname="GtkIconSet" opaque="true">
-      <method name="AddSource" cname="gtk_icon_set_add_source">
+      <method name="AddSource" cname="gtk_icon_set_add_source" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="const-GtkIconSource*" name="source" />
         </parameters>
       </method>
-      <method name="Copy" cname="gtk_icon_set_copy">
+      <method name="Copy" cname="gtk_icon_set_copy" deprecated="1">
         <return-type type="GtkIconSet*" owned="true" />
       </method>
-      <method name="GetSizes" cname="gtk_icon_set_get_sizes">
+      <method name="GetSizes" cname="gtk_icon_set_get_sizes" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="GtkIconSize**" name="sizes" />
           <parameter type="gint*" name="n_sizes" />
         </parameters>
       </method>
-      <method name="GetType" cname="gtk_icon_set_get_type" shared="true">
+      <method name="GetType" cname="gtk_icon_set_get_type" deprecated="1" shared="true">
         <return-type type="GType" />
       </method>
-      <constructor cname="gtk_icon_set_new" />
-      <constructor cname="gtk_icon_set_new_from_pixbuf">
+      <constructor cname="gtk_icon_set_new" deprecated="1" />
+      <constructor cname="gtk_icon_set_new_from_pixbuf" deprecated="1">
         <parameters>
           <parameter type="GdkPixbuf*" name="pixbuf" />
         </parameters>
       </constructor>
-      <method name="Ref" cname="gtk_icon_set_ref">
+      <method name="Ref" cname="gtk_icon_set_ref" deprecated="1">
         <return-type type="GtkIconSet*" />
       </method>
       <method name="RenderIcon" cname="gtk_icon_set_render_icon" deprecated="1">
@@ -25951,104 +29927,113 @@
           <parameter type="const-gchar*" name="detail" />
         </parameters>
       </method>
-      <method name="RenderIconPixbuf" cname="gtk_icon_set_render_icon_pixbuf">
+      <method name="RenderIconPixbuf" cname="gtk_icon_set_render_icon_pixbuf" deprecated="1">
         <return-type type="GdkPixbuf*" />
         <parameters>
           <parameter type="GtkStyleContext*" name="context" />
           <parameter type="GtkIconSize" name="size" />
         </parameters>
       </method>
-      <method name="Unref" cname="gtk_icon_set_unref">
+      <method name="RenderIconSurface" cname="gtk_icon_set_render_icon_surface" deprecated="1">
+        <return-type type="cairo_surface_t*" />
+        <parameters>
+          <parameter type="GtkStyleContext*" name="context" />
+          <parameter type="GtkIconSize" name="size" />
+          <parameter type="int" name="scale" />
+          <parameter type="GdkWindow*" name="for_window" />
+        </parameters>
+      </method>
+      <method name="Unref" cname="gtk_icon_set_unref" deprecated="1">
         <return-type type="void" />
       </method>
     </boxed>
     <boxed name="IconSource" cname="GtkIconSource" opaque="true">
-      <method name="Copy" cname="gtk_icon_source_copy">
+      <method name="Copy" cname="gtk_icon_source_copy" deprecated="1">
         <return-type type="GtkIconSource*" owned="true" />
       </method>
-      <method name="Free" cname="gtk_icon_source_free">
+      <method name="Free" cname="gtk_icon_source_free" deprecated="1">
         <return-type type="void" />
       </method>
-      <method name="GetDirection" cname="gtk_icon_source_get_direction">
+      <method name="GetDirection" cname="gtk_icon_source_get_direction" deprecated="1">
         <return-type type="GtkTextDirection" />
       </method>
-      <method name="GetDirectionWildcarded" cname="gtk_icon_source_get_direction_wildcarded">
+      <method name="GetDirectionWildcarded" cname="gtk_icon_source_get_direction_wildcarded" deprecated="1">
         <return-type type="gboolean" />
       </method>
-      <method name="GetFilename" cname="gtk_icon_source_get_filename">
+      <method name="GetFilename" cname="gtk_icon_source_get_filename" deprecated="1">
         <return-type type="const-gchar*" />
       </method>
-      <method name="GetIconName" cname="gtk_icon_source_get_icon_name">
+      <method name="GetIconName" cname="gtk_icon_source_get_icon_name" deprecated="1">
         <return-type type="const-gchar*" />
       </method>
-      <method name="GetPixbuf" cname="gtk_icon_source_get_pixbuf">
+      <method name="GetPixbuf" cname="gtk_icon_source_get_pixbuf" deprecated="1">
         <return-type type="GdkPixbuf*" />
       </method>
-      <method name="GetSize" cname="gtk_icon_source_get_size">
+      <method name="GetSize" cname="gtk_icon_source_get_size" deprecated="1">
         <return-type type="GtkIconSize" />
       </method>
-      <method name="GetSizeWildcarded" cname="gtk_icon_source_get_size_wildcarded">
+      <method name="GetSizeWildcarded" cname="gtk_icon_source_get_size_wildcarded" deprecated="1">
         <return-type type="gboolean" />
       </method>
-      <method name="GetState" cname="gtk_icon_source_get_state">
+      <method name="GetState" cname="gtk_icon_source_get_state" deprecated="1">
         <return-type type="GtkStateType" />
       </method>
-      <method name="GetStateWildcarded" cname="gtk_icon_source_get_state_wildcarded">
+      <method name="GetStateWildcarded" cname="gtk_icon_source_get_state_wildcarded" deprecated="1">
         <return-type type="gboolean" />
       </method>
-      <method name="GetType" cname="gtk_icon_source_get_type" shared="true">
+      <method name="GetType" cname="gtk_icon_source_get_type" deprecated="1" shared="true">
         <return-type type="GType" />
       </method>
-      <constructor cname="gtk_icon_source_new" />
-      <method name="SetDirection" cname="gtk_icon_source_set_direction">
+      <constructor cname="gtk_icon_source_new" deprecated="1" />
+      <method name="SetDirection" cname="gtk_icon_source_set_direction" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="GtkTextDirection" name="direction" />
         </parameters>
       </method>
-      <method name="SetDirectionWildcarded" cname="gtk_icon_source_set_direction_wildcarded">
+      <method name="SetDirectionWildcarded" cname="gtk_icon_source_set_direction_wildcarded" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="gboolean" name="setting" />
         </parameters>
       </method>
-      <method name="SetFilename" cname="gtk_icon_source_set_filename">
+      <method name="SetFilename" cname="gtk_icon_source_set_filename" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="const-gchar*" name="filename" />
         </parameters>
       </method>
-      <method name="SetIconName" cname="gtk_icon_source_set_icon_name">
+      <method name="SetIconName" cname="gtk_icon_source_set_icon_name" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="const-gchar*" name="icon_name" />
         </parameters>
       </method>
-      <method name="SetPixbuf" cname="gtk_icon_source_set_pixbuf">
+      <method name="SetPixbuf" cname="gtk_icon_source_set_pixbuf" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="GdkPixbuf*" name="pixbuf" />
         </parameters>
       </method>
-      <method name="SetSize" cname="gtk_icon_source_set_size">
+      <method name="SetSize" cname="gtk_icon_source_set_size" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="GtkIconSize" name="size" />
         </parameters>
       </method>
-      <method name="SetSizeWildcarded" cname="gtk_icon_source_set_size_wildcarded">
+      <method name="SetSizeWildcarded" cname="gtk_icon_source_set_size_wildcarded" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="gboolean" name="setting" />
         </parameters>
       </method>
-      <method name="SetState" cname="gtk_icon_source_set_state">
+      <method name="SetState" cname="gtk_icon_source_set_state" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="GtkStateType" name="state" />
         </parameters>
       </method>
-      <method name="SetStateWildcarded" cname="gtk_icon_source_set_state_wildcarded">
+      <method name="SetStateWildcarded" cname="gtk_icon_source_set_state_wildcarded" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="gboolean" name="setting" />
@@ -26076,10 +30061,63 @@
     <struct name="KeyHash" cname="GtkKeyHash" opaque="true" />
     <struct name="KeyHashEntry" cname="GtkKeyHashEntry" opaque="true" />
     <struct name="KeySnooperData" cname="GtkKeySnooperData" opaque="true" />
+    <struct name="KineticScrolling" cname="GtkKineticScrolling" opaque="true">
+      <method name="Free" cname="gtk_kinetic_scrolling_free">
+        <return-type type="void" />
+      </method>
+      <constructor cname="gtk_kinetic_scrolling_new">
+        <parameters>
+          <parameter type="gdouble" name="lower" />
+          <parameter type="gdouble" name="upper" />
+          <parameter type="gdouble" name="overshoot_width" />
+          <parameter type="gdouble" name="decel_friction" />
+          <parameter type="gdouble" name="overshoot_friction" />
+          <parameter type="gdouble" name="initial_position" />
+          <parameter type="gdouble" name="initial_velocity" />
+        </parameters>
+      </constructor>
+      <method name="Tick" cname="gtk_kinetic_scrolling_tick">
+        <return-type type="gboolean" />
+        <parameters>
+          <parameter type="gdouble" name="time_delta" />
+          <parameter type="gdouble*" name="position" />
+        </parameters>
+      </method>
+    </struct>
     <struct name="LabelSelectionInfo" cname="GtkLabelSelectionInfo" opaque="true" />
     <struct name="LayoutChild" cname="GtkLayoutChild" opaque="true" />
+    <struct name="Magnifier" cname="GtkMagnifier" opaque="true" />
+    <struct name="MagnifierClass" cname="GtkMagnifierClass" opaque="true" />
     <struct name="MenuAttachData" cname="GtkMenuAttachData" opaque="true" />
     <struct name="MenuPopdownData" cname="GtkMenuPopdownData" opaque="true" />
+    <struct name="MenuTracker" cname="GtkMenuTracker" opaque="true">
+      <method name="Free" cname="gtk_menu_tracker_free">
+        <return-type type="void" />
+      </method>
+      <constructor cname="gtk_menu_tracker_new">
+        <parameters>
+          <parameter type="GtkActionObservable*" name="observer" />
+          <parameter type="GMenuModel*" name="model" />
+          <parameter type="gboolean" name="with_separators" />
+          <parameter type="gboolean" name="merge_sections" />
+          <parameter type="const-gchar*" name="action_namespace" />
+          <parameter type="GtkMenuTrackerInsertFunc" name="insert_func" />
+          <parameter type="GtkMenuTrackerRemoveFunc" name="remove_func" />
+          <parameter type="gpointer" name="user_data" />
+        </parameters>
+      </constructor>
+      <constructor cname="gtk_menu_tracker_new_for_item_link">
+        <parameters>
+          <parameter type="GtkMenuTrackerItem*" name="item" />
+          <parameter type="const-gchar*" name="link_name" />
+          <parameter type="gboolean" name="merge_sections" />
+          <parameter type="GtkMenuTrackerInsertFunc" name="insert_func" />
+          <parameter type="GtkMenuTrackerRemoveFunc" name="remove_func" />
+          <parameter type="gpointer" name="user_data" />
+        </parameters>
+      </constructor>
+    </struct>
+    <struct name="MenuTrackerSection" cname="GtkMenuTrackerSection" opaque="true" />
     <struct name="MnemonicHash" cname="GtkMnemonicHash" opaque="true" />
     <struct name="ModuleInfo" cname="GtkModuleInfo" opaque="true" />
     <struct name="MountOperationLookupContext" cname="GtkMountOperationLookupContext" opaque="true" />
@@ -26092,6 +30130,7 @@
         </parameters>
       </method>
     </struct>
+    <struct name="OverlayChild" cname="GtkOverlayChild" opaque="true" />
     <struct name="PageRange" cname="GtkPageRange">
       <field name="Start" cname="start" type="gint" />
       <field name="End" cname="end" type="gint" />
@@ -26215,6 +30254,7 @@
       </method>
     </boxed>
     <struct name="PathElement" cname="GtkPathElement" opaque="true" />
+    <struct name="PixelCache" cname="GtkPixelCache" opaque="true" />
     <struct name="PrintBackend" cname="GtkPrintBackend" opaque="true" />
     <struct name="PrintBackendModule" cname="GtkPrintBackendModule" opaque="true" />
     <struct name="PrintBackendModuleClass" cname="GtkPrintBackendModuleClass" opaque="true" />
@@ -26451,6 +30491,8 @@
       <constructor cname="gtk_requisition_new" />
     </boxed>
     <struct name="RetrievalInfo" cname="GtkRetrievalInfo" opaque="true" />
+    <struct name="RoundedBox" cname="GtkRoundedBox" opaque="true" />
+    <struct name="RoundedBoxCorner" cname="GtkRoundedBoxCorner" opaque="true" />
     <struct name="ScaleMark" cname="GtkScaleMark" opaque="true" />
     <boxed name="SelectionData" cname="GtkSelectionData" opaque="true">
       <method name="Copy" cname="gtk_selection_data_copy">
@@ -26559,8 +30601,7 @@
       <field name="Origin" cname="origin" type="gchar*" />
       <field name="Value" cname="value" type="GValue" />
     </struct>
-    <struct name="SpinnerAccessible" cname="GtkSpinnerAccessible" opaque="true" />
-    <struct name="SpinnerAccessibleClass" cname="GtkSpinnerAccessibleClass" opaque="true" />
+    <struct name="StackChildInfo" cname="GtkStackChildInfo" opaque="true" />
     <struct name="StatusbarMsg" cname="GtkStatusbarMsg" opaque="true" />
     <struct name="StockItem" cname="GtkStockItem">
       <field name="StockId" cname="stock_id" type="gchar*" />
@@ -26568,62 +30609,77 @@
       <field name="Modifier" cname="modifier" type="GdkModifierType" />
       <field name="Keyval" cname="keyval" type="guint" />
       <field name="TranslationDomain" cname="translation_domain" type="gchar*" />
-      <method name="Copy" cname="gtk_stock_item_copy">
+      <method name="Copy" cname="gtk_stock_item_copy" deprecated="1">
         <return-type type="GtkStockItem*" owned="true" />
       </method>
-      <method name="Free" cname="gtk_stock_item_free">
+      <method name="Free" cname="gtk_stock_item_free" deprecated="1">
         <return-type type="void" />
       </method>
     </struct>
     <struct name="StockTranslateFunc" cname="GtkStockTranslateFunc" opaque="true" />
+    <struct name="StyleAnimation" cname="GtkStyleAnimation" opaque="true" />
+    <struct name="StyleAnimationClass" cname="GtkStyleAnimationClass" opaque="true" />
+    <struct name="StyleCascade" cname="GtkStyleCascade" opaque="true" />
+    <struct name="StyleCascadeClass" cname="GtkStyleCascadeClass" opaque="true" />
+    <struct name="StyleCascadeIter" cname="GtkStyleCascadeIter" opaque="true" />
     <struct name="StyleInfo" cname="GtkStyleInfo" opaque="true" />
+    <struct name="StyleProperty" cname="GtkStyleProperty" opaque="true" />
+    <struct name="StylePropertyClass" cname="GtkStylePropertyClass" opaque="true" />
     <struct name="StyleProviderData" cname="GtkStyleProviderData" opaque="true" />
-    <struct name="SwitchAccessible" cname="GtkSwitchAccessible" opaque="true" />
-    <struct name="SwitchAccessibleClass" cname="GtkSwitchAccessibleClass" opaque="true" />
+    <struct name="StyleProviderPrivateInterface" cname="GtkStyleProviderPrivateInterface" opaque="true" />
     <boxed name="SymbolicColor" cname="GtkSymbolicColor" opaque="true">
-      <method name="GetType" cname="gtk_symbolic_color_get_type" shared="true">
+      <method name="GetType" cname="gtk_symbolic_color_get_type" deprecated="1" shared="true">
         <return-type type="GType" />
       </method>
-      <constructor cname="gtk_symbolic_color_new_alpha">
+      <constructor cname="gtk_symbolic_color_new_alpha" deprecated="1">
         <parameters>
           <parameter type="GtkSymbolicColor*" name="color" />
           <parameter type="gdouble" name="factor" />
         </parameters>
       </constructor>
-      <constructor cname="gtk_symbolic_color_new_literal">
+      <constructor cname="gtk_symbolic_color_new_literal" deprecated="1">
         <parameters>
           <parameter type="const-GdkRGBA*" name="color" />
         </parameters>
       </constructor>
-      <constructor cname="gtk_symbolic_color_new_mix">
+      <constructor cname="gtk_symbolic_color_new_mix" deprecated="1">
         <parameters>
           <parameter type="GtkSymbolicColor*" name="color1" />
           <parameter type="GtkSymbolicColor*" name="color2" />
           <parameter type="gdouble" name="factor" />
         </parameters>
       </constructor>
-      <constructor cname="gtk_symbolic_color_new_name">
+      <constructor cname="gtk_symbolic_color_new_name" deprecated="1">
         <parameters>
           <parameter type="const-gchar*" name="name" />
         </parameters>
       </constructor>
-      <constructor cname="gtk_symbolic_color_new_shade">
+      <constructor cname="gtk_symbolic_color_new_shade" deprecated="1">
         <parameters>
           <parameter type="GtkSymbolicColor*" name="color" />
           <parameter type="gdouble" name="factor" />
         </parameters>
       </constructor>
-      <method name="Ref" cname="gtk_symbolic_color_ref">
+      <constructor cname="gtk_symbolic_color_new_win32" deprecated="1">
+        <parameters>
+          <parameter type="const-gchar*" name="theme_class" />
+          <parameter type="gint" name="id" />
+        </parameters>
+      </constructor>
+      <method name="Ref" cname="gtk_symbolic_color_ref" deprecated="1">
         <return-type type="GtkSymbolicColor*" />
       </method>
-      <method name="Resolve" cname="gtk_symbolic_color_resolve">
+      <method name="Resolve" cname="gtk_symbolic_color_resolve" deprecated="1">
         <return-type type="gboolean" />
         <parameters>
           <parameter type="GtkStyleProperties*" name="props" />
           <parameter type="GdkRGBA*" name="resolved_color" />
         </parameters>
       </method>
-      <method name="Unref" cname="gtk_symbolic_color_unref">
+      <method name="ToString" cname="gtk_symbolic_color_to_string" deprecated="1">
+        <return-type type="char*" />
+      </method>
+      <method name="Unref" cname="gtk_symbolic_color_unref" deprecated="1">
         <return-type type="void" />
       </method>
     </boxed>
@@ -26745,6 +30801,11 @@
         <return-type type="void" />
       </method>
     </boxed>
+    <struct name="TargetPair" cname="GtkTargetPair">
+      <field name="Target" cname="target" type="GdkAtom" />
+      <field name="Flags" cname="flags" type="guint" />
+      <field name="Info" cname="info" type="guint" />
+    </struct>
     <struct name="TextAppearance" cname="GtkTextAppearance">
       <field name="BgColor" cname="bg_color" type="GdkColor" />
       <field name="FgColor" cname="fg_color" type="GdkColor" />
@@ -26754,7 +30815,8 @@
       <field name="DrawBg" cname="draw_bg" bits="1" type="guint" />
       <field name="InsideSelection" cname="inside_selection" bits="1" type="guint" />
       <field name="IsText" cname="is_text" bits="1" type="guint" />
-      <field name="Padding" cname="padding" array_len="4" type="guint" access="private" />
+      <field name="Rgba" cname="rgba" array_len="2" type="GdkRGBA*" />
+      <field name="Padding" cname="padding" array_len="2" type="guint" access="private" />
     </struct>
     <struct name="TextAttrAppearance" cname="GtkTextAttrAppearance" opaque="true" />
     <boxed name="TextAttributes" cname="GtkTextAttributes" opaque="true">
@@ -26777,7 +30839,8 @@
       <field name="Invisible" cname="invisible" bits="1" type="guint" access="public" writeable="true" />
       <field name="BgFullHeight" cname="bg_full_height" bits="1" type="guint" access="public" writeable="true" />
       <field name="Editable" cname="editable" bits="1" type="guint" access="public" writeable="true" />
-      <field name="Padding" cname="padding" array_len="4" type="guint" access="private" />
+      <field name="PgBgRgba" cname="pg_bg_rgba" type="GdkRGBA*" access="private" />
+      <field name="Padding" cname="padding" array_len="3" type="guint" access="private" />
       <method name="Copy" cname="gtk_text_attributes_copy">
         <return-type type="GtkTextAttributes*" owned="true" />
       </method>
@@ -26801,7 +30864,8 @@
     <struct name="TextBTree" cname="GtkTextBTree" opaque="true" />
     <struct name="TextBTreeNode" cname="GtkTextBTreeNode" opaque="true" />
     <struct name="TextChildBody" cname="GtkTextChildBody" opaque="true" />
-    <struct name="TextCursorDisplay" cname="GtkTextCursorDisplay" opaque="true" />
+    <struct name="TextHandle" cname="GtkTextHandle" opaque="true" />
+    <struct name="TextHandleClass" cname="GtkTextHandleClass" opaque="true" />
     <boxed name="TextIter" cname="GtkTextIter">
       <field name="Dummy1" cname="dummy1" type="gpointer" access="private" />
       <field name="Dummy2" cname="dummy2" type="gpointer" access="private" />
@@ -26817,6 +30881,12 @@
       <field name="Dummy12" cname="dummy12" type="gint" access="private" />
       <field name="Dummy13" cname="dummy13" type="gint" access="private" />
       <field name="Dummy14" cname="dummy14" type="gpointer" access="private" />
+      <method name="Assign" cname="gtk_text_iter_assign">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="const-GtkTextIter*" name="other" />
+        </parameters>
+      </method>
       <method name="BackwardChar" cname="gtk_text_iter_backward_char">
         <return-type type="gboolean" />
       </method>
@@ -27259,9 +31329,10 @@
     <struct name="TextViewChild" cname="GtkTextViewChild" opaque="true" />
     <struct name="TextWindow" cname="GtkTextWindow" opaque="true" />
     <struct name="ThemeEngine" cname="GtkThemeEngine" opaque="true" />
+    <struct name="ThemingBackground" cname="GtkThemingBackground" opaque="true" />
     <struct name="ThemingModule" cname="GtkThemingModule" opaque="true" />
     <struct name="ThemingModuleClass" cname="GtkThemingModuleClass" opaque="true" />
-    <struct name="TimelinePriv" cname="GtkTimelinePriv" opaque="true" />
+    <struct name="TickCallbackInfo" cname="GtkTickCallbackInfo" opaque="true" />
     <struct name="ToggleActionEntry" cname="GtkToggleActionEntry">
       <field name="Name" cname="name" type="const-gchar*" />
       <field name="StockId" cname="stock_id" type="const-gchar*" />
@@ -27344,6 +31415,12 @@
         <parameters>
           <parameter type="gint" name="first_index" />
           <parameter ellipsis="true" />
+        </parameters>
+      </constructor>
+      <constructor cname="gtk_tree_path_new_from_indicesv">
+        <parameters>
+          <parameter type="gint*" name="indices" />
+          <parameter type="gsize" name="length" />
         </parameters>
       </constructor>
       <constructor cname="gtk_tree_path_new_from_string">
@@ -27436,10 +31513,23 @@
       <field name="Margin" cname="margin" type="GtkBorder" />
     </struct>
     <boxed name="WidgetPath" cname="GtkWidgetPath" opaque="true">
+      <method name="AppendForWidget" cname="gtk_widget_path_append_for_widget">
+        <return-type type="gint" />
+        <parameters>
+          <parameter type="GtkWidget*" name="widget" />
+        </parameters>
+      </method>
       <method name="AppendType" cname="gtk_widget_path_append_type">
         <return-type type="gint" />
         <parameters>
           <parameter type="GType" name="type" />
+        </parameters>
+      </method>
+      <method name="AppendWithSiblings" cname="gtk_widget_path_append_with_siblings">
+        <return-type type="gint" />
+        <parameters>
+          <parameter type="GtkWidgetPath*" name="siblings" />
+          <parameter type="guint" name="sibling_index" />
         </parameters>
       </method>
       <method name="Copy" cname="gtk_widget_path_copy">
@@ -27473,7 +31563,7 @@
           <parameter type="const-gchar*" name="name" />
         </parameters>
       </method>
-      <method name="IterAddRegion" cname="gtk_widget_path_iter_add_region">
+      <method name="IterAddRegion" cname="gtk_widget_path_iter_add_region" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="gint" name="pos" />
@@ -27487,7 +31577,7 @@
           <parameter type="gint" name="pos" />
         </parameters>
       </method>
-      <method name="IterClearRegions" cname="gtk_widget_path_iter_clear_regions">
+      <method name="IterClearRegions" cname="gtk_widget_path_iter_clear_regions" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="gint" name="pos" />
@@ -27501,6 +31591,24 @@
       </method>
       <method name="IterGetObjectType" cname="gtk_widget_path_iter_get_object_type">
         <return-type type="GType" />
+        <parameters>
+          <parameter type="gint" name="pos" />
+        </parameters>
+      </method>
+      <method name="IterGetSiblingIndex" cname="gtk_widget_path_iter_get_sibling_index">
+        <return-type type="guint" />
+        <parameters>
+          <parameter type="gint" name="pos" />
+        </parameters>
+      </method>
+      <method name="IterGetSiblings" cname="gtk_widget_path_iter_get_siblings">
+        <return-type type="const-GtkWidgetPath*" />
+        <parameters>
+          <parameter type="gint" name="pos" />
+        </parameters>
+      </method>
+      <method name="IterGetState" cname="gtk_widget_path_iter_get_state">
+        <return-type type="GtkStateFlags" />
         <parameters>
           <parameter type="gint" name="pos" />
         </parameters>
@@ -27533,7 +31641,7 @@
           <parameter type="GQuark" name="qname" />
         </parameters>
       </method>
-      <method name="IterHasQregion" cname="gtk_widget_path_iter_has_qregion">
+      <method name="IterHasQregion" cname="gtk_widget_path_iter_has_qregion" deprecated="1">
         <return-type type="gboolean" />
         <parameters>
           <parameter type="gint" name="pos" />
@@ -27541,7 +31649,7 @@
           <parameter type="GtkRegionFlags*" name="flags" />
         </parameters>
       </method>
-      <method name="IterHasRegion" cname="gtk_widget_path_iter_has_region">
+      <method name="IterHasRegion" cname="gtk_widget_path_iter_has_region" deprecated="1">
         <return-type type="gboolean" />
         <parameters>
           <parameter type="gint" name="pos" />
@@ -27555,7 +31663,7 @@
           <parameter type="gint" name="pos" />
         </parameters>
       </method>
-      <method name="IterListRegions" cname="gtk_widget_path_iter_list_regions">
+      <method name="IterListRegions" cname="gtk_widget_path_iter_list_regions" deprecated="1">
         <return-type type="GSList*" />
         <parameters>
           <parameter type="gint" name="pos" />
@@ -27568,7 +31676,7 @@
           <parameter type="const-gchar*" name="name" />
         </parameters>
       </method>
-      <method name="IterRemoveRegion" cname="gtk_widget_path_iter_remove_region">
+      <method name="IterRemoveRegion" cname="gtk_widget_path_iter_remove_region" deprecated="1">
         <return-type type="void" />
         <parameters>
           <parameter type="gint" name="pos" />
@@ -27589,6 +31697,13 @@
           <parameter type="GType" name="type" />
         </parameters>
       </method>
+      <method name="IterSetState" cname="gtk_widget_path_iter_set_state">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="gint" name="pos" />
+          <parameter type="GtkStateFlags" name="state" />
+        </parameters>
+      </method>
       <method name="Length" cname="gtk_widget_path_length">
         <return-type type="gint" />
       </method>
@@ -27599,10 +31714,21 @@
           <parameter type="GType" name="type" />
         </parameters>
       </method>
+      <method name="Ref" cname="gtk_widget_path_ref">
+        <return-type type="GtkWidgetPath*" />
+      </method>
+      <method name="ToString" cname="gtk_widget_path_to_string">
+        <return-type type="char*" />
+      </method>
+      <method name="Unref" cname="gtk_widget_path_unref">
+        <return-type type="void" />
+      </method>
     </boxed>
     <struct name="WindowGeometryInfo" cname="GtkWindowGeometryInfo" opaque="true" />
     <struct name="WindowKeyEntry" cname="GtkWindowKeyEntry" opaque="true" />
+    <struct name="WindowPopover" cname="GtkWindowPopover" opaque="true" />
     <struct name="XEmbedMessage" cname="GtkXEmbedMessage" opaque="true" />
+    <struct name="HandleWindow" cname="HandleWindow" opaque="true" />
     <struct name="HashNode" cname="HashNode" opaque="true" />
     <struct name="IconAlias" cname="IconAlias" opaque="true" />
     <struct name="IconSize" cname="IconSize" opaque="true" />
@@ -27610,10 +31736,10 @@
     <struct name="Node" cname="Node" opaque="true" />
     <struct name="NodeUIReference" cname="NodeUIReference" opaque="true" />
     <struct name="ParseContext" cname="ParseContext" opaque="true" />
+    <struct name="PointData" cname="PointData" opaque="true" />
     <struct name="PrintPagesData" cname="PrintPagesData" opaque="true" />
     <struct name="PrinterFinder" cname="PrinterFinder" opaque="true" />
     <struct name="PropertyData" cname="PropertyData" opaque="true" />
-    <struct name="PropertyNode" cname="PropertyNode" opaque="true" />
     <struct name="PropertyValue" cname="PropertyValue" opaque="true" />
     <struct name="Range" cname="Range" opaque="true" />
     <struct name="RequestContentsInfo" cname="RequestContentsInfo" opaque="true" />
@@ -27623,22 +31749,18 @@
     <struct name="RequestTextInfo" cname="RequestTextInfo" opaque="true" />
     <struct name="RequestURIInfo" cname="RequestURIInfo" opaque="true" />
     <struct name="ResponseData" cname="ResponseData" opaque="true" />
-    <struct name="SelectorElement" cname="SelectorElement" opaque="true" />
-    <struct name="SelectorPath" cname="SelectorPath" opaque="true" />
-    <struct name="SelectorStyleInfo" cname="SelectorStyleInfo" opaque="true" />
-    <struct name="SettingsIconSize" cname="SettingsIconSize" opaque="true" />
     <struct name="SharedData" cname="SharedData" opaque="true" />
     <struct name="SortData" cname="SortData" opaque="true" />
     <struct name="SortElt" cname="SortElt" opaque="true" />
     <struct name="SortLevel" cname="SortLevel" opaque="true" />
-    <struct name="SortTuple" cname="SortTuple" opaque="true" />
-    <struct name="StyleData" cname="StyleData" opaque="true" />
-    <struct name="StylePriorityInfo" cname="StylePriorityInfo" opaque="true" />
     <struct name="StylePropertyValue" cname="StylePropertyValue" opaque="true" />
+    <struct name="SymbolicPixbufCache" cname="SymbolicPixbufCache" opaque="true" />
     <struct name="ToolbarContent" cname="ToolbarContent" opaque="true" />
+    <struct name="TransitionInfo" cname="TransitionInfo" opaque="true" />
     <struct name="TreeRowData" cname="TreeRowData" opaque="true" />
     <struct name="TreeViewDragInfo" cname="TreeViewDragInfo" opaque="true" />
     <struct name="ValueData" cname="ValueData" opaque="true" />
+    <struct name="WidgetPropertyValue" cname="WidgetPropertyValue" opaque="true" />
     <class name="Accel" cname="GtkAccel_">
       <method name="GroupsActivate" cname="gtk_accel_groups_activate" shared="true">
         <return-type type="gboolean" />
@@ -27666,10 +31788,28 @@
           <parameter type="GdkModifierType" name="accelerator_mods" />
         </parameters>
       </method>
+      <method name="GetLabelWithKeycode" cname="gtk_accelerator_get_label_with_keycode" shared="true">
+        <return-type type="gchar*" />
+        <parameters>
+          <parameter type="GdkDisplay*" name="display" />
+          <parameter type="guint" name="accelerator_key" />
+          <parameter type="guint" name="keycode" />
+          <parameter type="GdkModifierType" name="accelerator_mods" />
+        </parameters>
+      </method>
       <method name="Name" cname="gtk_accelerator_name" shared="true">
         <return-type type="gchar*" />
         <parameters>
           <parameter type="guint" name="accelerator_key" />
+          <parameter type="GdkModifierType" name="accelerator_mods" />
+        </parameters>
+      </method>
+      <method name="NameWithKeycode" cname="gtk_accelerator_name_with_keycode" shared="true">
+        <return-type type="gchar*" />
+        <parameters>
+          <parameter type="GdkDisplay*" name="display" />
+          <parameter type="guint" name="accelerator_key" />
+          <parameter type="guint" name="keycode" />
           <parameter type="GdkModifierType" name="accelerator_mods" />
         </parameters>
       </method>
@@ -27678,6 +31818,15 @@
         <parameters>
           <parameter type="const-gchar*" name="accelerator" />
           <parameter type="guint*" name="accelerator_key" />
+          <parameter type="GdkModifierType*" name="accelerator_mods" />
+        </parameters>
+      </method>
+      <method name="ParseWithKeycode" cname="gtk_accelerator_parse_with_keycode" shared="true">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="const-gchar*" name="accelerator" />
+          <parameter type="guint*" name="accelerator_key" />
+          <parameter type="guint**" name="accelerator_codes" />
           <parameter type="GdkModifierType*" name="accelerator_mods" />
         </parameters>
       </method>
@@ -27696,7 +31845,7 @@
       </method>
     </class>
     <class name="Global" cname="GtkGlobal">
-      <method name="AlternativeDialogButtonOrder" cname="gtk_alternative_dialog_button_order" shared="true">
+      <method name="AlternativeDialogButtonOrder" cname="gtk_alternative_dialog_button_order" deprecated="1" shared="true">
         <return-type type="gboolean" />
         <parameters>
           <parameter type="GdkScreen*" name="screen" />
@@ -27721,7 +31870,7 @@
           <parameter type="GtkRequestedSize*" name="sizes" />
         </parameters>
       </method>
-      <method name="DrawInsertionCursor" cname="gtk_draw_insertion_cursor" shared="true">
+      <method name="DrawInsertionCursor" cname="gtk_draw_insertion_cursor" deprecated="1" shared="true">
         <return-type type="void" />
         <parameters>
           <parameter type="GtkWidget*" name="widget" />
@@ -27776,6 +31925,9 @@
       </method>
       <method name="GetInterfaceAge" cname="gtk_get_interface_age" shared="true">
         <return-type type="guint" />
+      </method>
+      <method name="GetLocaleDirection" cname="gtk_get_locale_direction" shared="true">
+        <return-type type="GtkTextDirection" />
       </method>
       <method name="GetMajorVersion" cname="gtk_get_major_version" shared="true">
         <return-type type="guint" />
@@ -28196,7 +32348,7 @@
       </method>
     </class>
     <class name="Drag" cname="GtkDrag_">
-      <method name="Begin" cname="gtk_drag_begin" shared="true">
+      <method name="Begin" cname="gtk_drag_begin" deprecated="1" shared="true">
         <return-type type="GdkDragContext*" />
         <parameters>
           <parameter type="GtkWidget*" name="widget" />
@@ -28204,6 +32356,18 @@
           <parameter type="GdkDragAction" name="actions" />
           <parameter type="gint" name="button" />
           <parameter type="GdkEvent*" name="event" />
+        </parameters>
+      </method>
+      <method name="BeginWithCoordinates" cname="gtk_drag_begin_with_coordinates" shared="true">
+        <return-type type="GdkDragContext*" />
+        <parameters>
+          <parameter type="GtkWidget*" name="widget" />
+          <parameter type="GtkTargetList*" name="targets" />
+          <parameter type="GdkDragAction" name="actions" />
+          <parameter type="gint" name="button" />
+          <parameter type="GdkEvent*" name="event" />
+          <parameter type="gint" name="x" />
+          <parameter type="gint" name="y" />
         </parameters>
       </method>
       <method name="CheckThreshold" cname="gtk_drag_check_threshold" shared="true">
@@ -28329,6 +32493,15 @@
           <parameter type="GdkDragContext*" name="context" />
         </parameters>
       </method>
+      <method name="SetIconGicon" cname="gtk_drag_set_icon_gicon" shared="true">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GdkDragContext*" name="context" />
+          <parameter type="GIcon*" name="icon" />
+          <parameter type="gint" name="hot_x" />
+          <parameter type="gint" name="hot_y" />
+        </parameters>
+      </method>
       <method name="SetIconName" cname="gtk_drag_set_icon_name" shared="true">
         <return-type type="void" />
         <parameters>
@@ -28347,7 +32520,7 @@
           <parameter type="gint" name="hot_y" />
         </parameters>
       </method>
-      <method name="SetIconStock" cname="gtk_drag_set_icon_stock" shared="true">
+      <method name="SetIconStock" cname="gtk_drag_set_icon_stock" deprecated="1" shared="true">
         <return-type type="void" />
         <parameters>
           <parameter type="GdkDragContext*" name="context" />
@@ -28406,6 +32579,13 @@
           <parameter type="GdkDragAction" name="actions" />
         </parameters>
       </method>
+      <method name="SourceSetIconGicon" cname="gtk_drag_source_set_icon_gicon" shared="true">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkWidget*" name="widget" />
+          <parameter type="GIcon*" name="icon" />
+        </parameters>
+      </method>
       <method name="SourceSetIconName" cname="gtk_drag_source_set_icon_name" shared="true">
         <return-type type="void" />
         <parameters>
@@ -28420,7 +32600,7 @@
           <parameter type="GdkPixbuf*" name="pixbuf" />
         </parameters>
       </method>
-      <method name="SourceSetIconStock" cname="gtk_drag_source_set_icon_stock" shared="true">
+      <method name="SourceSetIconStock" cname="gtk_drag_source_set_icon_stock" deprecated="1" shared="true">
         <return-type type="void" />
         <parameters>
           <parameter type="GtkWidget*" name="widget" />
@@ -28465,13 +32645,13 @@
       </method>
     </class>
     <class name="Icon" cname="GtkIcon_">
-      <method name="SizeFromName" cname="gtk_icon_size_from_name" shared="true">
+      <method name="SizeFromName" cname="gtk_icon_size_from_name" deprecated="1" shared="true">
         <return-type type="GtkIconSize" />
         <parameters>
           <parameter type="const-gchar*" name="name" />
         </parameters>
       </method>
-      <method name="SizeGetName" cname="gtk_icon_size_get_name" shared="true">
+      <method name="SizeGetName" cname="gtk_icon_size_get_name" deprecated="1" shared="true">
         <return-type type="const-gchar*" />
         <parameters>
           <parameter type="GtkIconSize" name="size" />
@@ -28485,7 +32665,7 @@
           <parameter type="gint*" name="height" />
         </parameters>
       </method>
-      <method name="SizeLookupForSettings" cname="gtk_icon_size_lookup_for_settings" shared="true">
+      <method name="SizeLookupForSettings" cname="gtk_icon_size_lookup_for_settings" deprecated="1" shared="true">
         <return-type type="gboolean" />
         <parameters>
           <parameter type="GtkSettings*" name="settings" />
@@ -28494,7 +32674,7 @@
           <parameter type="gint*" name="height" />
         </parameters>
       </method>
-      <method name="SizeRegister" cname="gtk_icon_size_register" shared="true">
+      <method name="SizeRegister" cname="gtk_icon_size_register" deprecated="1" shared="true">
         <return-type type="GtkIconSize" />
         <parameters>
           <parameter type="const-gchar*" name="name" />
@@ -28502,7 +32682,7 @@
           <parameter type="gint" name="height" />
         </parameters>
       </method>
-      <method name="SizeRegisterAlias" cname="gtk_icon_size_register_alias" shared="true">
+      <method name="SizeRegisterAlias" cname="gtk_icon_size_register_alias" deprecated="1" shared="true">
         <return-type type="void" />
         <parameters>
           <parameter type="const-gchar*" name="alias" />
@@ -28551,14 +32731,14 @@
       </method>
     </class>
     <class name="Key" cname="GtkKey_">
-      <method name="SnooperInstall" cname="gtk_key_snooper_install" shared="true">
+      <method name="SnooperInstall" cname="gtk_key_snooper_install" deprecated="1" shared="true">
         <return-type type="guint" />
         <parameters>
           <parameter type="GtkKeySnoopFunc" name="snooper" />
           <parameter type="gpointer" name="func_data" />
         </parameters>
       </method>
-      <method name="SnooperRemove" cname="gtk_key_snooper_remove" shared="true">
+      <method name="SnooperRemove" cname="gtk_key_snooper_remove" deprecated="1" shared="true">
         <return-type type="void" />
         <parameters>
           <parameter type="guint" name="snooper_handler_id" />
@@ -28589,6 +32769,14 @@
       </method>
     </class>
     <class name="Print" cname="GtkPrint_">
+      <method name="ActionAndTarget" cname="gtk_print_action_and_target" shared="true">
+        <return-type type="gchar*" />
+        <parameters>
+          <parameter type="const-gchar*" name="action_namespace" />
+          <parameter type="const-gchar*" name="action_name" />
+          <parameter type="GVariant*" name="target" />
+        </parameters>
+      </method>
       <method name="ErrorQuark" cname="gtk_print_error_quark" shared="true">
         <return-type type="GQuark" />
       </method>
@@ -28844,12 +33032,44 @@
           <parameter type="gdouble" name="height" />
         </parameters>
       </method>
-      <method name="IconPixbuf" cname="gtk_render_icon_pixbuf" shared="true">
+      <method name="Icon" cname="gtk_render_icon" shared="true">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkStyleContext*" name="context" />
+          <parameter type="cairo_t*" name="cr" />
+          <parameter type="GdkPixbuf*" name="pixbuf" />
+          <parameter type="gdouble" name="x" />
+          <parameter type="gdouble" name="y" />
+        </parameters>
+      </method>
+      <method name="IconPixbuf" cname="gtk_render_icon_pixbuf" deprecated="1" shared="true">
         <return-type type="GdkPixbuf*" />
         <parameters>
           <parameter type="GtkStyleContext*" name="context" />
           <parameter type="const-GtkIconSource*" name="source" />
           <parameter type="GtkIconSize" name="size" />
+        </parameters>
+      </method>
+      <method name="IconSurface" cname="gtk_render_icon_surface" shared="true">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkStyleContext*" name="context" />
+          <parameter type="cairo_t*" name="cr" />
+          <parameter type="cairo_surface_t*" name="surface" />
+          <parameter type="gdouble" name="x" />
+          <parameter type="gdouble" name="y" />
+        </parameters>
+      </method>
+      <method name="InsertionCursor" cname="gtk_render_insertion_cursor" shared="true">
+        <return-type type="void" />
+        <parameters>
+          <parameter type="GtkStyleContext*" name="context" />
+          <parameter type="cairo_t*" name="cr" />
+          <parameter type="gdouble" name="x" />
+          <parameter type="gdouble" name="y" />
+          <parameter type="PangoLayout*" name="layout" />
+          <parameter type="int" name="index" />
+          <parameter type="PangoDirection" name="direction" />
         </parameters>
       </method>
       <method name="Layout" cname="gtk_render_layout" shared="true">
@@ -28957,31 +33177,31 @@
       </method>
     </class>
     <class name="Stock" cname="GtkStock_">
-      <method name="Add" cname="gtk_stock_add" shared="true">
+      <method name="Add" cname="gtk_stock_add" deprecated="1" shared="true">
         <return-type type="void" />
         <parameters>
           <parameter type="const-GtkStockItem*" name="items" />
           <parameter type="guint" name="n_items" />
         </parameters>
       </method>
-      <method name="AddStatic" cname="gtk_stock_add_static" shared="true">
+      <method name="AddStatic" cname="gtk_stock_add_static" deprecated="1" shared="true">
         <return-type type="void" />
         <parameters>
           <parameter type="const-GtkStockItem*" name="items" />
           <parameter type="guint" name="n_items" />
         </parameters>
       </method>
-      <method name="ListIds" cname="gtk_stock_list_ids" shared="true">
+      <method name="ListIds" cname="gtk_stock_list_ids" deprecated="1" shared="true">
         <return-type type="GSList*" />
       </method>
-      <method name="Lookup" cname="gtk_stock_lookup" shared="true">
+      <method name="Lookup" cname="gtk_stock_lookup" deprecated="1" shared="true">
         <return-type type="gboolean" />
         <parameters>
           <parameter type="const-gchar*" name="stock_id" />
           <parameter type="GtkStockItem*" name="item" />
         </parameters>
       </method>
-      <method name="SetTranslateFunc" cname="gtk_stock_set_translate_func" shared="true">
+      <method name="SetTranslateFunc" cname="gtk_stock_set_translate_func" deprecated="1" shared="true">
         <return-type type="void" />
         <parameters>
           <parameter type="const-gchar*" name="domain" />

--- a/sample/GtkDemo/Makefile.am
+++ b/sample/GtkDemo/Makefile.am
@@ -21,7 +21,6 @@ sources = \
 	DemoButtonBox.cs		\
 	DemoClipboard.cs		\
 	DemoColorSelection.cs	\
-	DemoCssBasics.cs		\
 	DemoDialog.cs			\
 	DemoDrawingArea.cs		\
 	DemoEditableCells.cs	\

--- a/sources/Makefile.am
+++ b/sources/Makefile.am
@@ -1,26 +1,32 @@
 EXTRA_DIST =					\
 	README					\
 	sources.xml				\
-	gtk_tree_model_signal_fix.patch
+	gtk_tree_model_signal_fix.patch		\
+	gtkselectionprivate-space.patch		\
+	gtktextattributes-gi-scanner.patch	\
+	gtk_text_view_public.patch
 
-TARGET_GTK_VERSION=3.0.0
+TARGET_GTK_VERSION=3.14.15
 
 GTK_DOWNLOADS = \
 	http://ftp.gnome.org/pub/GNOME/sources/glib/2.42/glib-2.42.2.tar.xz			\
 	http://ftp.gnome.org/pub/GNOME/sources/pango/1.36/pango-1.36.8.tar.xz			\
 	http://ftp.gnome.org/pub/GNOME/sources/atk/2.14/atk-2.14.0.tar.xz			\
 	http://ftp.gnome.org/pub/GNOME/sources/gdk-pixbuf/2.30/gdk-pixbuf-2.30.8.tar.xz		\
-	http://ftp.gnome.org/pub/GNOME/sources/gtk+/3.0/gtk+-$(TARGET_GTK_VERSION).tar.bz2
+	http://ftp.gnome.org/pub/GNOME/sources/gtk+/3.14/gtk+-$(TARGET_GTK_VERSION).tar.xz
 
 api: 
 	PATH=../parser:$$PATH $(RUNTIME) ../parser/gapi-parser.exe sources.xml
 
 get-source-code:
 	for i in $(GTK_DOWNLOADS); do                  \
-		wget $$i --output-document=- | tar -xj ;   \
+		wget $$i --output-document=- | tar -xJ ;   \
 	done;
 	ln -f -s gtkfilechooserprivate.h gtk+-$(TARGET_GTK_VERSION)/gtk/gtkfilechooserpriv.h
 	patch -p0 gtk+-$(TARGET_GTK_VERSION)/gtk/gtktreemodel.c < gtk_tree_model_signal_fix.patch
+	patch -p0 gtk+-$(TARGET_GTK_VERSION)/gtk/gtkselectionprivate.h < gtkselectionprivate-space.patch
+	patch -p0 gtk+-$(TARGET_GTK_VERSION)/gtk/gtktextattributes.h < gtktextattributes-gi-scanner.patch
+	patch -p0 gtk+-$(TARGET_GTK_VERSION)/gtk/gtktextview.h < gtk_text_view_public.patch
 	echo "typedef struct _GtkClipboard GtkClipboard;" >> gtk+-$(TARGET_GTK_VERSION)/gtk/gtkclipboard.h
 	echo "typedef struct _GtkClipboardClass GtkClipboardClass;" >> gtk+-$(TARGET_GTK_VERSION)/gtk/gtkclipboard.h
 

--- a/sources/gtk_text_view_public.patch
+++ b/sources/gtk_text_view_public.patch
@@ -1,0 +1,11 @@
+--- gtk+-3.16.6.orig/gtk/gtktextview.h	2015-09-04 11:37:38.035020919 +0200
++++ gtk+-3.16.6/gtk/gtktextview.h	2015-09-04 11:38:59.958096121 +0200
+@@ -155,8 +155,6 @@
+ {
+   GtkContainerClass parent_class;
+ 
+-  /*< public */
+-
+   void (* populate_popup)        (GtkTextView      *text_view,
+                                   GtkWidget        *popup);
+   void (* move_cursor)           (GtkTextView      *text_view,

--- a/sources/gtkselectionprivate-space.patch
+++ b/sources/gtkselectionprivate-space.patch
@@ -1,0 +1,11 @@
+--- gtk+-3.12.0.orig/gtk/gtkselectionprivate.h	2014-06-10 09:14:53.055629108 +0200
++++ gtk+-3.12.0/gtk/gtkselectionprivate.h	2014-06-10 09:14:59.503650175 +0200
+@@ -52,7 +52,7 @@
+   /*< private >*/
+   GList *list;
+   guint ref_count;
+- };
++};
+ 
+ gboolean _gtk_selection_clear           (GtkWidget         *widget,
+                                          GdkEventSelection *event);

--- a/sources/gtktextattributes-gi-scanner.patch
+++ b/sources/gtktextattributes-gi-scanner.patch
@@ -1,0 +1,29 @@
+--- gtk+-3.12.0/gtk/gtktextattributes.h	2014-03-24 18:28:56.000000000 +0100
++++ gtk+-3.12.0.new/gtk/gtktextattributes.h	2014-06-10 13:49:44.619905956 +0200
+@@ -112,26 +112,12 @@
+   guint inside_selection : 1;
+   guint is_text : 1;
+ 
+-  /* For the sad story of this bit of code, see
+-   * https://bugzilla.gnome.org/show_bug.cgi?id=711158
+-   */
+-#ifdef __GI_SCANNER__
+-  /* The scanner should only see the transparent union, so that its
+-   * content does not vary across architectures.
+-   */
+-  union {
+-    GdkRGBA *rgba[2];
+-    /*< private >*/
+-    guint padding[4];
+-  };
+-#else
+   GdkRGBA *rgba[2];
+ #if (defined(__SIZEOF_INT__) && defined(__SIZEOF_POINTER__)) && (__SIZEOF_INT__ == __SIZEOF_POINTER__)
+   /* unusable, just for ABI compat */
+   /*< private >*/
+   guint padding[2];
+ #endif
+-#endif
+ };
+ 
+ /**

--- a/sources/sources.xml
+++ b/sources/sources.xml
@@ -143,11 +143,12 @@
   <api filename="../gdk/gdk-api.raw">
     <library name="libgdk-3-0.dll">
       <namespace name="Gdk">
-        <directory path="gtk+-3.0.0/gdk">
+        <directory path="gtk+-3.14.15/gdk">
           <exclude>gdkalias.h</exclude>
           <exclude>gdkwindowimpl.h</exclude>
           <exclude>keyname-table.h</exclude>
         </directory>
+        <directory path="gtk+-3.14.15/gdk/deprecated" />
       </namespace>
     </library>
     <library name="libgdk_pixbuf-2.0-0.dll">
@@ -167,7 +168,7 @@
   <api filename="../gtk/gtk-api.raw">
     <library name="libgtk-3-0.dll">
       <namespace name="Gtk">
-        <directory path="gtk+-3.0.0/gtk">
+        <directory path="gtk+-3.14.15/gtk">
           <!-- Internal stuff -->
           <exclude>gtkalias.h</exclude>
           <exclude>gtkappchooseronline.h</exclude>
@@ -260,7 +261,10 @@
           <exclude>gtktree.h</exclude>
           <exclude>gtktreeitem.c</exclude>
           <exclude>gtktreeitem.h</exclude>
+          <exclude>gtkcellarea.c</exclude>
+          <exclude>gtklockbutton.h</exclude>
         </directory>
+        <directory path="gtk+-3.14.15/gtk/deprecated" />
       </namespace>
     </library>
   </api>


### PR DESCRIPTION
Based on the patches from Mikkel Kruse Johnsen.

See that the CSS demo is currently disabled since the CssProvider
is not properly picked up for some reason. We will need to research
a bit on this but for now it is good enough doing it without.
