### PR TITLE
[GLib] Use a custom eq comparer for IntPtr dictionary keys.

### DIFF
--- a/glib/GType.cs
+++ b/glib/GType.cs
@@ -66,7 +66,7 @@ namespace GLib {
 		public static readonly GType Param = new GType ((IntPtr) TypeFundamentals.TypeParam);
 		public static readonly GType Object = new GType ((IntPtr) TypeFundamentals.TypeObject);
 
-		static Dictionary<IntPtr, Type> types = new Dictionary<IntPtr, Type> ();
+		static Dictionary<IntPtr, Type> types = new Dictionary<IntPtr, Type> (IntPtrEqualityComparer.Instance);
 		static Dictionary<Type, GType> gtypes = new Dictionary<Type, GType> ();
 
 		public static void Register (GType native_type, System.Type type)

--- a/glib/IntPtrEqualityComparer.cs
+++ b/glib/IntPtrEqualityComparer.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace GLib
+{
+	class IntPtrEqualityComparer : IEqualityComparer<IntPtr>
+	{
+		public static readonly IEqualityComparer<IntPtr> Instance = new IntPtrEqualityComparer ();
+
+		public bool Equals (IntPtr x, IntPtr y)
+		{
+			return x == y;
+		}
+
+		public int GetHashCode (IntPtr obj)
+		{
+			return obj.GetHashCode ();
+		}
+	}
+}

--- a/glib/Makefile.am
+++ b/glib/Makefile.am
@@ -40,6 +40,7 @@ sources =		 			\
 	Idle.cs					\
 	IgnoreClassInitializersAttribute.cs	\
 	InitiallyUnowned.cs			\
+	IntPtrEqualityComparer.cs	\
 	IOChannel.cs				\
 	IWrapper.cs				\
 	ListBase.cs				\

--- a/glib/Object.cs
+++ b/glib/Object.cs
@@ -37,7 +37,7 @@ namespace GLib {
 		bool disposed = false;
 		bool owned = true;
 		Hashtable data;
-		static Dictionary<IntPtr, ToggleRef> Objects = new Dictionary<IntPtr, ToggleRef>();
+		static Dictionary<IntPtr, ToggleRef> Objects = new Dictionary<IntPtr, ToggleRef>(IntPtrEqualityComparer.Instance);
 		static object lockObject = new object ();
 		static List<ToggleRef> PendingDestroys = new List<ToggleRef> ();
 		static bool idle_queued;

--- a/glib/glib.csproj
+++ b/glib/glib.csproj
@@ -192,6 +192,7 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="WeakObject.cs" />
+    <Compile Include="IntPtrEqualityComparer.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />


### PR DESCRIPTION
This improves performance on all key operations on the dictionaries by preventing the boxing of the IntPtr.