### PR TITLE
[GLib] Optimize string marshalling

### DIFF
--- a/glib/Marshaller.cs
+++ b/glib/Marshaller.cs
@@ -76,18 +76,6 @@ namespace GLib {
 			return ret;
 		}
 
-#if HAVE_NET_4_6
-		static bool hasFastGetStringOverload = typeof (System.Text.Encoding).GetMethod ("GetString", new [] { typeof (byte*), typeof (int) }) != null;
-		static string Utf8PtrToStringFast (IntPtr ptr, int len)
-		{
-			unsafe
-			{
-				var p = (byte*)ptr;
-				return System.Text.Encoding.UTF8.GetString (p, len);
-			}
-		}
-#endif
-
 		[DllImport ("libglib-2.0-0.dll", CallingConvention = CallingConvention.Cdecl)]
 		unsafe static extern char* g_utf8_to_utf16 (IntPtr native_str, IntPtr len, IntPtr items_read, IntPtr items_written, IntPtr error);
 

--- a/glib/Marshaller.cs
+++ b/glib/Marshaller.cs
@@ -90,7 +90,10 @@ namespace GLib {
 				return null;
 			unsafe
 			{
-				return new string (g_utf8_to_utf16 (ptr, new IntPtr (-1), IntPtr.Zero, IntPtr.Zero, IntPtr.Zero));
+				char *utf16 = g_utf8_to_utf16 (ptr, new IntPtr (-1), IntPtr.Zero, IntPtr.Zero, IntPtr.Zero);
+				var result = new string (utf16);
+				g_free ((IntPtr)utf16);
+				return result;
 			}
 		}
 

--- a/glib/Signal.cs
+++ b/glib/Signal.cs
@@ -172,7 +172,7 @@ namespace GLib {
 			}
 
 			if (before_closure == null && after_closure == null)
-				tref.Signals.Remove (name);
+				tref.RemoveSignal (name);
 		}
 
 		EventHandler closure_disposed_cb;

--- a/glib/ToggleRef.cs
+++ b/glib/ToggleRef.cs
@@ -69,12 +69,20 @@ namespace GLib {
 			}
 		}
 
+		internal void RemoveSignal (string name)
+		{
+			if (signals == null)
+				return;
+			
+			signals.Remove (name);
+		}
+
   		public void Free ()
   		{
 			if (signals != null) {
-				var array = new Signal [signals.Values.Count];
-				signals.Values.CopyTo (array, 0);
-				foreach (Signal s in array)
+				var copy = signals.Values;
+				signals = null;
+				foreach (Signal s in copy)
 					s.Free ();
 			}
 


### PR DESCRIPTION
This commit changes the stack to use glib conversions between utf16 and utf8, only doing one iteration of the string on conversion.
This patch doesn't handle error checking yet, this is a TODO