### PR TITLE
Correct use of sizeof method in gtk/ColorSelection.custom

### DIFF
--- a/gtk/ColorSelection.custom
+++ b/gtk/ColorSelection.custom
@@ -44,7 +44,10 @@
 				return null;
 			}
 			Gdk.Color[] colors = new Gdk.Color[n_colors];
-			int colorSize = sizeof(Gdk.Color);
+			int colorSize = 0;			
+			unsafe {
+				colorSize = sizeof(Gdk.Color);
+			}
 			for (int i=0; i < n_colors; i++)
 			{
 				colors[i] = Gdk.Color.New(parsedColors);


### PR DESCRIPTION
If compiling gtk-sharp using mono 4.8.0 on debian 8 I get error like:

generated/ColorSelection.custom(47,20): error CS0233: `Gdk.Color' does not have a predefined size, therefore sizeof can only be used in an unsafe context (consider using System.Runtime.InteropServices.Marshal.SizeOf)