### PR TITLE
[Atk] Fix property names.

### DIFF
--- a/atk/Atk.metadata
+++ b/atk/Atk.metadata
@@ -58,7 +58,7 @@
   <attr path="/api/namespace/object[@cname='AtkObject']/*[@name='AtkObjectNamePropertyValue']" name="cname">accessible-value</attr>
   <attr path="/api/namespace/object[@cname='AtkObject']/*[@name='AtkObjectNamePropertyRole']" name="cname">accessible-role</attr>
   <attr path="/api/namespace/object[@cname='AtkObject']/*[@name='AtkObjectNamePropertyComponentLayer']" name="cname">accessible-component-layer</attr>
-  <attr path="/api/namespace/object[@cname='AtkObject']/*[@name='AtkObjectNamePropertyMdiZorder']" name="cname">accessible-mdi-zorder</attr>
+  <attr path="/api/namespace/object[@cname='AtkObject']/*[@name='AtkObjectNamePropertyComponentMdiZorder']" name="cname">accessible-component-mdi-zorder</attr>
   <attr path="/api/namespace/object[@cname='AtkObject']/*[@name='AtkObjectNamePropertyTableCaption']" name="cname">accessible-table-caption</attr>
   <attr path="/api/namespace/object[@cname='AtkObject']/*[@name='AtkObjectNamePropertyTableColumnDescription']" name="cname">accessible-table-column-description</attr>
   <attr path="/api/namespace/object[@cname='AtkObject']/*[@name='AtkObjectNamePropertyTableColumnHeader']" name="cname">accessible-table-column-header</attr>
@@ -66,5 +66,5 @@
   <attr path="/api/namespace/object[@cname='AtkObject']/*[@name='AtkObjectNamePropertyTableRowHeader']" name="cname">accessible-row-header</attr>
   <attr path="/api/namespace/object[@cname='AtkObject']/*[@name='AtkObjectNamePropertyTableSummary']" name="cname">accessible-table-summary</attr>
   <attr path="/api/namespace/object[@cname='AtkObject']/*[@name='AtkObjectNamePropertyTableCaptionObject']" name="cname">accessible-table-caption-object</attr>
-  <attr path="/api/namespace/object[@cname='AtkObject']/*[@name='AtkObjectNamePropertyTableHypertextNumLinks']" name="cname">accessible-table-hypertext-nlinks</attr>
+  <attr path="/api/namespace/object[@cname='AtkObject']/*[@name='AtkObjectNamePropertyHypertextNumLinks']" name="cname">accessible-hypertext-nlinks</attr>
 </metadata>

--- a/atk/Atk.metadata
+++ b/atk/Atk.metadata
@@ -51,4 +51,20 @@
   <attr path="/api/namespace/object[@cname='AtkObject']/*[@cname='atk_object_get_attributes']" name="hidden">1</attr>
   <attr path="/api/namespace/interface[@cname='AtkText']/*[@cname='atk_text_get_run_attributes']" name="hidden">1</attr>
   <attr path="/api/namespace/interface[@cname='AtkText']/*[@cname='atk_text_get_default_attributes']" name="hidden">1</attr>
+  <!-- The names are const strings, not string literals, so we need to match them to the real value -->
+  <attr path="/api/namespace/object[@cname='AtkObject']/*[@name='AtkObjectNamePropertyName']" name="cname">accessible-name</attr>
+  <attr path="/api/namespace/object[@cname='AtkObject']/*[@name='AtkObjectNamePropertyDescription']" name="cname">accessible-description</attr>
+  <attr path="/api/namespace/object[@cname='AtkObject']/*[@name='AtkObjectNamePropertyParent']" name="cname">accessible-parent</attr>
+  <attr path="/api/namespace/object[@cname='AtkObject']/*[@name='AtkObjectNamePropertyValue']" name="cname">accessible-value</attr>
+  <attr path="/api/namespace/object[@cname='AtkObject']/*[@name='AtkObjectNamePropertyRole']" name="cname">accessible-role</attr>
+  <attr path="/api/namespace/object[@cname='AtkObject']/*[@name='AtkObjectNamePropertyComponentLayer']" name="cname">accessible-component-layer</attr>
+  <attr path="/api/namespace/object[@cname='AtkObject']/*[@name='AtkObjectNamePropertyMdiZorder']" name="cname">accessible-mdi-zorder</attr>
+  <attr path="/api/namespace/object[@cname='AtkObject']/*[@name='AtkObjectNamePropertyTableCaption']" name="cname">accessible-table-caption</attr>
+  <attr path="/api/namespace/object[@cname='AtkObject']/*[@name='AtkObjectNamePropertyTableColumnDescription']" name="cname">accessible-table-column-description</attr>
+  <attr path="/api/namespace/object[@cname='AtkObject']/*[@name='AtkObjectNamePropertyTableColumnHeader']" name="cname">accessible-table-column-header</attr>
+  <attr path="/api/namespace/object[@cname='AtkObject']/*[@name='AtkObjectNamePropertyTableRowDescription']" name="cname">accessible-table-row-description</attr>
+  <attr path="/api/namespace/object[@cname='AtkObject']/*[@name='AtkObjectNamePropertyTableRowHeader']" name="cname">accessible-row-header</attr>
+  <attr path="/api/namespace/object[@cname='AtkObject']/*[@name='AtkObjectNamePropertyTableSummary']" name="cname">accessible-table-summary</attr>
+  <attr path="/api/namespace/object[@cname='AtkObject']/*[@name='AtkObjectNamePropertyTableCaptionObject']" name="cname">accessible-table-caption-object</attr>
+  <attr path="/api/namespace/object[@cname='AtkObject']/*[@name='AtkObjectNamePropertyTableHypertextNumLinks']" name="cname">accessible-table-hypertext-nlinks</attr>
 </metadata>


### PR DESCRIPTION
Atk defines the properties via const strings, not literal strings, so the perl parser grabs the wrong id. https://github.com/GNOME/atk/blob/125dac528339267821dbbd6da9b19fe9949334e9/atk/atkobject.c#L259-L273