### PR TITLE
[Generator] Don't try to reconstruct the value on a struct parameter …

### DIFF
--- a/generator/Parameters.cs
+++ b/generator/Parameters.cs
@@ -488,9 +488,12 @@ namespace GtkSharp.Generation {
 
 		public override string[] Finish {
 			get {
-				string[] result = new string [2];
-				result [0] = CallName + " = " + FromNative ("native_" + CallName) + ";";
-				result [1] = (Generatable as IManualMarshaler).ReleaseNative ("native_" + CallName) + ";";
+				string[] result = new string [PassAs == string.Empty ? 1 : 2];
+				int i = 0;
+				if (PassAs != string.Empty) {
+					result [i++] = CallName + " = " + FromNative ("native_" + CallName) + ";";
+				}
+				result [i++] = (Generatable as IManualMarshaler).ReleaseNative ("native_" + CallName) + ";";
 				return result;
 			}
 		}


### PR DESCRIPTION
…passed by value

In the case of TreeStore.GetValue, the generated code would try to assign
iter to the value that was marshalled back from native.

This behaviour is incorrect, as the struct was passed by value, and
discarded, having no effect on the code-flow but useless overhead.
```
public void GetValue(Gtk.TreeIter, int column, ref GLib.Value value) {
	IntPtr native_iter = GLib.Marshaller.StructureToPtrAlloc (iter);
	IntPtr native_value = GLib.Marshaller.StructureToPtrAlloc (value);
	gtk_tree_model_get_value(Handle, native_iter, column, native_value);
	// The line below is removed.
	native_iter = TreeIter.New (native_iter);
	Marshal.FreeHGlobal (native_iter);
	value = (GLib.Value) Marshal.PtrToStructure (native_value, typeof (GLib.Value));
	Marshal.FreeHGlobal (native_value);
}
```