### PR TITLE
[Generator] Override dispose for opaques

### DIFF
--- a/generator/OpaqueGen.cs
+++ b/generator/OpaqueGen.cs
@@ -159,6 +159,18 @@ namespace GtkSharp.Generation {
 			}
 
 			if (finalizer_needed) {
+				// Generate Dispose override.
+				sw.WriteLine ("\t\tpublic override void Dispose ()");
+				sw.WriteLine ("\t\t{");
+				sw.WriteLine ("\t\t\tif (Owned)");
+				if (dispose != null)
+					sw.WriteLine ("\t\t\t\t{0} (Raw);", dispose.CName);
+				else if (unref != null)
+					sw.WriteLine ("\t\t\t\t{0} (Raw);", unref.CName);
+				sw.WriteLine ("\t\t\tbase.Dispose();");
+				sw.WriteLine ("\t\t}");
+
+				// Generate finalizer
 				sw.WriteLine ("\t\tclass FinalizerInfo {");
 				sw.WriteLine ("\t\t\tIntPtr handle;");
 				sw.WriteLine ();


### PR DESCRIPTION
When owning an opaque, we need to properly implement the Dispose method, otherwise if someone disposes and doesn't wait for the finalizer to hit, it'll leak memory.

https://gist.github.com/Therzok/370fa07bfe84d848fb87cf1d5d3450b9