### PR TITLE
[DO NOT MERGE!] [Gtk] Free toggleref on object destroy???

### DIFF
--- a/gtk/Object.custom
+++ b/gtk/Object.custom
@@ -83,6 +83,7 @@
 			if (obj == null)
 				return;
 			obj.OnDestroyed ();
+			obj.Dispose ();
 		}
 		
 		static EventHandler native_destroy_handler;
@@ -92,15 +93,6 @@
 					native_destroy_handler = new EventHandler (NativeDestroy);
 				return native_destroy_handler;
 			}
-		}
-
-		public override void Dispose ()
-		{
-			// Don't call base.Dispose because it's calling g_object_unref
-			// which is done by gtk_object_destroy for Gtk.Object
-
-			//Should line below be uncommented?(but it breaks backward compatiblity)
-			//throw new InvalidOperationException("Calling Dispose is invalid for Gtk objects. Call Destroy().");
 		}
 
 		protected override IntPtr Raw {


### PR DESCRIPTION
Up for discussion. Should we do this on destroy? Should we also do it on dispose and also free the toggleref there?