### PR TITLE
ValueArray: Create copy when receiving pointer

### DIFF
--- a/glib/ValueArray.cs
+++ b/glib/ValueArray.cs
@@ -43,7 +43,7 @@ namespace GLib {
 
 		public ValueArray (IntPtr raw)
 		{
-			handle = raw;
+			handle = g_value_array_copy (raw);
 		}
 		
 		~ValueArray ()


### PR DESCRIPTION
The "ref" operation of GValueArray is a copy, so we don't have a
choice.

I can reproduce the crash with GStreamer, but the code code to do it is:
```c-sharp
GLib.ValueArray va = new GLib.ValueArray (1);
GLib.Value v = new GLib.Value (va);
GLib.ValueArray va2 = (GLib.ValueArray) v;
```