### PR TITLE
[Gtk] Fix leak on SizeRequest

### DIFF
--- a/gtk/Gtk.metadata
+++ b/gtk/Gtk.metadata
@@ -842,7 +842,7 @@
   <attr path="/api/namespace/object[@cname='GtkWidget']/method[@name='SetEvents']/*/*[@type='gint']" name="type">GdkEventMask</attr>
   <attr path="/api/namespace/object[@cname='GtkWidget']/method[@name='Set']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GtkWidget']/method[@name='SetState']" name="hidden">1</attr>
-  <attr path="/api/namespace/object[@cname='GtkWidget']/method[@name='SizeRequest']/*/*[@name='requisition']" name="pass_as">out</attr>
+  <attr path="/api/namespace/object[@cname='GtkWidget']/method[@name='SizeRequest']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GtkWidget']/method[@name='StyleGet']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GtkWidget']/method[@name='StyleGetProperty']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GtkWidget']/method[@name='StyleGetValist']" name="hidden">1</attr>

--- a/gtk/Widget.custom
+++ b/gtk/Widget.custom
@@ -393,3 +393,14 @@ public void ModifyText (Gtk.StateType state)
 {
 	gtk_widget_modify_text_ptr (Handle, (int) state, IntPtr.Zero);
 }
+
+[DllImport("libgtk-win32-2.0-0.dll", CallingConvention = CallingConvention.Cdecl)]
+static extern void gtk_widget_size_request(IntPtr raw, ref Gtk.Requisition requisition);
+
+public Gtk.Requisition SizeRequest()
+{
+        Gtk.Application.AssertMainThread();
+        Gtk.Requisition requisition = default(Requisition);
+        gtk_widget_size_request(Handle, ref requisition);
+        return requisition;
+}

--- a/gtk/Widget.custom
+++ b/gtk/Widget.custom
@@ -400,7 +400,7 @@ static extern void gtk_widget_size_request(IntPtr raw, ref Gtk.Requisition requi
 public Gtk.Requisition SizeRequest()
 {
         Gtk.Application.AssertMainThread();
-        Gtk.Requisition requisition = default(Requisition);
+        Gtk.Requisition requisition = Requisition;
         gtk_widget_size_request(Handle, ref requisition);
         return requisition;
 }

--- a/gtk/Widget.custom
+++ b/gtk/Widget.custom
@@ -393,3 +393,14 @@ public void ModifyText (Gtk.StateType state)
 {
 	gtk_widget_modify_text_ptr (Handle, (int) state, IntPtr.Zero);
 }
+
+[DllImport("libgtk-win32-2.0-0.dll", CallingConvention = CallingConvention.Cdecl)]
+static extern void gtk_widget_size_request(IntPtr raw, ref Gtk.Requisition requisition);
+
+public Gtk.Requisition SizeRequest()
+{
+        Gtk.Application.AssertMainThread();
+        Gtk.Requisition requisition = Requisition;
+        gtk_widget_size_request(Handle, ref requisition);
+        return requisition;
+}


### PR DESCRIPTION
Fixing leak on sizeRequest function by taking Requisition property from Gtk.Widget class.