### PR TITLE
[Gen] Always free strdup strings as they're not held by native

### DIFF
--- a/generator/MarshalGen.cs
+++ b/generator/MarshalGen.cs
@@ -60,5 +60,22 @@ namespace GtkSharp.Generation {
 			return String.Format (from_fmt, var);
 		}
 	}
+
+	public class StringMarshalGen : MarshalGen, IManualMarshaler
+	{
+		public StringMarshalGen (string ctype, string type, string mtype, string call_fmt, string from_fmt) : base (ctype, type, mtype, call_fmt, from_fmt, true)
+		{
+		}
+
+		public string AllocNative (string managed_var)
+		{
+			return CallByName (managed_var);
+		}
+
+		public string ReleaseNative (string native_var)
+		{
+			return string.Format ("GLib.Marshaller.Free ({0})", native_var);
+		}
+	}
 }
 

--- a/generator/SymbolTable.cs
+++ b/generator/SymbolTable.cs
@@ -107,9 +107,9 @@ namespace GtkSharp.Generation {
 			AddType (new ConstStringGen ("const-xmlChar"));
 			AddType (new ConstStringGen ("const-char"));
 			AddType (new ConstFilenameGen ("const-gfilename"));
-			AddType (new MarshalGen ("gfilename", "string", "IntPtr", "GLib.Marshaller.StringToFilenamePtr({0})", "GLib.Marshaller.FilenamePtrToStringGFree({0})"));
-			AddType (new MarshalGen ("gchar", "string", "IntPtr", "GLib.Marshaller.StringToPtrGStrdup({0})", "GLib.Marshaller.PtrToStringGFree({0})"));
-			AddType (new MarshalGen ("char", "string", "IntPtr", "GLib.Marshaller.StringToPtrGStrdup({0})", "GLib.Marshaller.PtrToStringGFree({0})"));
+			AddType (new StringMarshalGen ("gfilename", "string", "IntPtr", "GLib.Marshaller.StringToFilenamePtr({0})", "GLib.Marshaller.FilenamePtrToStringGFree({0})"));
+			AddType (new StringMarshalGen ("gchar", "string", "IntPtr", "GLib.Marshaller.StringToPtrGStrdup({0})", "GLib.Marshaller.PtrToStringGFree({0})"));
+			AddType (new StringMarshalGen ("char", "string", "IntPtr", "GLib.Marshaller.StringToPtrGStrdup({0})", "GLib.Marshaller.PtrToStringGFree({0})"));
 			AddType (new SimpleGen ("GStrv", "string[]", "null"));
 
 			// manually wrapped types requiring more complex marshaling


### PR DESCRIPTION
This fixes a few leaks caused by gstrdup-ing by firing and forgetting.

https://gist.github.com/Therzok/822d377e69476d172f434aa79ef74aed