### PR TITLE
glib: negate Marshaller compiler define

### DIFF
--- a/configure.in.in
+++ b/configure.in.in
@@ -234,8 +234,8 @@ AM_CONDITIONAL(ENABLE_MONOGETOPTIONS, test "x$has_mono" = "xtrue")
 
 CSFLAGS="$DEBUG_FLAGS $CSDEFINES $WIN64DEFINES -unsafe"
 
-if test "x$NET_4_6_SUPPORT" = "xtrue" ; then
-  CSFLAGS="$CSFLAGS -define:HAVE_NET_4_6"
+if test "x$NET_4_6_SUPPORT" = "xfalse" ; then
+  CSFLAGS="$CSFLAGS -define:UTF8_SLOW_PATH"
 fi
 PKG_CHECK_MODULES(GLIB_2_31,
   glib-2.0 >= 2.31,

--- a/glib/Marshaller.cs
+++ b/glib/Marshaller.cs
@@ -84,16 +84,17 @@ namespace GLib {
 				return null;
 
 			int len = (int) (uint)glibsharp_strlen (ptr);
-#if HAVE_NET_4_6
+
+#if UTF8_SLOW_PATH
+			byte [] bytes = new byte [len];
+			Marshal.Copy (ptr, bytes, 0, len);
+			return System.Text.Encoding.UTF8.GetString (bytes);
+#else
 			unsafe
 			{
 				var p = (byte*)ptr;
 				return System.Text.Encoding.UTF8.GetString (p, len);
 			}
-#else
-			byte [] bytes = new byte [len];
-			Marshal.Copy (ptr, bytes, 0, len);
-			return System.Text.Encoding.UTF8.GetString (bytes);
 #endif
 		}
 


### PR DESCRIPTION
So that the define is only enabled with the old mono
version, and no define is needed for modern versions.