### PR TITLE
[Gdk] Fix pixbuf leak

### DIFF
--- a/gdk/Gdk.metadata
+++ b/gdk/Gdk.metadata
@@ -126,7 +126,6 @@
   <attr path="/api/namespace/object[@cname='GdkPixbuf']/property" name="construct-only">true</attr>
   <attr path="/api/namespace/struct[@cname='GdkPixbufFormat']/method[@name='GetExtensions']/return-type" name="null_term_array">1</attr> 
   <attr path="/api/namespace/struct[@cname='GdkPixbufFormat']/method[@name='GetMimeTypes']/return-type" name="null_term_array">1</attr> 
-  <attr path="/api/namespace/object[@cname='GdkPixbufLoader']/method[@name='GetPixbuf']/return-type" name="needs_ref">true</attr>
   <attr path="/api/namespace/object[@cname='GdkPixbufLoader']/method[@name='Write']/*/*[@name='buf']" name="array">1</attr>
   <attr path="/api/namespace/object[@cname='GdkPixmap']" name="parent">GdkDrawable</attr>
   <attr path="/api/namespace/object[@cname='GdkPixmap']/method[@name='CreateFromXpm']/*/*[@name='mask']" name="pass_as">out</attr>


### PR DESCRIPTION
This forced a pixbuf ref on querying. This was not good, as the managed wrapper already takes a ref. So we'd continously ref the pixbuf on the same object, without setting the Owned property. While we could grab ownership of the pixbuf, better rely on the ref/unref semantics to properly handle this.