### PR TITLE
[Gdk,Gtk] Fix possible invalid memory access with GdkEvent.

### DIFF
--- a/gdk/Display.custom
+++ b/gdk/Display.custom
@@ -83,3 +83,23 @@
 			gdk_display_add_client_message_filter (Handle, message_type == null ? IntPtr.Zero : message_type.Handle, func_wrapper.NativeDelegate, IntPtr.Zero);
 		}
 
+		[DllImport("libgdk-win32-2.0-0.dll", CallingConvention = CallingConvention.Cdecl)]
+		static extern IntPtr gdk_display_get_event(IntPtr raw);
+
+		public Gdk.Event Event { 
+			get {
+				IntPtr raw_ret = gdk_display_get_event(Handle);
+				Gdk.Event ret = Gdk.Event.GetEvent (raw_ret, true);
+				return ret;
+			}
+		}
+
+		[DllImport("libgdk-win32-2.0-0.dll", CallingConvention = CallingConvention.Cdecl)]
+		static extern IntPtr gdk_display_peek_event(IntPtr raw);
+
+		public Gdk.Event PeekEvent() {
+			IntPtr raw_ret = gdk_display_peek_event(Handle);
+			Gdk.Event ret = Gdk.Event.GetEvent (raw_ret, true);
+			return ret;
+		}
+

