### PR TITLE
[GLib] Backwards compatibility with source removal

### DIFF
--- a/glib/Source.cs
+++ b/glib/Source.cs
@@ -71,7 +71,7 @@ namespace GLib {
 
 		public static bool Remove (uint tag)
 		{
-			return g_source_remove (tag);
+			return tag == 0 || g_source_remove (tag);
 		}
 	}
 }


### PR DESCRIPTION
Before, the code would check whether the source was registered in the dictionary. Thus, it would return true without invoking the source removal.