### PR TITLE
Leak fixes

### DIFF
--- a/glib/Object.cs
+++ b/glib/Object.cs
@@ -35,7 +35,6 @@ namespace GLib {
 		IntPtr handle;
 		ToggleRef tref;
 		bool disposed = false;
-		bool owned = true;
 		Hashtable data;
 		static Dictionary<IntPtr, ToggleRef> Objects = new Dictionary<IntPtr, ToggleRef>();
 		static object lockObject = new object ();
@@ -95,8 +94,7 @@ namespace GLib {
 				Console.WriteLine ("Exception while disposing a " + this + " in Gtk#");
 				throw e;
 			}
-			if (owned)
-				g_object_unref (handle);
+			g_object_unref (handle);
 			handle = IntPtr.Zero;
 			GC.SuppressFinalize (this);
 		}
@@ -144,7 +142,6 @@ namespace GLib {
 				return null;
 			}
 
-			obj.owned = owned_ref;
 			return obj;
 		}
 

--- a/glib/Object.cs
+++ b/glib/Object.cs
@@ -135,6 +135,9 @@ namespace GLib {
 				return obj;
 			}
 
+			if (!owned_ref)
+				g_object_ref (o);
+
 			obj = GLib.ObjectManager.CreateObject (o);
 			if (obj == null) {
 				g_object_unref (o);

--- a/glib/Object.cs
+++ b/glib/Object.cs
@@ -94,7 +94,6 @@ namespace GLib {
 				Console.WriteLine ("Exception while disposing a " + this + " in Gtk#");
 				throw e;
 			}
-			g_object_unref (handle);
 			handle = IntPtr.Zero;
 			GC.SuppressFinalize (this);
 		}

--- a/glib/ToggleRef.cs
+++ b/glib/ToggleRef.cs
@@ -39,6 +39,7 @@ namespace GLib {
 			gch = GCHandle.Alloc (this);
 			reference = target;
 			g_object_add_toggle_ref (target.Handle, ToggleNotifyCallback, (IntPtr) gch);
+			g_object_unref (target.Handle);
 		}
 
 		public bool IsAlive {

--- a/gtk/Object.custom
+++ b/gtk/Object.custom
@@ -94,11 +94,10 @@
 
 		public override void Dispose ()
 		{
-			// Don't call base.Dispose because it's calling g_object_unref
-			// which is done by gtk_object_destroy for Gtk.Object
-
-			//Should line below be uncommented?(but it breaks backward compatiblity)
-			//throw new InvalidOperationException("Calling Dispose is invalid for Gtk objects. Call Destroy().");
+			if (Handle == IntPtr.Zero)
+				return;
+			InternalDestroyed -= NativeDestroyHandler;
+			base.Dispose ();
 		}
 
 		protected override IntPtr Raw {

--- a/gtk/Object.custom
+++ b/gtk/Object.custom
@@ -123,31 +123,27 @@
 		{
 			if (Handle == IntPtr.Zero)
 				return;
+			if (IsFloating)
+				IsFloating = false;
 			gtk_object_destroy (Handle);
 			InternalDestroyed -= NativeDestroyHandler;
 		}
 
-		[DllImport ("libgobject-2.0-0.dll", CallingConvention = CallingConvention.Cdecl)]
-		static extern bool g_object_is_floating (IntPtr raw);
+		[DllImport("gtksharpglue-2", CallingConvention=CallingConvention.Cdecl)]
+		private static extern bool gtksharp_object_is_floating (IntPtr raw);
 
-		[DllImport ("libgobject-2.0-0.dll", CallingConvention = CallingConvention.Cdecl)]
-		static extern void g_object_force_floating (IntPtr raw);
+		[DllImport("gtksharpglue-2", CallingConvention=CallingConvention.Cdecl)]
+ 		private static extern bool gtksharp_object_set_floating (IntPtr raw, bool val);
 
 		[DllImport ("libgobject-2.0-0.dll", CallingConvention = CallingConvention.Cdecl)]
 		static extern void g_object_unref (IntPtr raw);
 
 		public bool IsFloating {
 			get {
-				return g_object_is_floating (Handle);
+				return gtksharp_object_is_floating (Handle);
 			}
 			set {
-				if (value == true) {
-					if (!IsFloating)
-						g_object_force_floating (Handle);
-				} else {
-					g_object_ref_sink (Handle);
-					g_object_unref (Handle);
-				}
+				gtksharp_object_set_floating (Handle, value);
 			}
 		}
 

--- a/gtk/Object.custom
+++ b/gtk/Object.custom
@@ -100,11 +100,16 @@
 			base.Dispose ();
 		}
 
+		[DllImport("libgobject-2.0-0.dll", CallingConvention=CallingConvention.Cdecl)]
+		private static extern void g_object_ref_sink (IntPtr raw);
+
 		protected override IntPtr Raw {
 			get {
 				return base.Raw;
 			}
 			set {
+				if (value != IntPtr.Zero)
+					g_object_ref_sink (value);
 				base.Raw = value;
 				if (value != IntPtr.Zero)
 					InternalDestroyed += NativeDestroyHandler;

--- a/gtk/Object.custom
+++ b/gtk/Object.custom
@@ -119,8 +119,6 @@
 		{
 			if (Handle == IntPtr.Zero)
 				return;
-			if (IsFloating)//We have to check or we will increment ref_count
-				IsFloating = false;
 			gtk_object_destroy (Handle);
 			InternalDestroyed -= NativeDestroyHandler;
 		}

--- a/gtk/Object.custom
+++ b/gtk/Object.custom
@@ -127,18 +127,27 @@
 			InternalDestroyed -= NativeDestroyHandler;
 		}
 
-		[DllImport("gtksharpglue-2", CallingConvention=CallingConvention.Cdecl)]
-		private static extern bool gtksharp_object_is_floating (IntPtr raw);
+		[DllImport ("libgobject-2.0-0.dll", CallingConvention = CallingConvention.Cdecl)]
+		static extern bool g_object_is_floating (IntPtr raw);
 
-		[DllImport("gtksharpglue-2", CallingConvention=CallingConvention.Cdecl)]
-		private static extern bool gtksharp_object_set_floating (IntPtr raw, bool val);
+		[DllImport ("libgobject-2.0-0.dll", CallingConvention = CallingConvention.Cdecl)]
+		static extern void g_object_force_floating (IntPtr raw);
+
+		[DllImport ("libgobject-2.0-0.dll", CallingConvention = CallingConvention.Cdecl)]
+		static extern void g_object_unref (IntPtr raw);
 
 		public bool IsFloating {
 			get {
-				return gtksharp_object_is_floating (Handle);
+				return g_object_is_floating (Handle);
 			}
 			set {
-				gtksharp_object_set_floating (Handle, value);
+				if (value == true) {
+					if (!IsFloating)
+						g_object_force_floating (Handle);
+				} else {
+					g_object_ref_sink (Handle);
+					g_object_unref (Handle);
+				}
 			}
 		}
 


### PR DESCRIPTION
Revert the memory fixes added in https://github.com/mono/gtk-sharp/pull/136 and only kept InitiallyOwned logic.

The problem is that whenever you'd create an object in managed, i.e.
new ListStore(typeof(string))

This would create an object that would never get unref'd after being owned by managed. This caused the reference to remain a strong ref, so the finalizers would never work.

On the other hand, we'd have a too big refcount at the time of Disposal, meaning memory wouldn't be cleaned up.

Kept InitiallyUnowned logic from master that would wrongly ref a Gtk.Object.