--- a/gdk/Event.cs
+++ b/gdk/Event.cs
@@ -41,10 +41,26 @@ namespace Gdk {
 		static extern IntPtr gdk_event_get_type ();
 
 		IntPtr raw;
+		bool owned;
 
-		public Event(IntPtr raw) 
+		[DllImport ("libgdk-win32-2.0-0.dll", CallingConvention = CallingConvention.Cdecl)]
+		static extern void gdk_event_free (IntPtr raw);
+
+		~Event()
+		{
+			gdk_event_free (raw);
+		}
+
+		public Event(IntPtr raw) : this(raw, false)
+		{
+		}
+
+		public Event(IntPtr raw, bool owned) 
 		{
 			this.raw = raw;
+			this.owned = owned;
+			if (!owned)
+				System.GC.SuppressFinalize (this);
 		}
 
 		public IntPtr Handle {
@@ -85,62 +101,67 @@ namespace Gdk {
 
 		public static Event GetEvent (IntPtr raw)
 		{
+			return GetEvent (raw, false);
+		}
+
+		public static Event GetEvent (IntPtr raw, bool owned)
+		{
 			if (raw == IntPtr.Zero)
 				return null;
 
 			switch (gtksharp_gdk_event_get_event_type (raw)) {
 			case EventType.Expose:
-				return new EventExpose (raw);
+				return new EventExpose (raw, owned);
 			case EventType.MotionNotify:
-				return new EventMotion (raw);
+				return new EventMotion (raw, owned);
 			case EventType.ButtonPress:
 			case EventType.TwoButtonPress:
 			case EventType.ThreeButtonPress:
 			case EventType.ButtonRelease:
-				return new EventButton (raw);
+				return new EventButton (raw, owned);
 			case EventType.KeyPress:
 			case EventType.KeyRelease:
-				return new EventKey (raw);
+				return new EventKey (raw, owned);
 			case EventType.EnterNotify:
 			case EventType.LeaveNotify:
-				return new EventCrossing (raw);
+				return new EventCrossing (raw, owned);
 			case EventType.FocusChange:
-				return new EventFocus (raw);
+				return new EventFocus (raw, owned);
 			case EventType.Configure:
-				return new EventConfigure (raw);
+				return new EventConfigure (raw, owned);
 			case EventType.PropertyNotify:
-				return new EventProperty (raw);
+				return new EventProperty (raw, owned);
 			case EventType.SelectionClear:
 			case EventType.SelectionRequest:
 			case EventType.SelectionNotify:
-				return new EventSelection (raw);
+				return new EventSelection (raw, owned);
 			case EventType.ProximityIn:
 			case EventType.ProximityOut:
-				return new EventProximity (raw);
+				return new EventProximity (raw, owned);
 			case EventType.DragEnter:
 			case EventType.DragLeave:
 			case EventType.DragMotion:
 			case EventType.DragStatus:
 			case EventType.DropStart:
 			case EventType.DropFinished:
-				return new EventDND (raw);
+				return new EventDND (raw, owned);
 			case EventType.ClientEvent:
-				return new EventClient (raw);
+				return new EventClient (raw, owned);
 			case EventType.VisibilityNotify:
-				return new EventVisibility (raw);
+				return new EventVisibility (raw, owned);
 			case EventType.Scroll:
-				return new EventScroll (raw);
+				return new EventScroll (raw, owned);
 			case EventType.WindowState:
-				return new EventWindowState (raw);
+				return new EventWindowState (raw, owned);
 			case EventType.Setting:
-				return new EventSetting (raw);
+				return new EventSetting (raw, owned);
 #if GTK_SHARP_2_6
 			case EventType.OwnerChange:
-				return new EventOwnerChange (raw);
+				return new EventOwnerChange (raw, owned);
 #endif
 #if GTK_SHARP_2_8
 			case EventType.GrabBroken:
-				return new EventGrabBroken (raw);
+				return new EventGrabBroken (raw, owned);
 #endif
 			case EventType.Map:
 			case EventType.Unmap:
@@ -148,7 +169,7 @@ namespace Gdk {
 			case EventType.Delete:
 			case EventType.Destroy:
 			default:
-				return new Gdk.Event (raw);
+				return new Gdk.Event (raw, owned);
 			}
 		}
 	}

--- a/gdk/EventButton.cs
+++ b/gdk/EventButton.cs
@@ -52,7 +52,8 @@ namespace Gdk {
 		[DllImport("gdksharpglue-2", CallingConvention=CallingConvention.Cdecl)]
 		static extern IntPtr gtksharp_gdk_event_button_get_axes (IntPtr evt);
 
-		public EventButton (IntPtr raw) : base (raw) {} 
+		public EventButton (IntPtr raw) : base (raw) { }
+		public EventButton (IntPtr raw, bool owned) : base (raw, owned) { }
 
 		public uint Time {
 			get {

--- a/gdk/EventClient.cs
+++ b/gdk/EventClient.cs
@@ -35,7 +35,8 @@ namespace Gdk {
 		[DllImport("gdksharpglue-2", CallingConvention=CallingConvention.Cdecl)]
 		static extern IntPtr gtksharp_gdk_event_client_get_data (IntPtr evt);
 
-		public EventClient (IntPtr raw) : base (raw) {} 
+		public EventClient (IntPtr raw) : base (raw) { }
+		public EventClient (IntPtr raw, bool owned) : base (raw, owned) { }
 
 		public Atom MessageType {
 			get {

--- a/gdk/EventConfigure.cs
+++ b/gdk/EventConfigure.cs
@@ -38,7 +38,8 @@ namespace Gdk {
 		[DllImport("gdksharpglue-2", CallingConvention=CallingConvention.Cdecl)]
 		static extern int gtksharp_gdk_event_configure_get_height (IntPtr evt);
 
-		public EventConfigure (IntPtr raw) : base (raw) {} 
+		public EventConfigure (IntPtr raw) : base (raw) { }
+		public EventConfigure (IntPtr raw, bool owned) : base (raw, owned) { }
 
 		public int X {
 			get {

--- a/gdk/EventCrossing.cs
+++ b/gdk/EventCrossing.cs
@@ -56,7 +56,8 @@ namespace Gdk {
 		[DllImport("gdksharpglue-2", CallingConvention=CallingConvention.Cdecl)]
 		static extern bool gtksharp_gdk_event_crossing_get_focus (IntPtr evt);
 
-		public EventCrossing (IntPtr raw) : base (raw) {} 
+		public EventCrossing (IntPtr raw) : base (raw) { }
+		public EventCrossing (IntPtr raw, bool owned) : base (raw, owned) { }
 
 		public uint Time {
 			get {

--- a/gdk/EventDND.cs
+++ b/gdk/EventDND.cs
@@ -38,7 +38,8 @@ namespace Gdk {
 		[DllImport("gdksharpglue-2", CallingConvention=CallingConvention.Cdecl)]
 		static extern short gtksharp_gdk_event_dnd_get_y_root (IntPtr evt);
 
-		public EventDND (IntPtr raw) : base (raw) {} 
+		public EventDND (IntPtr raw) : base (raw) { }
+		public EventDND (IntPtr raw, bool owned) : base (raw, owned) { }
 
 		public DragContext Context {
 			get {

--- a/gdk/EventExpose.cs
+++ b/gdk/EventExpose.cs
@@ -36,6 +36,7 @@ namespace Gdk {
 		static extern int gtksharp_gdk_event_expose_get_count (IntPtr evt);
 
 		public EventExpose (IntPtr raw) : base (raw) {} 
+		public EventExpose (IntPtr raw, bool owned) : base (raw, owned) {}
 
 		public Rectangle Area {
 			get {

--- a/gdk/EventFocus.cs
+++ b/gdk/EventFocus.cs
@@ -29,7 +29,8 @@ namespace Gdk {
 		[DllImport("gdksharpglue-2", CallingConvention=CallingConvention.Cdecl)]
 		static extern short gtksharp_gdk_event_focus_get_in (IntPtr evt);
 
-		public EventFocus (IntPtr raw) : base (raw) {} 
+		public EventFocus (IntPtr raw) : base (raw) { }
+		public EventFocus (IntPtr raw, bool owned) : base (raw, owned) { }
 
 		public bool In {
 			get {

--- a/gdk/EventGrabBroken.cs
+++ b/gdk/EventGrabBroken.cs
@@ -39,10 +39,14 @@ namespace Gdk {
 
 		NativeEventGrabBroken native_struct;
 
-		public EventGrabBroken (IntPtr raw) : base (raw) 
+		public EventGrabBroken (IntPtr raw) : this (raw, false)
+		{
+		}
+
+		public EventGrabBroken (IntPtr raw, bool owned) : base (raw, owned)
 		{
 			native_struct = Marshal.PtrToStructure<NativeEventGrabBroken> (raw);
-		} 
+		}
 
 		public bool Keyboard {
 			get {

--- a/gdk/EventHelper.custom
+++ b/gdk/EventHelper.custom
@@ -1,0 +1,46 @@
+
+
+		[DllImport("libgdk-win32-2.0-0.dll", CallingConvention = CallingConvention.Cdecl)]
+		static extern IntPtr gdk_event_new(int type);
+
+		public static Gdk.Event New(Gdk.EventType type) {
+			IntPtr raw_ret = gdk_event_new((int) type);
+			Gdk.Event ret = Gdk.Event.GetEvent (raw_ret, true);
+			return ret;
+		}
+
+		[DllImport("libgdk-win32-2.0-0.dll", CallingConvention = CallingConvention.Cdecl)]
+		static extern IntPtr gdk_event_get();
+
+		public static Gdk.Event Get() {
+			IntPtr raw_ret = gdk_event_get();
+			Gdk.Event ret = Gdk.Event.GetEvent (raw_ret, true);
+			return ret;
+		}
+
+		[DllImport("libgdk-win32-2.0-0.dll", CallingConvention = CallingConvention.Cdecl)]
+		static extern IntPtr gdk_event_copy(IntPtr evnt);
+
+		public static Gdk.Event Copy(Gdk.Event evnt) {
+			IntPtr raw_ret = gdk_event_copy(evnt == null ? IntPtr.Zero : evnt.Handle);
+			Gdk.Event ret = Gdk.Event.GetEvent (raw_ret, true);
+			return ret;
+		}
+
+		[DllImport("libgdk-win32-2.0-0.dll", CallingConvention = CallingConvention.Cdecl)]
+		static extern IntPtr gdk_event_get_graphics_expose(IntPtr window);
+
+		public static Gdk.Event GetGraphicsExpose(Gdk.Window window) {
+			IntPtr raw_ret = gdk_event_get_graphics_expose(window == null ? IntPtr.Zero : window.Handle);
+			Gdk.Event ret = Gdk.Event.GetEvent (raw_ret, true);
+			return ret;
+		}
+
+		[DllImport("libgdk-win32-2.0-0.dll", CallingConvention = CallingConvention.Cdecl)]
+		static extern IntPtr gdk_event_peek();
+
+		public static Gdk.Event Peek() {
+			IntPtr raw_ret = gdk_event_peek();
+			Gdk.Event ret = Gdk.Event.GetEvent (raw_ret, true);
+			return ret;
+		}

--- a/gdk/EventKey.cs
+++ b/gdk/EventKey.cs
@@ -41,7 +41,8 @@ namespace Gdk {
 		[DllImport("gdksharpglue-2", CallingConvention=CallingConvention.Cdecl)]
 		static extern byte gtksharp_gdk_event_key_get_group (IntPtr evt);
 
-		public EventKey (IntPtr raw) : base (raw) {} 
+		public EventKey (IntPtr raw) : base (raw) { }
+		public EventKey (IntPtr raw, bool owned) : base (raw, owned) { }
 
 		public uint Time {
 			get {

--- a/gdk/EventMotion.cs
+++ b/gdk/EventMotion.cs
@@ -53,7 +53,8 @@ namespace Gdk {
 		[DllImport("gdksharpglue-2", CallingConvention=CallingConvention.Cdecl)]
 		static extern IntPtr gtksharp_gdk_event_motion_get_axes (IntPtr evt);
 
-		public EventMotion (IntPtr raw) : base (raw) {} 
+		public EventMotion (IntPtr raw) : base (raw) { }
+		public EventMotion (IntPtr raw, bool owned) : base (raw, owned) { }
 
 		public uint Time {
 			get {

--- a/gdk/EventOwnerChange.cs
+++ b/gdk/EventOwnerChange.cs
@@ -26,7 +26,8 @@ namespace Gdk {
 
 	public class EventOwnerChange : Event {
 
-		public EventOwnerChange (IntPtr handle) : base (handle) {}
+		public EventOwnerChange (IntPtr handle) : base (handle) { }
+		public EventOwnerChange (IntPtr raw, bool owned) : base (raw, owned) { }
 
 		struct NativeStruct {
 			public Gdk.EventType type;

--- a/gdk/EventProperty.cs
+++ b/gdk/EventProperty.cs
@@ -35,7 +35,8 @@ namespace Gdk {
 		[DllImport("gdksharpglue-2", CallingConvention=CallingConvention.Cdecl)]
 		static extern PropertyState gtksharp_gdk_event_property_get_state (IntPtr evt);
 
-		public EventProperty (IntPtr raw) : base (raw) {} 
+		public EventProperty (IntPtr raw) : base (raw) { }
+		public EventProperty (IntPtr raw, bool owned) : base (raw, owned) { }
 
 		public Atom Atom {
 			get {

--- a/gdk/EventProximity.cs
+++ b/gdk/EventProximity.cs
@@ -32,7 +32,8 @@ namespace Gdk {
 		[DllImport("gdksharpglue-2", CallingConvention=CallingConvention.Cdecl)]
 		static extern IntPtr gtksharp_gdk_event_proximity_get_device (IntPtr evt);
 
-		public EventProximity (IntPtr raw) : base (raw) {} 
+		public EventProximity (IntPtr raw) : base (raw) { }
+		public EventProximity (IntPtr raw, bool owned) : base (raw, owned) { }
 
 		public Device Device {
 			get {

--- a/gdk/EventScroll.cs
+++ b/gdk/EventScroll.cs
@@ -50,7 +50,8 @@ namespace Gdk {
 		[DllImport("gdksharpglue-2", CallingConvention=CallingConvention.Cdecl)]
 		static extern IntPtr gtksharp_gdk_event_scroll_get_device (IntPtr evt);
 
-		public EventScroll (IntPtr raw) : base (raw) {} 
+		public EventScroll (IntPtr raw) : base (raw) { }
+		public EventScroll (IntPtr raw, bool owned) : base (raw, owned) { }
 
 		public uint Time {
 			get {

--- a/gdk/EventSelection.cs
+++ b/gdk/EventSelection.cs
@@ -41,7 +41,8 @@ namespace Gdk {
 		[DllImport("gdksharpglue-2", CallingConvention=CallingConvention.Cdecl)]
 		static extern uint gtksharp_gdk_event_selection_get_requestor (IntPtr evt);
 
-		public EventSelection (IntPtr raw) : base (raw) {} 
+		public EventSelection (IntPtr raw) : base (raw) { }
+		public EventSelection (IntPtr raw, bool owned) : base (raw, owned) { }
 
 		public Atom Property {
 			get {

--- a/gdk/EventSetting.cs
+++ b/gdk/EventSetting.cs
@@ -32,7 +32,8 @@ namespace Gdk {
 		[DllImport("gdksharpglue-2", CallingConvention=CallingConvention.Cdecl)]
 		static extern IntPtr gtksharp_gdk_event_setting_get_name (IntPtr evt);
 
-		public EventSetting (IntPtr raw) : base (raw) {} 
+		public EventSetting (IntPtr raw) : base (raw) { }
+		public EventSetting (IntPtr raw, bool owned) : base (raw, owned) { }
 
 		public SettingAction Action {
 			get {

--- a/gdk/EventVisibility.cs
+++ b/gdk/EventVisibility.cs
@@ -29,7 +29,8 @@ namespace Gdk {
 		[DllImport("gdksharpglue-2", CallingConvention=CallingConvention.Cdecl)]
 		static extern VisibilityState gtksharp_gdk_event_visibility_get_state (IntPtr evt);
 
-		public EventVisibility (IntPtr raw) : base (raw) {} 
+		public EventVisibility (IntPtr raw) : base (raw) { }
+		public EventVisibility (IntPtr raw, bool owned) : base (raw, owned) { }
 
 		public VisibilityState State {
 			get {

--- a/gdk/EventWindowState.cs
+++ b/gdk/EventWindowState.cs
@@ -32,7 +32,8 @@ namespace Gdk {
 		[DllImport("gdksharpglue-2", CallingConvention=CallingConvention.Cdecl)]
 		static extern WindowState gtksharp_gdk_event_window_state_get_new_window_state (IntPtr evt);
 
-		public EventWindowState (IntPtr raw) : base (raw) {} 
+		public EventWindowState (IntPtr raw) : base (raw) { }
+		public EventWindowState (IntPtr raw, bool owned) : base (raw, owned) { }
 
 		public WindowState ChangedMask {
 			get {

--- a/gdk/Gdk.metadata
+++ b/gdk/Gdk.metadata
@@ -20,6 +20,11 @@
   <attr path="/api/namespace/class[@cname='GdkDrag_']/method[@name='FindWindow']/*/*[@name='dest_window']" name="pass_as">out</attr>
   <attr path="/api/namespace/class[@cname='GdkDrag_']/method[@name='FindWindowForScreen']/*/*[@name='dest_window']" name="pass_as">out</attr>
   <attr path="/api/namespace/class[@cname='GdkEvent_']/method[@name='HandlerSet']" name="hidden">1</attr>
+  <attr path="/api/namespace/class[@cname='GdkEvent_']/method[@name='Copy']" name="hidden">1</attr>
+  <attr path="/api/namespace/class[@cname='GdkEvent_']/method[@name='Get']" name="hidden">1</attr>
+  <attr path="/api/namespace/class[@cname='GdkEvent_']/method[@name='GetGraphicsExpose']" name="hidden">1</attr>
+  <attr path="/api/namespace/class[@cname='GdkEvent_']/method[@name='New']" name="hidden">1</attr>
+  <attr path="/api/namespace/class[@cname='GdkEvent_']/method[@name='Peek']" name="hidden">1</attr>
   <attr path="/api/namespace/class[@cname='GdkEvent_']" name="name">EventHelper</attr>
   <attr path="/api/namespace/class[@cname='GdkInput_']/method[@name='Add']" name="hidden">1</attr>
   <attr path="/api/namespace/class[@cname='GdkInput_']/method[@name='AddFull']" name="hidden">1</attr>

--- a/gdk/Gdk.metadata
+++ b/gdk/Gdk.metadata
@@ -81,6 +81,8 @@
   <attr path="/api/namespace/object[@cname='GdkDisplay']/method[@name='SupportsComposite']" name="name">GetSupportsComposite</attr>
   <attr path="/api/namespace/object[@cname='GdkDisplay']/method[@name='SupportsInputShapes']" name="name">GetSupportsInputShapes</attr>
   <attr path="/api/namespace/object[@cname='GdkDisplay']/method[@name='SupportsShapes']" name="name">GetSupportsShapes</attr>
+  <attr path="/api/namespace/object[@cname='GdkDisplay']/method[@name='PeekEvent']" name="hidden">1</attr>
+  <attr path="/api/namespace/object[@cname='GdkDisplay']/method[@name='GetEvent']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GdkDisplayManager']/method[@name='ListDisplays']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GdkDragContext']/field[@cname='protocol']" name="name">DragProtocol</attr>
   <attr path="/api/namespace/object[@cname='GdkDragContext']/field[@cname='targets']" name="hidden">1</attr>

--- a/gdk/Makefile.am
+++ b/gdk/Makefile.am
@@ -47,6 +47,7 @@ customs = 			\
 	DragContext.custom	\
 	Drawable.custom		\
 	EdgeTable.custom	\
+	EventHelper.custom	\
 	GCValues.custom		\
 	Global.custom		\
 	Input.custom		\

--- a/gtk/Application.cs
+++ b/gtk/Application.cs
@@ -181,15 +181,10 @@ namespace Gtk {
 		[DllImport("libgtk-win32-2.0-0.dll", CallingConvention=CallingConvention.Cdecl)]
 		static extern IntPtr gtk_get_current_event ();
 
-		[DllImport ("libgdk-win32-2.0-0.dll", CallingConvention = CallingConvention.Cdecl)]
-		static extern void gdk_event_free (IntPtr raw);
-
 		public static Gdk.Event CurrentEvent {
 			get {
 				var raw_ret = gtk_get_current_event ();
-				var ret = Gdk.Event.GetEvent (raw_ret);
-				if (raw_ret != IntPtr.Zero)
-					gdk_event_free (raw_ret);
+				var ret = Gdk.Event.GetEvent (raw_ret, true);
 				return ret;
 			}
 		}

--- a/gtk/Global.custom
+++ b/gtk/Global.custom
@@ -44,9 +44,7 @@
 		public static Gdk.Event CurrentEvent { 
 			get {
 				IntPtr raw_ret = gtk_get_current_event();
-				Gdk.Event ret = Gdk.Event.GetEvent (raw_ret);
-				if (raw_ret != IntPtr.Zero)
-					gdk_event_free (raw_ret);
+				Gdk.Event ret = Gdk.Event.GetEvent (raw_ret, true);
 				return ret;
 			}
 		}


### PR DESCRIPTION
This was freeing the event right after construction. Manually bind these as symbols.xml doesn't support smart owned binding.