### PR TITLE
Generator: ByRef generator now passes the value by ref

### DIFF
--- a/generator/ByRefGen.cs
+++ b/generator/ByRefGen.cs
@@ -24,39 +24,14 @@ namespace GtkSharp.Generation {
 
 	using System;
 
-	public class ByRefGen : SimpleBase, IManualMarshaler {
+	public class ByRefGen : SimpleBase {
 		
 		public ByRefGen (string ctype, string type) : base (ctype, type, type + ".Empty") {}
 		
 		public override string MarshalType {
 			get {
-				return "IntPtr";
+				return "ref " + QualifiedName;
 			}
-		}
-
-		public override string CallByName (string var_name)
-		{
-			return "native_" + var_name;
-		}
-		
-		public string AllocNative ()
-		{
-			return "Marshal.AllocHGlobal (Marshal.SizeOf (typeof (" + QualifiedName + ")))";
-		}
-
-		public string AllocNative (string var_name)
-		{
-			return "GLib.Marshaller.StructureToPtrAlloc (" + var_name + ")";
-		}
-
-		public override string FromNative (string var_name)
-		{
-			return String.Format ("({0}) Marshal.PtrToStructure ({1}, typeof ({0}))", QualifiedName, var_name);
-		}
-
-		public string ReleaseNative (string var_name)
-		{
-			return "Marshal.FreeHGlobal (" + var_name + ")";
 		}
 	}
 }

--- a/generator/ManagedCallString.cs
+++ b/generator/ManagedCallString.cs
@@ -139,9 +139,9 @@ namespace GtkSharp.Generation {
 
 				if (igen is CallbackGen)
 					continue;
-				else if (igen is StructBase || igen is ByRefGen)
+				else if (igen is StructBase)
 					ret += indent + String.Format ("if ({0} != IntPtr.Zero) System.Runtime.InteropServices.Marshal.StructureToPtr (my{0}, {0}, false);\n", p.Name);
-				else
+				else if (!(igen is ByRefGen))
 					ret += indent + p.Name + " = " + igen.ToNativeReturn ("my" + p.Name) + ";\n";
 			}
 

--- a/generator/Parameters.cs
+++ b/generator/Parameters.cs
@@ -505,6 +505,42 @@ namespace GtkSharp.Generation {
 		}
 	}
 
+	public class ByRefParameter : Parameter
+	{
+
+		public ByRefParameter (XmlElement elem) : base (elem) { }
+
+		public override string MarshalType {
+			get {
+				return "ref " + CallName;
+			}
+		}
+
+		public override string [] Prepare {
+			get {
+				return new string [0];
+			}
+		}
+
+		public override string CallString {
+			get {
+				return "ref " + CallName;
+			}
+		}
+
+		public override string [] Finish {
+			get {
+				return new string [0];
+			}
+		}
+
+		public override string NativeSignature {
+			get {
+				return "ref " + CSType + " " + CallName;
+			}
+		}
+	}
+
 	public class Parameters : IEnumerable {
 		
 		ArrayList param_list = new ArrayList ();
@@ -663,8 +699,10 @@ namespace GtkSharp.Generation {
 					}
 				} else if (p.CType == "GError**")
 					p = new ErrorParameter (parm);
-				else if (gen is StructBase || gen is ByRefGen) {
+				else if (gen is StructBase) {
 					p = new StructParameter (parm);
+				} else if (gen is ByRefGen) {
+					p = new ByRefParameter (parm);
 				} else if (gen is CallbackGen) {
 					has_cb = true;
 				}


### PR DESCRIPTION
This avoid an extra heap allocation for each object passed by ref so it can be transitioned directly into native memory. Native counterparts will handle data mutation, so managed will see it anyway.

https://gist.github.com/Therzok/f0627b87a5f89c1e3e5b2aab58b59b08

Don't merge yet, as I need to test it.