### PR TITLE
Probably good finalizer optimizations?

### DIFF
--- a/glib/Makefile.am
+++ b/glib/Makefile.am
@@ -59,6 +59,7 @@ sources =		 			\
 	Opaque.cs				\
 	PropertyAttribute.cs			\
 	PtrArray.cs				\
+	SafeObjectHandle.cs			\
 	Signal.cs				\
 	SignalArgs.cs				\
 	SignalAttribute.cs			\

--- a/glib/Opaque.cs
+++ b/glib/Opaque.cs
@@ -88,34 +88,9 @@ namespace GLib {
 			}
 		}
 
-		static object lockObject = new object ();
-		static List<Opaque> PendingFrees = new List<Opaque> ();
-		static bool idleQueued;
-
-		bool PerformQueuedFrees ()
-		{
-			List<Opaque> references;
-			lock (lockObject) {
-				references = PendingFrees;
-				PendingFrees = new List<Opaque> ();
-				idleQueued = false;
-			}
-
-			foreach (var opaque in references)
-				opaque.Raw = IntPtr.Zero;
-			
-			return false;
-		}
-
 		~Opaque ()
 		{
-			lock (lockObject) {
-				PendingFrees.Add (this);
-				if (!idleQueued) {
-					idleQueued = true;
-					Timeout.Add (50, new TimeoutHandler (PerformQueuedFrees));
-				}
-			}
+			Raw = IntPtr.Zero;
 		}
 
 		public virtual void Dispose ()

--- a/glib/SafeObjectHandle.cs
+++ b/glib/SafeObjectHandle.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+namespace GLib
+{
+	class SafeObjectHandle : SafeHandleZeroOrMinusOneIsInvalid
+	{
+		public static SafeObjectHandle Zero = new SafeObjectHandle ();
+
+		internal ToggleRef tref;
+
+		SafeObjectHandle () : base (false)
+		{
+		}
+
+		SafeObjectHandle (IntPtr handle) : base(true)
+		{
+			SetHandle (handle);
+		}
+
+		static readonly Dictionary<IntPtr, ToggleRef> Objects = new Dictionary<IntPtr, ToggleRef> (IntPtrEqualityComparer.Instance);
+		public static SafeObjectHandle Create (Object obj, IntPtr handle)
+		{
+			if (handle == IntPtr.Zero)
+				return Zero;
+
+			var safeHandle = new SafeObjectHandle (handle) {
+				tref = new ToggleRef (obj, handle)
+			};
+
+			lock (Objects)
+				Objects [handle] = safeHandle.tref;
+
+			return safeHandle;
+		}
+
+		public static bool TryGetObject (IntPtr o, out Object obj)
+		{
+			bool ret;
+			ToggleRef tr;
+
+			lock (Objects)
+				ret = Objects.TryGetValue (o, out tr);
+			
+			obj = ret ? tr.Target : null;
+			return ret;
+		}
+
+		protected override bool ReleaseHandle ()
+		{
+			lock (Objects)
+				Objects.Remove (handle);
+
+			if (tref != null)
+				tref.Free ();
+			return true;
+		}
+	}
+}

--- a/glib/ToggleRef.cs
+++ b/glib/ToggleRef.cs
@@ -33,14 +33,14 @@ namespace GLib {
 		GCHandle gch;
 		Hashtable signals;
 
-		public ToggleRef (GLib.Object target)
+		public ToggleRef (GLib.Object target, IntPtr handle)
 		{
-			handle = target.Handle;
+			this.handle = handle;
 			gch = GCHandle.Alloc (this);
 			reference = target;
-			g_object_add_toggle_ref (target.Handle, ToggleNotifyCallback, (IntPtr) gch);
+			g_object_add_toggle_ref (handle, ToggleNotifyCallback, (IntPtr) gch);
 			if (target.owned && !(target is InitiallyUnowned))
-				g_object_unref (target.Handle);
+				g_object_unref (handle);
 		}
 
 		public IntPtr Handle {

--- a/glib/ValueArray.cs
+++ b/glib/ValueArray.cs
@@ -67,33 +67,8 @@ namespace GLib {
 			if (Handle == IntPtr.Zero)
 				return;
 
-			lock (lockObject) {
-				PendingFrees.Add (handle);
-
-				if (! idle_queued) {
-					Timeout.Add (50, new TimeoutHandler (PerformFrees));
-					idle_queued = true;
-				}
-			}
-
+			g_value_array_free (Handle);
 			handle = IntPtr.Zero;
-		}
-
-		static bool PerformFrees ()
-		{
-			List<IntPtr> handles;
-
-			lock (lockObject) {
-				idle_queued = false;
-
-				handles = PendingFrees;
-				PendingFrees = new List<IntPtr> (8);
-			}
-
-			for (int i = 0; i < handles.Count; ++i)
-				g_value_array_free (handles [i]);
-
-			return false;
 		}
 		
 		public IntPtr Handle {

--- a/glib/glib.csproj
+++ b/glib/glib.csproj
@@ -194,6 +194,7 @@
     <Compile Include="WeakObject.cs" />
     <Compile Include="IntPtrEqualityComparer.cs" />
     <Compile Include="FastActivator.cs" />
+    <Compile Include="SafeObjectHandle.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/pango/Attribute.cs
+++ b/pango/Attribute.cs
@@ -30,6 +30,8 @@ namespace Pango {
 		{
 			this.raw = raw;
 			this.owned = owned;
+			if (!owned)
+				GC.SuppressFinalize (this);
 		}
 
 		[DllImport("pangosharpglue-2", CallingConvention=CallingConvention.Cdecl)]


### PR DESCRIPTION
This patch introduces 2 new mechanisms:
1. Promoting only the safehandle + toggleref of a given GLib.Object derived class.
2. Removes finalizer queues on the UI thread with simple unrefs. GLib is thread safe by itself, so unref-ing shouldn't cause _any_ issues.
3. Modify some classes so their finalizers aren't run if the handle isn't owned