### PR TITLE
Check for libtoolize rather than libtool

### DIFF
--- a/bootstrap-generic
+++ b/bootstrap-generic
@@ -41,18 +41,18 @@ DIE=0
   DIE=1
 }
 
-if [ -z "$LIBTOOL" ]; then
-  LIBTOOL=`which glibtool 2>/dev/null` 
-  if [ ! -x "$LIBTOOL" ]; then
-    LIBTOOL=`which libtool`
+if [ -z "$LIBTOOLIZE" ]; then
+  LIBTOOLIZE=`which glibtoolize 2>/dev/null`
+  if [ ! -x "$LIBTOOLIZE" ]; then
+    LIBTOOLIZE=`which libtoolize`
   fi
 fi
 
 (grep "^AM_PROG_LIBTOOL" $srcdir/configure.in >/dev/null) && {
-  ($LIBTOOL --version) < /dev/null > /dev/null 2>&1 || {
+  ($LIBTOOLIZE --version) < /dev/null > /dev/null 2>&1 || {
     echo
-    echo "**Error**: You must have \`libtool' installed to compile Gtk#."
-    echo "Get ftp://ftp.gnu.org/pub/gnu/libtool-1.2d.tar.gz"
+    echo "**Error**: You must have \`libtoolize' installed to compile Gtk#."
+    echo "Get ftp://ftp.gnu.org/pub/gnu/libtool-1.3.tar.gz"
     echo "(or a newer version if it is available)"
     DIE=1
   }
@@ -93,13 +93,6 @@ case $CC in
 xlc )
   am_opt=--include-deps;;
 esac
-
-if [ -z "$LIBTOOLIZE" ]; then
-  LIBTOOLIZE=`which glibtoolize 2>/dev/null` 
-  if [ ! -x "$LIBTOOLIZE" ]; then
-    LIBTOOLIZE=`which libtoolize`
-  fi
-fi
 
 
 if grep "^AM_PROG_LIBTOOL" configure.in >/dev/null; then


### PR DESCRIPTION
Current Debian packaging puts libtool in its own package (libtool-bin)
leaving only libtoolize in the main package. The mono build process
uses libtoolize not libtool, so during autogen check for libtoolize
not libtool.