### PR TITLE
Use csc instead of mcs

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -53,7 +53,7 @@ $(POLICY_ASSEMBLIES) : policy.%.$(ASSEMBLY): policy.%.config $(SNK)
 	$(AL) -link:policy.$*.config -version:$* -out:$@ -keyfile:$(SNK)
 
 build_sources = $(addprefix $(srcdir)/, $(sources)) AssemblyInfo.cs
-build_references = $(addprefix -r:, $(references)) $(MONO_CAIRO_LIBS)
+build_references = $(addprefix -r:, $(references)) $(addsuffix .dll, $(MONO_CAIRO_LIBS))
 
 $(ASSEMBLY): generated-stamp $(SNK) $(build_sources) $(references)
 	@rm -f $(ASSEMBLY).mdb

--- a/audit/makefile
+++ b/audit/makefile
@@ -1,4 +1,4 @@
-MCS=mcs
+MCS=csc
 
 all: extract-missing.exe mono-api-info.exe mono-api-diff.exe
 

--- a/configure.in.in
+++ b/configure.in.in
@@ -141,7 +141,7 @@ if test "x$RUNTIME" != "xno" ; then
 	RUNTIME=mono
 fi
 
-AC_PATH_PROG([CSC], mcs, no)
+AC_PATH_PROG([CSC], csc, no)
 if test `uname -s` = "Darwin"; then
 	LIB_PREFIX=
 	LIB_SUFFIX=.dylib

--- a/sample/GtkDemo/Makefile.am
+++ b/sample/GtkDemo/Makefile.am
@@ -9,7 +9,7 @@ assemblies = \
 	$(top_builddir)/atk/atk-sharp.dll $(top_builddir)/gdk/gdk-sharp.dll \
 	$(top_builddir)/gtk/gtk-sharp.dll $(local_mono_cairo)
 
-references = $(addprefix -r:, $(assemblies)) @MONO_CAIRO_LIBS@
+references = $(addprefix -r:, $(assemblies)) $(addsuffix .dll, @MONO_CAIRO_LIBS@)
 TARGETS = GtkDemo.exe
 DEBUGS = $(addsuffix .mdb, $(TARGETS)) 
 CLEANFILES = $(TARGETS) $(DEBUGS)

--- a/sample/Makefile.am
+++ b/sample/Makefile.am
@@ -3,7 +3,7 @@ SUBDIRS = test GtkDemo pixmaps valtest opaquetest
 if ENABLE_MONO_CAIRO
 cairo_ref=-r:$(top_builddir)/cairo/Mono.Cairo.dll
 else
-cairo_ref=$(MONO_CAIRO_LIBS)
+cairo_ref=$(addsuffix .dll, $(MONO_CAIRO_LIBS))
 endif
 
 if ENABLE_GLADE


### PR DESCRIPTION
mcs sets the timestamp in the PE header to 0 which breaks some MS internal tools, let's use csc instead.