### PR TITLE
enable custom code of GtkBuilder for auto binding support

### DIFF
--- a/gtk/Builder.custom
+++ b/gtk/Builder.custom
@@ -23,7 +23,6 @@
 // Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 // Boston, MA 02111-1307, USA.
 
-#if GTK_SHARP_2_14
 
 [System.Serializable]
 public class HandlerNotFoundException : SystemException
@@ -412,4 +411,3 @@ void BindFields (object target, Type type)
 	while (type != typeof(object) && type != null);
 }
 
-#endif


### PR DESCRIPTION
[The GtkBuilder class _is_ already part of the GTK+ 2.12 API] [0]. Only 2
functions were added in 2.14 which we do not generate or use. The GtkBuilder
class is already shipped in GTK#2 but the custom code was disabled, which
provides a reflection based auto binder. I have tested the auto binder and it
works perfectly. [The same code is used in the GTK#3 branch] [1] btw.

 [0]: https://developer.gnome.org/gtk2/stable/GtkBuilder.html#gtk-builder-new
 [1]: https://github.com/mono/gtk-sharp/blob/master/gtk/Builder.cs