### PR TITLE
[Gtk] fix leak on SizeRequest() method

### DIFF
--- a/gtk/Widget.custom
+++ b/gtk/Widget.custom
@@ -393,3 +393,14 @@ public void ModifyText (Gtk.StateType state)
 {
 	gtk_widget_modify_text_ptr (Handle, (int) state, IntPtr.Zero);
 }
+
+[DllImport("libgtk-win32-2.0-0.dll", CallingConvention = CallingConvention.Cdecl)]
+static extern void gtk_widget_size_request(IntPtr raw, ref Gtk.Requisition requisition);
+
+public Gtk.Requisition SizeRequest()
+{
+        Gtk.Application.AssertMainThread();
+        Gtk.Requisition requisition = default(Requisition);
+        gtk_widget_size_request(Handle, ref requisition);
+        return requisition;
+}


### PR DESCRIPTION
This fix is to prevent instanciating new Requisition struct each time SizeRequest() is called.
Instead, we pass Requisition property inside gtk_widget_size_request native method.