### PR TITLE
Updated Mono Hand Book link from outdated docs

### DIFF
--- a/README
+++ b/README
@@ -96,7 +96,7 @@ Developers:
     For developers wishing to "get started" with Gtk#, they are encouraged
     to read the Mono Hand Book:
 
-        http://www.mono-project.com/Monkeyguide
+        http://www.mono-project.com/docs/gui/gtksharp/
 
 
 Hackers:


### PR DESCRIPTION
Link for getting started with Gtk went to outdated generic mono documentation.