### PR TITLE
Use csc instead of mcs

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -50,7 +50,7 @@ $(POLICY_ASSEMBLIES) : policy.%.$(ASSEMBLY): policy.%.config $(SNK)
 	$(AL) -link:policy.$*.config -out:$@ -keyfile:$(SNK)
 
 build_sources = $(addprefix $(srcdir)/, $(sources))
-build_references = $(addprefix -r:, $(references)) $(MONO_CAIRO_LIBS)
+build_references = $(addprefix -r:, $(references)) $(addsuffix .dll, $(MONO_CAIRO_LIBS))
 
 $(ASSEMBLY): generated-stamp $(SNK) $(build_sources) $(references)
 	@rm -f $(ASSEMBLY).mdb

--- a/audit/makefile
+++ b/audit/makefile
@@ -1,4 +1,4 @@
-MCS=dmcs
+MCS=csc
 
 COMMON_SOURCES = \
 	AssemblyResolver.cs	\

--- a/configure.ac
+++ b/configure.ac
@@ -133,7 +133,7 @@ if test "x$RUNTIME" != "no" ; then
 	RUNTIME="mono$RUNTIME_DEBUG_FLAGS"
 fi
 
-AC_PATH_PROG(CSC, mcs, no)
+AC_PATH_PROG(CSC, csc, no)
 if test `uname -s` = "Darwin"; then
 	LIB_PREFIX=
 	LIB_SUFFIX=.dylib


### PR DESCRIPTION
mcs sets the timestamp in the PE header to 0 which breaks some MS internal tools, let's use csc instead.