### PR TITLE
Fix Gtk.Menu leak

### DIFF
--- a/gtk/Gtk.metadata
+++ b/gtk/Gtk.metadata
@@ -943,6 +943,7 @@
   <attr path="/api/namespace/boxed[@cname='GtkSelectionData']/method[@cname='gtk_selection_data_get_pixbuf']/return-type" name="owned">true</attr>
   <attr path="/api/namespace/object[@cname='GtkStyle']/method[@cname='gtk_style_render_icon']/return-type" name="owned">true</attr>
   <attr path="/api/namespace/object[@cname='GtkTreeView']/constructor[@cname='gtk_tree_view_new_with_model']" name="hidden">1</attr>
+  <attr path="/api/namespace/object[@cname='GtkMenu']/method[@cname='gtk_menu_popup']/parameters/parameter[@name='func']" name="scope">async</attr>
   <!-- Fix some names to prevent API breaks. -->
   <attr path="/api/namespace/interface[@cname='GtkRecentChooser']/method[@cname='gtk_recent_chooser_get_uris']" name="name">GetSelectedUris</attr>
   <attr path="/api/namespace/boxed[@cname='GtkSelectionData']/method[@cname='gtk_selection_data_get_uris']" name="name">GetSelectedUris</attr>


### PR DESCRIPTION
```
public void Popup(Gtk.Widget parent_menu_shell, Gtk.Widget parent_menu_item, Gtk.MenuPositionFunc func, uint button, uint activate_time) {
	GtkSharp.MenuPositionFuncWrapper func_wrapper = new GtkSharp.MenuPositionFuncWrapper (func);
	func_wrapper.PersistUntilCalled (); // This line is added which frees the wrapper after call
	gtk_menu_popup(Handle, parent_menu_shell == null ? IntPtr.Zero : parent_menu_shell.Handle, parent_menu_item == null ? IntPtr.Zero : parent_menu_item.Handle, func_wrapper.NativeDelegate, IntPtr.Zero, button, activate_time);
}
```