### PR TITLE
[Gtk] Make Application.Invoke snappier.

### DIFF
--- a/glib/DestroyNotify.cs
+++ b/glib/DestroyNotify.cs
@@ -40,6 +40,10 @@ namespace GLib {
 
 		static DestroyNotify release_gchandle;
 
+		/// <summary>
+		/// Frees the GCHandle passed as data to the method.
+		/// </summary>
+		/// <value>The notify handler.</value>
 		public static DestroyNotify NotifyHandler {
 			get {
 				if (release_gchandle == null)

--- a/glib/Idle.cs
+++ b/glib/Idle.cs
@@ -67,7 +67,7 @@ namespace GLib {
 			IdleProxy p = new IdleProxy (hndlr);
 			var handle = GCHandle.Alloc (p);
 
-			p.ID = g_idle_add_full (defaultPriority, SourceProxy.SourceHandler, (IntPtr)handle, NotifyHandler);
+			p.ID = g_idle_add_full (defaultPriority, SourceProxy.SourceHandler, (IntPtr)handle, FreeGCHandleAndRemoveFromDictionary);
 
 			lock (idle_handlers) {
 				if (p.needsAdd) {
@@ -127,7 +127,7 @@ namespace GLib {
 
 		static DestroyNotify release_gchandle;
 
-		public static DestroyNotify NotifyHandler {
+		static DestroyNotify FreeGCHandleAndRemoveFromDictionary {
 			get {
 				if (release_gchandle == null)
 					release_gchandle = new DestroyNotify (ReleaseGCHandle);

--- a/glib/Timeout.cs
+++ b/glib/Timeout.cs
@@ -59,6 +59,12 @@ namespace GLib {
 			return Add (interval, handle);
 		}
 
+		/// <summary>
+		/// The handle will be freed automatically on source removal.
+		/// </summary>
+		/// <returns>The add.</returns>
+		/// <param name="interval">Interval.</param>
+		/// <param name="handle">Handle.</param>
 		internal static uint Add (uint interval, GCHandle handle)
 		{
 			return g_timeout_add_full (defaultPriority, interval, SourceProxy.SourceHandler, (IntPtr)handle, DestroyHelper.NotifyHandler);

--- a/glib/Timeout.cs
+++ b/glib/Timeout.cs
@@ -56,6 +56,11 @@ namespace GLib {
 			TimeoutProxy p = new TimeoutProxy (hndlr);
 			var handle = GCHandle.Alloc (p);
 
+			return Add (interval, handle);
+		}
+
+		internal static uint Add (uint interval, GCHandle handle)
+		{
 			return g_timeout_add_full (defaultPriority, interval, SourceProxy.SourceHandler, (IntPtr)handle, DestroyHelper.NotifyHandler);
 		}
 	}

--- a/gtk/Application.cs
+++ b/gtk/Application.cs
@@ -206,9 +206,8 @@ namespace Gtk {
 
 		internal class InvokeProxyWithArgs : InvokeProxy
 		{
-			readonly EventHandler d;
 			readonly object sender;
-			protected EventArgs args;
+			readonly EventArgs args;
 
 			internal InvokeProxyWithArgs (EventHandler d, object sender, EventArgs args) : base (d)
 			{

--- a/gtk/Application.cs
+++ b/gtk/Application.cs
@@ -223,6 +223,40 @@ namespace Gtk {
 			}
 		}
 
+		internal class InvokeProxyAction : GLib.SourceProxy
+		{
+			readonly System.Action act;
+
+			internal InvokeProxyAction (System.Action act)
+			{
+				this.act = act;
+			}
+
+			protected override bool Invoke ()
+			{
+				act ();
+				return false;
+			}
+		}
+
+		internal class InvokeProxyAction<T> : GLib.SourceProxy
+		{
+			readonly Action<T> act;
+			readonly T arg;
+
+			internal InvokeProxyAction (Action<T> act, T arg)
+			{
+				this.act = act;
+				this.arg = arg;
+			}
+
+			protected override bool Invoke ()
+			{
+				act (arg);
+				return false;
+			}
+		}
+
 		public static void Invoke (EventHandler d)
 		{
 			var p = new InvokeProxy (d);
@@ -234,6 +268,22 @@ namespace Gtk {
 		public static void Invoke (object sender, EventArgs args, EventHandler d)
 		{
 			var p = new InvokeProxyWithArgs (d, sender, args);
+			var handle = GCHandle.Alloc (p);
+
+			GLib.Timeout.Add (0, handle);
+		}
+
+		public static void Invoke (System.Action act)
+		{
+			var p = new InvokeProxyAction (act);
+			var handle = GCHandle.Alloc (p);
+
+			GLib.Timeout.Add (0, handle);
+		}
+
+		public static void Invoke<T> (Action<T> act, T arg)
+		{
+			var p = new InvokeProxyAction<T> (act, arg);
 			var handle = GCHandle.Alloc (p);
 
 			GLib.Timeout.Add (0, handle);


### PR DESCRIPTION
Mirrors behaviour from TimeoutProxy. Split into two classes, the Invoke without args class is now smaller. Fast-path by not creating extra junk along the way. Performance is now comparable to GLib.Timeout.Add.