### PR TITLE
[GLib] Avoid keeping a reference to the error

### DIFF
--- a/glib/GException.cs
+++ b/glib/GException.cs
@@ -26,27 +26,26 @@ namespace GLib {
 	
 	public class GException : Exception
 	{
-		IntPtr errptr;
-	
-		public GException (IntPtr errptr) : base ()
+		public GException (IntPtr errptr) : base (ToString(errptr))
 		{
-			this.errptr = errptr;
+			g_clear_error (ref errptr);
+		}
+
+		static string ToString (IntPtr errPtr)
+		{
+			if (errPtr != IntPtr.Zero) {
+				string message = Marshaller.Utf8PtrToString (gtksharp_error_get_message (errPtr));
+				if (!string.IsNullOrEmpty (message))
+					return message;
+			}
+			return "No GLib message";
 		}
 
 		[DllImport("glibsharpglue-2", CallingConvention=CallingConvention.Cdecl)]
 		static extern IntPtr gtksharp_error_get_message (IntPtr errptr);
-		public override string Message {
-			get {
-				return Marshaller.Utf8PtrToString (gtksharp_error_get_message (errptr));
-			}
-		}
 
 		[DllImport("libglib-2.0-0.dll", CallingConvention=CallingConvention.Cdecl)]
 		static extern void g_clear_error (ref IntPtr errptr);
-		~GException ()
-		{
-			g_clear_error (ref errptr);
-		}
 	}
 }
 


### PR DESCRIPTION
The original impl did not take into account exceptions marshalling across thread boundaries so it could end up with the error being accessed after being disposed
Fix this by querying the message in-place, and also clear the error after, to signal to glib that we've suceeded in recovering

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1247180