### PR TITLE
[GLib, Gen] Add IgnoreRegistrationAttribute

### DIFF
--- a/generator/ClassBase.cs
+++ b/generator/ClassBase.cs
@@ -26,6 +26,7 @@
 namespace GtkSharp.Generation {
 	using System;
 	using System.Collections;
+	using System.Collections.Generic;
 	using System.IO;
 	using System.Xml;
 
@@ -253,6 +254,27 @@ namespace GtkSharp.Generation {
 			default:
 				return false;
 			}
+		}
+
+		public string GetIgnoreAttribute ()
+		{
+			var list = new List<string> ();
+			OnGenerateIgnoreAttribute (list);
+
+			for (int i = 0; i < list.Count; ++i)
+				list [i] = list [i] + "=false";
+
+			return string.Format ("[GLib.IgnoreRegistration ({0})]", string.Join (", ", list.ToArray ()));
+;		}
+
+		protected virtual void OnGenerateIgnoreAttribute (List<string> ignoreItems)
+		{
+			if (props.Count > 0)
+				ignoreItems.Add ("Properties");
+			if (sigs != null && sigs.Count > 0)
+				ignoreItems.Add ("DefaultHandlers");
+			if (interfaces.Count > 0 || managed_interfaces.Count > 0)
+				ignoreItems.Add ("Interfaces");
 		}
 
 		public void GenProperties (GenerationInfo gen_info, ClassBase implementor)

--- a/generator/ObjectGen.cs
+++ b/generator/ObjectGen.cs
@@ -180,6 +180,7 @@ namespace GtkSharp.Generation {
 			foreach (string attr in custom_attrs)
 				sw.WriteLine ("\t" + attr);
 			GenerateAttribute (sw);
+			sw.WriteLine ("\t" + GetIgnoreAttribute());
 			sw.Write ("\t{0} {1}class " + Name, IsInternal ? "internal" : "public", IsAbstract ? "abstract " : "");
 			string cs_parent = table.GetCSType(Elem.GetAttribute("parent"));
 			if (cs_parent != "") {

--- a/glib/IgnoreRegistrationAttribute.cs
+++ b/glib/IgnoreRegistrationAttribute.cs
@@ -1,0 +1,17 @@
+﻿using System;
+namespace GLib
+{
+	[AttributeUsage (AttributeTargets.Class, Inherited = false)]
+	public sealed class IgnoreRegistrationAttribute : Attribute
+	{
+		public IgnoreRegistrationAttribute()
+		{
+			Properties = true;
+			DefaultHandlers = true;
+			Interfaces = true;
+		}
+		public bool Properties { get; set; }
+		public bool DefaultHandlers { get; set; }
+		public bool Interfaces { get; set; }
+	}
+}

--- a/glib/IgnoreRegistrationAttribute.cs
+++ b/glib/IgnoreRegistrationAttribute.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 namespace GLib
 {
-	[AttributeUsage (AttributeTargets.Class, Inherited = false)]
+	[AttributeUsage (AttributeTargets.Class | AttributeTargets.Assembly, Inherited = false)]
 	public sealed class IgnoreRegistrationAttribute : Attribute
 	{
 		public IgnoreRegistrationAttribute()

--- a/glib/Makefile.am
+++ b/glib/Makefile.am
@@ -40,6 +40,7 @@ sources =		 			\
 	GTypeAttribute.cs			\
 	Idle.cs					\
 	IgnoreClassInitializersAttribute.cs	\
+	IgnoreRegistrationAttribute.cs	\
 	InitiallyUnowned.cs			\
 	IntPtrEqualityComparer.cs	\
 	IOChannel.cs				\

--- a/glib/Object.cs
+++ b/glib/Object.cs
@@ -335,13 +335,17 @@ namespace GLib {
 			GLib.Marshaller.Free (native_name);
 			GLib.GType.Register (gtype, t);
 
-			var attributes = t.GetCustomAttributes (typeof (IgnoreRegistrationAttribute), false);
-			if (attributes.Length == 0) {
+			var attribute = t.Assembly.GetCustomAttribute<IgnoreRegistrationAttribute> ();
+			if (attribute == null) {
+				var attributes = t.GetCustomAttributes (typeof (IgnoreRegistrationAttribute), false);
+				attribute = attributes.Length > 0 ? (IgnoreRegistrationAttribute)attributes[0] : null;
+			}
+
+			if (attribute == null) {
 				AddProperties (gtype, t);
 				ConnectDefaultHandlers (gtype, t);
 				AddInterfaces (gtype, t);
 			} else {
-				var attribute = (IgnoreRegistrationAttribute)attributes [0];
 				if (!attribute.Properties)
 					AddProperties (gtype, t);
 				if (!attribute.DefaultHandlers)

--- a/glib/Object.cs
+++ b/glib/Object.cs
@@ -334,10 +334,22 @@ namespace GLib {
 			GType gtype = new GType (gtksharp_register_type (native_name, parent_gtype.Val));
 			GLib.Marshaller.Free (native_name);
 			GLib.GType.Register (gtype, t);
-			AddProperties (gtype, t);
-			ConnectDefaultHandlers (gtype, t);
+
+			var attributes = t.GetCustomAttributes (typeof (IgnoreRegistrationAttribute), false);
+			if (attributes.Length == 0) {
+				AddProperties (gtype, t);
+				ConnectDefaultHandlers (gtype, t);
+				AddInterfaces (gtype, t);
+			} else {
+				var attribute = (IgnoreRegistrationAttribute)attributes [0];
+				if (!attribute.Properties)
+					AddProperties (gtype, t);
+				if (!attribute.DefaultHandlers)
+					ConnectDefaultHandlers (gtype, t);
+				if (!attribute.Interfaces)
+					AddInterfaces (gtype, t);
+			}
 			InvokeClassInitializers (gtype, t);
-			AddInterfaces (gtype, t);
 			g_types[t] = gtype;
 			return gtype;
 		}

--- a/glib/glib.csproj
+++ b/glib/glib.csproj
@@ -194,6 +194,7 @@
     <Compile Include="WeakObject.cs" />
     <Compile Include="IntPtrEqualityComparer.cs" />
     <Compile Include="FastActivator.cs" />
+    <Compile Include="IgnoreRegistrationAttribute.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />


### PR DESCRIPTION
This attribute allows for a fast path of registration of a gtype. We selectively choose what to register if we mark the type with the attribute. Thus, if you mark something with IgnoreRegistration(DefaultHandlers=false), it'll only register DefaultHandlers for a method, so we don't reflect all the methods of each type when we register the gtype.