### PR TITLE
refs issue:#298 Fix mono compilation errors

### DIFF
--- a/sample/test/TestRange.cs
+++ b/sample/test/TestRange.cs
@@ -8,7 +8,7 @@
 
 using System;
 
-using Gtk;
+using Gtk; using Range = Gtk.Range;
 
 namespace WidgetViewer {
 


### PR DESCRIPTION
Fix of TestRange. The use of type "Range" is confused: either System.Range or Gtk.Range --> use of "using Gtk.Range;" to tell mcs to use the Gtk one.